### PR TITLE
Do not search for dupes by pk

### DIFF
--- a/pulpcore/app/models/content.py
+++ b/pulpcore/app/models/content.py
@@ -60,8 +60,6 @@ class QueryMixin:
         """
         Returns a Q object that represents the model
         """
-        if self.pk:
-            return models.Q(pk=self.pk)
         try:
             kwargs = self.natural_key_dict()
         except AttributeError:


### PR DESCRIPTION
Reopened from https://github.com/pulp/pulp/pull/3822

The ContentUnitSaver stage uses content.q() to retrieve the query for a
duplicate content unit. However, there are cases where the pk of the
content is set even when the save fails with an IntegrityError. This
means that content.q() will always search for content that does not
exist. Instead, we should always query by the natural key.

[noissue]

Please be sure you have read our documentation on creating PRs:
https://docs.pulpproject.org/en/3.0/nightly/contributing/pull-request-walkthrough.html
