### PR TITLE
Updates to account for repo name change

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,7 +33,7 @@ jobs:
         distributions: sdist bdist_wheel
         user: pulp
         password:
-          secure: "ej2lekfOr8S3Du6D6HPlB20+g5jwgZz75ouHlqIpc+IAgdAxmpn5vkspsAevMtchLw7sNgDAAbl0bQVacMDnn+zbo21s93OXcOmYzgy4IlTgopc+xi1XaKFdLMLiEiZ+KOGVJgg7yQwS3yeS28FARZGNDYTF/+N7eITteDThcG4="
+          secure: "EerGV8Z0jybfuq2yHWrD2fu6NnZxLBjAz/kyhGGuXOcSCkBsWfrDoatszMhKtBR7A4o+xzUo/OsRV2rILz3IWPg0aOBk3GAAH0dg6axt25JrJbnd8+lCj4XTyhg0dR/J/EsE0S8xGV6mG6Z+ubRvBRtc1pGdQvq2PxuQcPISi35zNhwqUoNIJ8f1NDa7Rl/7jyhM/YIlrfH2gtRaIDIhrHHeXqm9JIHCPRpyx//t1BKDov3TrPeiohmu/OvwNS3F4a/Juxscl9sAm4JeduJA5N6nYkjlCsYYe7L54kluXIN0bCcKv0qKNDbf/EfTP3/SHzywkJwr5IFlRsf2rNiOiBrec03Xhh10JbIhyFMyI2BqDHSghfxG8D3m4EFtwebowgXixCBBRDyIRxiK+NEt4DxVahwV4gZiYZzG0h7TqL2/zmgTL4Tj09iqKbfLtzccmVLsGikHWCQxctefHCyD6oN/TWRSay0fLZGIyCL0YwQOTyS6IzfBYlwxDtke92okHrH2bASVBczAZcOMUOcbxxYVrL2XWQI8XIjguOBlxbv80GM1ZXC+rEvZ9WOSLBv9QJAC1V+cYfWAjCQ3jpmzz2TSIx4HH7l1wt5fBOMnnWDB+gKfqLlOpMrAnqkbR/YiyXkL0wBtAOW7ZTS0iDARgJpKT3V/dvyqXYwEmWfDJB4="
         on:
           tags: true
       if: tag IS present

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-[![Build Status](https://travis-ci.org/pulp/pulp.svg)](https://travis-ci.org/pulp/pulp)
+[![Build Status](https://travis-ci.org/pulp/pulpcore.svg)](https://travis-ci.org/pulp/pulpcore)
 [![PyPI](https://img.shields.io/pypi/pyversions/pulpcore.svg)](https://pypi.python.org/pypi/pulpcore)
-[![codecov](https://codecov.io/gh/pulp/pulp/branch/master/graph/badge.svg)](https://codecov.io/gh/pulp/pulp/branch/master)
-[![Code Quality: Python](https://img.shields.io/lgtm/grade/python/g/pulp/pulp.svg?logo=lgtm&logoWidth=18)](https://lgtm.com/projects/g/pulp/pulp/context:python)
-[![Total Alerts](https://img.shields.io/lgtm/alerts/g/pulp/pulp.svg?logo=lgtm&logoWidth=18)](https://lgtm.com/projects/g/pulp/pulp/alerts)
+[![codecov](https://codecov.io/gh/pulp/pulpcore/branch/master/graph/badge.svg)](https://codecov.io/gh/pulp/pulpcore/branch/master)
+[![Code Quality: Python](https://img.shields.io/lgtm/grade/python/g/pulp/pulpcore.svg?logo=lgtm&logoWidth=18)](https://lgtm.com/projects/g/pulp/pulpcore/context:python)
+[![Total Alerts](https://img.shields.io/lgtm/alerts/g/pulp/pulpcore.svg?logo=lgtm&logoWidth=18)](https://lgtm.com/projects/g/pulp/pulpcore/alerts)
 
 **Acquire, Organize, and Distribute Software**
 
@@ -18,7 +18,7 @@ Using Pulp you can:
 Pulp is completely free and open-source!
 - License: GNUv2
 - Documentation: http://docs.pulpproject.org/en/3.0/nightly/
-- Source: https://github.com/pulp/pulp/
+- Source: https://github.com/pulp/pulpcore/
 - Bugs: https://pulp.plan.io/projects/pulp
 
 For more information, check out the project website: http://www.pulpproject.org

--- a/docs/contributing/continuous-integration.rst
+++ b/docs/contributing/continuous-integration.rst
@@ -14,10 +14,10 @@ units (function, method or class instance) are working correctly.
 A Pull Request that has failing unit tests cannot be merged.
 
 The unit tests for `pulpcore` are in `pulpcore/tests
-<https://github.com/pulp/pulp/tree/master/pulpcore/tests/unit>`_.
+<https://github.com/pulp/pulpcore/tree/master/pulpcore/tests/unit>`_.
 
 The unit tests for `pulpcore-plugin` are in `pulpcore-plugins/tests
-<https://github.com/pulp/pulp/tree/master/plugin/tests/unit/>`_.
+<https://github.com/pulp/pulpcore/tree/master/plugin/tests/unit/>`_.
 
 Functional Tests
 ----------------
@@ -30,7 +30,7 @@ toolkit written to ease the testing of Pulp.
 
 It is highly encouraged to accompany new features with functional
 tests in `pulpcore/functional
-<https://github.com/pulp/pulp/tree/master/pulpcore/tests/functional>`_.
+<https://github.com/pulp/pulpcore/tree/master/pulpcore/tests/functional>`_.
 
 Only the tests for features related to `pulpcore` should live in this repository.
 

--- a/docs/contributing/pull-request-walkthrough.rst
+++ b/docs/contributing/pull-request-walkthrough.rst
@@ -3,7 +3,7 @@ Pull Request Walkthrough
 
 Changes to pulpcore are submitted via `GitHub Pull Requests (PR)
 <https://help.github.com/articles/about-pull-requests/>`_ to the `pulp git repository
-<https://github.com/pulp/pulp>`_ . Plugin git repositories are listed in the `plugin table
+<https://github.com/pulp/pulpcore>`_ . Plugin git repositories are listed in the `plugin table
 <https://pulpproject.org/pulp-3-plugins/>`_.
 
 Boilerplate
@@ -12,8 +12,8 @@ Boilerplate
 If you would like to submit a patch, especially if you have a major change, it is recommended that
 you :ref:`chat with us<community>` before you get started.
 
-#. `Fork <https://help.github.com/articles/fork-a-repo/>`_ `pulp <https://github.com/pulp/pulp>`_ in
-   your GitHub account.
+#. `Fork <https://help.github.com/articles/fork-a-repo/>`_
+   `pulpcore <https://github.com/pulp/pulpcore>`_ in your GitHub account.
 #. :doc:`Install Pulp from source.<dev-setup/index>`
 #. Create a new branch from the :ref:`appropriate base branch<git-branch>`
 #. Review the :doc:`style-guide`.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -39,7 +39,7 @@ make Pulp better, please reach out!
 
 * Source code
 
-  * `pulpcore <https://github.com/pulp/pulp/>`_
+  * `pulpcore <https://github.com/pulp/pulpcore/>`_
   * `pulp-smash (test suite) <https://github.com/PulpQE/pulp-smash>`_
   * `plugin table <https://pulpproject.org/pulp-3-plugins/>`_
 

--- a/docs/installation/instructions.rst
+++ b/docs/installation/instructions.rst
@@ -52,8 +52,8 @@ a dependency)::
 
    To install from source, clone git repositories and do a local, editable pip installation::
 
-   $ git clone https://github.com/pulp/pulp.git
-   $ pip install -e ./pulp
+   $ git clone https://github.com/pulp/pulpcore.git
+   $ pip install -e ./pulpcore
    $ git clone https://github.com/pulp/pulpcore-plugin.git
    $ pip install -e ./pulpcore-plugin
 

--- a/docs/release-notes/pulpcore/3.0.x.rst
+++ b/docs/release-notes/pulpcore/3.0.x.rst
@@ -4,18 +4,18 @@ Pulp 3.0 Release Notes
 3.0.0b21
 ========
 
-`Comprehensive list of changes and bugfixes for beta 21 <https://github.com/pulp/pulp/compare/3.0.0b20...3.0.0b21>`_.
+`Comprehensive list of changes and bugfixes for beta 21 <https://github.com/pulp/pulpcore/compare/3.0.0b20...3.0.0b21>`_.
 
 
 3.0.0b20
 ========
 
-`Comprehensive list of changes and bugfixes for beta 20 <https://github.com/pulp/pulp/compare/3.0.0b19...3.0.0b20>`_.
+`Comprehensive list of changes and bugfixes for beta 20 <https://github.com/pulp/pulpcore/compare/3.0.0b19...3.0.0b20>`_.
 
 3.0.0b19
 ========
 
-`Comprehensive list of changes and bugfixes for beta 19 <https://github.com/pulp/pulp/compare/3.0.0b18...3.0.0b19>`_.
+`Comprehensive list of changes and bugfixes for beta 19 <https://github.com/pulp/pulpcore/compare/3.0.0b18...3.0.0b19>`_.
 
 Breaking Changes
 ----------------
@@ -26,7 +26,7 @@ Breaking Changes
 3.0.0b18
 ========
 
-`Comprehensive list of changes and bugfixes for beta 18 <https://github.com/pulp/pulp/compare/3.0.0b17...3.0.0b18>`_.
+`Comprehensive list of changes and bugfixes for beta 18 <https://github.com/pulp/pulpcore/compare/3.0.0b17...3.0.0b18>`_.
 
 Breaking Changes
 ----------------
@@ -39,7 +39,7 @@ Breaking Changes
 3.0.0b17
 ========
 
-`Comprehensive list of changes and bugfixes for beta 17 <https://github.com/pulp/pulp/compare/pulpcore-3.0.0b16...3.0.0b17>`_.
+`Comprehensive list of changes and bugfixes for beta 17 <https://github.com/pulp/pulpcore/compare/3.0.0b16...3.0.0b17>`_.
 
 Breaking Changes
 ----------------
@@ -53,43 +53,43 @@ Breaking Changes
 3.0.0b16
 ========
 
-`Comprehensive list of changes and bugfixes for beta 16 <https://github.com/pulp/pulp/compare/pulpcore-3.0.0b15...pulpcore-3.0.0b16>`_.
+`Comprehensive list of changes and bugfixes for beta 16 <https://github.com/pulp/pulpcore/compare/3.0.0b15...3.0.0b16>`_.
 
 3.0.0b15
 ========
 
-`Comprehensive list of changes and bugfixes for beta 15 <https://github.com/pulp/pulp/compare/pulpcore-3.0.0b14...pulpcore-3.0.0b15>`_.
+`Comprehensive list of changes and bugfixes for beta 15 <https://github.com/pulp/pulpcore/compare/3.0.0b14...3.0.0b15>`_.
 
 3.0.0b14
 ========
 
-`Comprehensive list of changes and bugfixes for beta 14 <https://github.com/pulp/pulp/compare/pulpcore-3.0.0b13...pulpcore-3.0.0b14>`_.
+`Comprehensive list of changes and bugfixes for beta 14 <https://github.com/pulp/pulpcore/compare/3.0.0b13...3.0.0b14>`_.
 
 
 3.0.0b13
 ========
 
-`Comprehensive list of changes and bugfixes for beta 13 <https://github.com/pulp/pulp/compare/pulpcore-3.0.0b12...pulpcore-3.0.0b13>`_.
+`Comprehensive list of changes and bugfixes for beta 13 <https://github.com/pulp/pulpcore/compare/3.0.0b12...3.0.0b13>`_.
 
 3.0.0b12
 ========
 
-`Comprehensive list of changes and bugfixes for beta 12 <https://github.com/pulp/pulp/compare/pulpcore-3.0.0b11...pulpcore-3.0.0b12>`_.
+`Comprehensive list of changes and bugfixes for beta 12 <https://github.com/pulp/pulpcore/compare/3.0.0b11...3.0.0b12>`_.
 
 3.0.0b11
 ========
 
-`Comprehensive list of changes and bugfixes for beta 11 <https://github.com/pulp/pulp/compare/pulpcore-3.0.0b10...pulpcore-3.0.0b11>`_.
+`Comprehensive list of changes and bugfixes for beta 11 <https://github.com/pulp/pulpcore/compare/3.0.0b10...3.0.0b11>`_.
 
 3.0.0b10
 ========
 
-`Comprehensive list of changes and bugfixes for beta 10 <https://github.com/pulp/pulp/compare/pulpcore-3.0.0b9...pulpcore-3.0.0b10>`_.
+`Comprehensive list of changes and bugfixes for beta 10 <https://github.com/pulp/pulpcore/compare/3.0.0b9...3.0.0b10>`_.
 
 3.0.0b9
 =======
 
-`Comprehensive list of changes and bugfixes for beta 9 <https://github.com/pulp/pulp/compare/pulpcore-3.0.0b8...pulpcore-3.0.0b9>`_.
+`Comprehensive list of changes and bugfixes for beta 9 <https://github.com/pulp/pulpcore/compare/3.0.0b8...3.0.0b9>`_.
 
 Breaking Changes
 ----------------
@@ -101,7 +101,7 @@ Breaking Changes
 3.0.0b8
 =======
 
-* `Comprehensive list of changes and bugfixes for beta 8 <https://github.com/pulp/pulp/compare/pulpcore-3.0.0b7...pulpcore-3.0.0b8>`_.
+* `Comprehensive list of changes and bugfixes for beta 8 <https://github.com/pulp/pulpcore/compare/3.0.0b7...3.0.0b8>`_.
 
 Breaking Changes
 ----------------
@@ -112,12 +112,12 @@ Breaking Changes
 3.0.0b7
 =======
 
-* `Comprehensive list of changes and bugfixes for beta 7 <https://github.com/pulp/pulp/compare/pulpcore-3.0.0b6...pulpcore-3.0.0b7>`_.
+* `Comprehensive list of changes and bugfixes for beta 7 <https://github.com/pulp/pulpcore/compare/3.0.0b6...3.0.0b7>`_.
 
 3.0.0b6
 =======
 
-* `Comprehensive list of changes and bugfixes for beta 6 <https://github.com/pulp/pulp/compare/pulpcore-3.0.0b5...pulpcore-3.0.0b6>`_.
+* `Comprehensive list of changes and bugfixes for beta 6 <https://github.com/pulp/pulpcore/compare/3.0.0b5...3.0.0b6>`_.
 
 Breaking Changes
 ----------------
@@ -128,12 +128,12 @@ Breaking Changes
 3.0.0b5
 =======
 
-* `Comprehensive list of changes and bugfixes for beta 5 <https://github.com/pulp/pulp/compare/pulpcore-3.0.0b4...pulpcore-3.0.0b5>`_.
+* `Comprehensive list of changes and bugfixes for beta 5 <https://github.com/pulp/pulpcore/compare/3.0.0b4...3.0.0b5>`_.
 
 3.0.0b4
 =======
 
-* `Comprehensive list of changes and bugfixes for beta 4 <https://github.com/pulp/pulp/compare/pulpcore-3.0.0b3...pulpcore-3.0.0b4>`_.
+* `Comprehensive list of changes and bugfixes for beta 4 <https://github.com/pulp/pulpcore/compare/3.0.0b3...3.0.0b4>`_.
 
 3.0.0b3
 =======


### PR DESCRIPTION
This updates two main things:
- various docs
- the encrypted key for Travis to publish to PyPI. This is an asset that
  is encrypted per-repo on Travis so changing the repo requires
  regenerating it.

https://pulp.plan.io/issues/4444
re #4444

Please be sure you have read our documentation on creating PRs:
https://docs.pulpproject.org/en/3.0/nightly/contributing/pull-request-walkthrough.html
