### PR TITLE
Adds `content` role to pulp-smash config file.

### DIFF
--- a/.travis/pulp-smash-config.json
+++ b/.travis/pulp-smash-config.json
@@ -9,6 +9,7 @@
             "hostname": "localhost",
             "roles": {
                 "api": {"port": 8000, "scheme": "http", "service": "nginx"},
+                "content": {"port": 8080, "scheme": "http", "service": "pulp_content_app"},
                 "pulp resource manager": {},
                 "pulp workers": {},
                 "redis": {},


### PR DESCRIPTION
this setting is required in order to test `pulp_docker` because plugin repos re-use this same smash settings file

see https://github.com/pulp/pulp_docker/pull/315

[noissue]

Please be sure you have read our documentation on creating PRs:
https://docs.pulpproject.org/en/3.0/nightly/contributing/pull-request-walkthrough.html
