### PR TITLE
Ensure you can run Pulp without /var/lib/pulp

### DIFF
--- a/pulpcore/app/models/storage.py
+++ b/pulpcore/app/models/storage.py
@@ -125,7 +125,7 @@ def get_artifact_path(sha256digest):
         A string representing the absolute path where a file backing the Artifact should be
         stored
     """
-    return os.path.join(settings.MEDIA_ROOT, 'artifact', sha256digest[0:2], sha256digest[2:])
+    return os.path.join('artifact', sha256digest[0:2], sha256digest[2:])
 
 
 def published_metadata_path(model, name):

--- a/pulpcore/app/settings.py
+++ b/pulpcore/app/settings.py
@@ -27,7 +27,6 @@ SETTINGS_MODULE_FOR_DYNACONF = settings.get('SETTINGS_MODULE_FOR_DYNACONF',
 
 # Build paths inside the project like this: os.path.join(BASE_DIR, ...)
 BASE_DIR = settings.get('BASE_DIR', os.path.dirname(os.path.abspath(__file__)))
-STATIC_ROOT = settings.get('STATIC_ROOT', '/var/lib/pulp/static/')
 
 # Quick-start development settings - unsuitable for production
 # See https://docs.djangoproject.com/en/1.11/howto/deployment/checklist/
@@ -38,10 +37,14 @@ DEBUG = settings.get('DEBUG', False, '@bool')
 ALLOWED_HOSTS = settings.get('ALLOWED_HOSTS', ['*'])
 
 MEDIA_ROOT = settings.get('MEDIA_ROOT', '/var/lib/pulp/')
+STATIC_ROOT = settings.get('STATIC_ROOT', os.path.join(MEDIA_ROOT, 'static/'))
+
 DEFAULT_FILE_STORAGE = settings.get('DEFAULT_FILE_STORAGE',
                                     'pulpcore.app.models.storage.FileSystem')
 
-FILE_UPLOAD_TEMP_DIR = settings.get('FILE_UPLOAD_TEMP_DIR', '/var/lib/pulp/tmp/')
+FILE_UPLOAD_TEMP_DIR = settings.get('FILE_UPLOAD_TEMP_DIR', os.path.join(MEDIA_ROOT, 'tmp/'))
+WORKING_DIRECTORY = settings.get('WORKING_DIRECTORY', os.path.join(MEDIA_ROOT, 'tmp/'))
+
 # List of upload handler classes to be applied in order.
 FILE_UPLOAD_HANDLERS = settings.get('FILE_UPLOAD_HANDLERS',
                                     ('pulpcore.app.files.HashingFileUploadHandler',)
@@ -208,8 +211,6 @@ LOGGING = settings.get('LOGGING', {
         },
     }
 })
-
-WORKING_DIRECTORY = settings.get('WORKING_DIRECTORY', '/var/lib/pulp/tmp')
 
 CONTENT_HOST = settings.get('CONTENT_HOST', None)
 CONTENT_PATH_PREFIX = settings.get('CONTENT_PATH_PREFIX', '/pulp/content/')

--- a/pulpcore/content/handler.py
+++ b/pulpcore/content/handler.py
@@ -343,7 +343,7 @@ class Handler:
             The :class:`aiohttp.web.FileResponse` for the file.
         """
         if settings.DEFAULT_FILE_STORAGE == 'pulpcore.app.models.storage.FileSystem':
-            return FileResponse(file.name)
+            return FileResponse(os.path.join(settings.MEDIA_ROOT, file.name))
         elif settings.DEFAULT_FILE_STORAGE == 'storages.backends.s3boto3.S3Boto3Storage':
             raise HTTPFound(file.url)
         else:

--- a/pulpcore/tests/functional/api/test_crd_artifacts.py
+++ b/pulpcore/tests/functional/api/test_crd_artifacts.py
@@ -2,13 +2,14 @@
 """Tests that perform actions over artifacts."""
 import hashlib
 import itertools
+import os
 import unittest
 
 from requests.exceptions import HTTPError
 
 from pulp_smash import api, cli, config, utils
 from pulp_smash.exceptions import CalledProcessError
-from pulp_smash.pulp3.constants import ARTIFACTS_PATH
+from pulp_smash.pulp3.constants import ARTIFACTS_PATH, MEDIA_PATH
 from pulp_smash.pulp3.utils import delete_orphans
 
 # This import is an exception, we use a file url but we are not actually using
@@ -136,7 +137,7 @@ class ArtifactsDeleteFileSystemTestCase(unittest.TestCase):
         files = {'file': utils.http_get(FILE_URL)}
         artifact = api_client.post(ARTIFACTS_PATH, files=files)
         self.addCleanup(api_client.delete, artifact['_href'])
-        cmd = ('ls', artifact['file'])
+        cmd = ('ls', os.path.join(MEDIA_PATH, artifact['file']))
         cli_client.run(cmd, sudo=True)
 
         # delete

--- a/pulpcore/tests/functional/api/using_plugin/test_orphans.py
+++ b/pulpcore/tests/functional/api/using_plugin/test_orphans.py
@@ -1,11 +1,12 @@
 # coding=utf-8:
 """Tests that perform actions over orphan files."""
+import os
 import unittest
 from random import choice
 
 from pulp_smash import api, cli, config, utils
 from pulp_smash.exceptions import CalledProcessError
-from pulp_smash.pulp3.constants import ARTIFACTS_PATH, REPO_PATH
+from pulp_smash.pulp3.constants import ARTIFACTS_PATH, MEDIA_PATH, REPO_PATH
 from pulp_smash.pulp3.utils import (
     delete_orphans,
     delete_version,
@@ -79,7 +80,7 @@ class DeleteOrphansTestCase(unittest.TestCase):
         )
 
         # Verify that the artifact is present on disk.
-        artifact_path = self.api_client.get(content['_artifact'])['file']
+        artifact_path = os.path.join(MEDIA_PATH, self.api_client.get(content['_artifact'])['file'])
         cmd = ('ls', artifact_path)
         self.cli_client.run(cmd, sudo=True)
 
@@ -104,7 +105,7 @@ class DeleteOrphansTestCase(unittest.TestCase):
 
         files = {'file': utils.http_get(FILE2_URL)}
         artifact = self.api_client.post(ARTIFACTS_PATH, files=files)
-        cmd = ('ls', artifact['file'])
+        cmd = ('ls', os.path.join(MEDIA_PATH, artifact['file']))
         self.cli_client.run(cmd, sudo=True)
 
         delete_orphans()


### PR DESCRIPTION
User can change where files are stored which help
to use with openshift and others cloud systems.

closes: #4380
https://pulp.plan.io/issues/4380

Signed-off-by: Pavel Picka <ppicka@redhat.com>
