### PR TITLE
Problem: pulp-manager is not needed

### DIFF
--- a/.travis/before_script.sh
+++ b/.travis/before_script.sh
@@ -36,11 +36,11 @@ echo "SECRET_KEY: \"$(cat /dev/urandom | tr -dc 'a-z0-9!@#$%^&*(\-_=+)' | head -
 # Run migrations.
 export DJANGO_SETTINGS_MODULE=pulpcore.app.settings
 export PULP_CONTENT_HOST=localhost:8080
-pulp-manager migrate --noinput
+django-admin migrate --noinput
 
 if [ "$TEST" != 'docs' ]; then
-  pulp-manager makemigrations file --noinput
-  pulp-manager migrate --noinput
+  django-admin makemigrations file --noinput
+  django-admin migrate --noinput
 fi
 
-pulp-manager reset-admin-password --password admin
+django-admin reset-admin-password --password admin

--- a/.travis/publish_docs.sh
+++ b/.travis/publish_docs.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-pulp-manager runserver >> ~/django_runserver.log 2>&1 &
+django-admin runserver >> ~/django_runserver.log 2>&1 &
 sleep 5
 
 openssl aes-256-cbc -K $encrypted_d1a778bda808_key -iv $encrypted_d1a778bda808_iv -in .travis/pulp-infra.enc -out ~/.ssh/pulp-infra -d

--- a/.travis/script.sh
+++ b/.travis/script.sh
@@ -21,7 +21,7 @@ wait_for_pulp() {
 }
 
 if [ "$TEST" = 'docs' ]; then
-  pulp-manager runserver >> ~/django_runserver.log 2>&1 &
+  django-admin runserver >> ~/django_runserver.log 2>&1 &
   sleep 5
   cd docs
   make html
@@ -51,7 +51,7 @@ show_logs_and_return_non_zero() {
 rq worker -n 'resource-manager@%h' -w 'pulpcore.tasking.worker.PulpWorker' -c 'pulpcore.rqconfig' >> ~/resource_manager.log 2>&1 &
 rq worker -n 'reserved-resource-worker-1@%h' -w 'pulpcore.tasking.worker.PulpWorker' -c 'pulpcore.rqconfig' >> ~/reserved_worker-1.log 2>&1 &
 gunicorn pulpcore.tests.functional.content_with_coverage:server --bind 'localhost:8080' --worker-class 'aiohttp.GunicornWebWorker' -w 2 >> ~/content_app.log 2>&1 &
-coverage run $(which pulp-manager) runserver --noreload >> ~/django_runserver.log 2>&1 &
+coverage run $(which django-admin) runserver --noreload >> ~/django_runserver.log 2>&1 &
 wait_for_pulp 20
 
 # Run functional tests

--- a/docs/components.rst
+++ b/docs/components.rst
@@ -23,7 +23,7 @@ things:
    A simple, but limited way to run the REST API as a standalone service using the built-in Django
    runserver.::
 
-      $ python pulp-manager runserver
+      $ python django-admin runserver
 
 
 The REST API can be deployed with any any WSGI webserver like a normal Django application. See the
@@ -93,4 +93,4 @@ For production environments, configure static content as follows:
 Collect all of the static content into place using the ``collectstatic`` command
 as follows::
 
-    $ pulp-manager collectstatic
+    $ django-admin collectstatic

--- a/docs/contributing/dev-setup/runtests.rst
+++ b/docs/contributing/dev-setup/runtests.rst
@@ -14,7 +14,7 @@ Prerequisites
 If you want to run the functional tests, you need a running pulp instance that is allowed to be
 mixed up by the tests.
 For example, using the development vm (see :ref:`DevSetup`),
-this can be accomplished by `workon pulp; pulp-manager runserver`.
+this can be accomplished by `workon pulp; django-admin runserver`.
 Also, you need a valid *pulp-smash*
 `config <https://pulp-smash.readthedocs.io/en/latest/configuration.html>`_ file.
 This can be created with `pulp-smash settings create`.
@@ -23,12 +23,12 @@ Running tests
 -------------
 
 In case pulp is installed in a virtual environment, activate it first (`workon pulp`).
-All tests of a plugin are run with `pulp-manager test <plugin_name>`.
+All tests of a plugin are run with `django-admin test <plugin_name>`.
 This involves setting up (and tearing down) the test database, however the functional tests are
 still performed against the configured pulp instance with its *production* database.
 
 To only perform the unittests, you can skip the prerequisites and call
-`pulp-manager test <plugin_name>.tests.unit`.
+`django-admin test <plugin_name>.tests.unit`.
 
 If you are only interested in functional tests, you can skip the creation of the test database by
 using `py.test <path_to_plugin>/<plugin_name>/tests/functional`.
@@ -41,5 +41,5 @@ using `py.test <path_to_plugin>/<plugin_name>/tests/functional`.
 .. note::
 
     You can be more specific on which tests to run by calling something like
-    `pulp-manager test pulp_file.tests.unit.test_models` or
+    `django-admin test pulp_file.tests.unit.test_models` or
     `py.test <path_to_plugin>/<plugin_name>/tests/functional/api/test_sync.py`.

--- a/docs/installation/instructions.rst
+++ b/docs/installation/instructions.rst
@@ -74,16 +74,16 @@ PyPI Installation
 
 8. Run Django Migrations::
 
-   $ pulp-manager migrate --noinput
-   $ pulp-manager reset-admin-password --password admin
+   $ django-admin migrate --noinput
+   $ django-admin reset-admin-password --password admin
 
 9. Collect Static Media for live docs and browsable API::
 
-   $ pulp-manager collectstatic --noinput
+   $ django-admin collectstatic --noinput
 
 10. Run Pulp::
 
-    $ pulp-manager runserver
+    $ django-admin runserver
 
 .. _database-install:
 

--- a/docs/integration-guide/rest-api/authentication.rst
+++ b/docs/integration-guide/rest-api/authentication.rst
@@ -6,11 +6,11 @@ All calls to REST API endpoints must be authenticated as a particular User.
 .. tip::
   The password for the "admin" user can be set using two methods.
 
-      ``pulp-manager reset-admin-password``
+      ``django-admin reset-admin-password``
 
   The above command prompts the user to enter a new password for "admin" user.
 
-      ``pulp-manager reset-admin-password --random``
+      ``django-admin reset-admin-password --random``
 
   The above command generates a random password for "admin" user and prints it to the screen.
 

--- a/pulpcore/app/entry_points.py
+++ b/pulpcore/app/entry_points.py
@@ -1,9 +1,0 @@
-"""This module provides system wide command to interface with pulpcore."""
-import os
-import sys
-
-
-def pulp_manager_entry_point():
-    os.environ["DJANGO_SETTINGS_MODULE"] = "pulpcore.app.settings"
-    from django.core.management import execute_from_command_line
-    execute_from_command_line(sys.argv)

--- a/setup.py
+++ b/setup.py
@@ -49,10 +49,5 @@ setup(
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
     ),
-    entry_points={
-        'console_scripts': [
-            'pulp-manager=pulpcore.app.entry_points:pulp_manager_entry_point'
-        ]
-    },
     scripts=['bin/pulp-content'],
 )


### PR DESCRIPTION
Solution: remove pulp-manager and update docs

This patch removes pulp-manager wrapper for django-admin. It also updates all the docs with references
to django-admin directly.

re: #4450
https://pulp.plan.io/issues/4450