### PR TITLE
Reimplement bulk_create() to be compatible with Pulp multi-table inherited models

### DIFF
--- a/pulpcore/app/models/content.py
+++ b/pulpcore/app/models/content.py
@@ -4,8 +4,9 @@ Content related Django models.
 import hashlib
 
 from django.core import validators
-from django.db import IntegrityError, models, transaction
+from django.db import IntegrityError, models, transaction, connections
 from django.forms.models import model_to_dict
+from django.utils.functional import partition
 from drf_chunked_upload.models import ChunkedUpload
 
 from itertools import chain
@@ -18,6 +19,122 @@ class BulkCreateManager(models.Manager):
     """
     A manager that provides a bulk_get_or_create()
     """
+
+    def bulk_create(self, objs, batch_size=None, ignore_conflicts=False):
+        """
+        Insert each of the instances into the database. Do *not* call
+        save() on each of the instances, do not send any pre/post_save
+        signals, and do not set the primary key attribute if it is an
+        autoincrement field (except if features.can_return_rows_from_bulk_insert=True).
+        Multi-table models are not supported.
+        """
+        # When you bulk insert you don't get the primary keys back (if it's an
+        # autoincrement, except if can_return_rows_from_bulk_insert=True), so
+        # you can't insert into the child tables which references this. There
+        # are two workarounds:
+        # 1) This could be implemented if you didn't have an autoincrement pk
+        # 2) You could do it by doing O(n) normal inserts into the parent
+        #    tables to get the primary keys back and then doing a single bulk
+        #    insert into the childmost table.
+        # We currently set the primary keys on the objects when using
+        # PostgreSQL via the RETURNING ID clause. It should be possible for
+        # Oracle as well, but the semantics for extracting the primary keys is
+        # trickier so it's not done yet.
+        assert batch_size is None or batch_size > 0
+        # Check that the parents share the same concrete model with the our
+        # model to detect the inheritance pattern ConcreteGrandParent ->
+        # MultiTableParent -> ProxyChild. Simply checking self.model._meta.proxy
+        # would not identify that case as involving multiple tables.
+        # import pydevd
+        # pydevd.settrace('localhost', port=12735, stdoutToServer=True, stderrToServer=True)
+
+        def _has_parent_model():
+            for parent in self.model._meta.get_parent_list():
+                if parent._meta.concrete_model is not self.model._meta.concrete_model:
+                    return parent._meta.concrete_model
+            return None
+
+        parent_model = _has_parent_model()
+
+        if not parent_model:
+            return super().bulk_create(objs)
+            # From here onwards we assume the multi-table inherited use case
+
+        if not objs:
+            return objs
+
+        def _populate_pk_values(self, objs):
+            for obj in objs:
+                if obj.pk is None:
+                    if parent_model:
+                        setattr(obj, obj._meta.pk.attname, getattr(obj, parent_model._meta.pk.attname))
+                    else:
+                        obj.pk = obj._meta.pk.get_pk_value_on_save(obj)
+
+        self._for_write = True
+        connection = connections[self.db]
+        objs = list(objs)
+        _populate_pk_values(self, objs)
+
+        def _populate_pulp_types(self, objs):
+            for obj in objs:
+                if not obj._type:
+                    obj._type = '{app_label}.{type}'.format(app_label=obj._meta.app_label, type=obj.TYPE)
+
+        _populate_pulp_types(self, objs)
+
+        with transaction.atomic(using=self.db, savepoint=False):
+            objs_with_pk, objs_without_pk = partition(lambda o: o.pk is None, objs)
+
+            if objs_with_pk:
+                base_objects = []
+                for obj in objs_with_pk:
+                    base_obj = parent_model()
+                    base_obj.pk = obj.pk
+                    base_obj._type = obj._type
+                    base_objects.append(base_obj)
+
+                base_fields = parent_model._meta.concrete_fields
+                parent_model.objects._queryset_class._batched_insert(parent_model.objects, base_objects, base_fields, batch_size )
+
+                obj_fields = self.model._meta.local_concrete_fields
+                # for (base_obj, obj) in zip(base_objects, objs_with_pk):
+                #     for field in obj_fields:
+                #         setattr(obj, field.attname, getattr(base_obj, field.attname))
+                for obj_with_pk in objs_with_pk:
+                    obj_with_pk._state.adding = False
+                    obj_with_pk._state.db = self.db
+                self._queryset_class._batched_insert(self, objs_with_pk, obj_fields, batch_size)
+
+            # if objs_without_pk:
+            #     base_objects = []
+            #     for obj in objs_without_pk:
+            #         base_obj = parent_model()
+            #         base_objects.append(base_obj)
+
+            #     base_fields = parent_model._meta.concrete_fields
+            #     self._batched_insert(base_objects, base_fields, batch_size, ignore_conflicts=ignore_conflicts)
+
+            #     obj_fields = self.model._meta.local_concrete_fields
+            #     for (base_obj, obj) in zip(base_objects, objs_with_pk):
+            #         for field in obj_fields:
+            #             setattr(obj, field.attname, getattr(base_obj, field.attname))
+            #     for obj_with_pk in objs_with_pk:
+            #         obj_with_pk._state.adding = False
+            #         obj_with_pk._state.db = self.db
+            #     self._batched_insert(objs_with_pk, obj_fields, batch_size, ignore_conflicts=ignore_conflicts)
+
+
+            #     fields = [f for f in fields if not isinstance(f, AutoField)]
+            #     ids = self._batched_insert(objs_without_pk, fields, batch_size, ignore_conflicts=ignore_conflicts)
+            #     if connection.features.can_return_rows_from_bulk_insert and not ignore_conflicts:
+            #         assert len(ids) == len(objs_without_pk)
+            #     for obj_without_pk, pk in zip(objs_without_pk, ids):
+            #         obj_without_pk.pk = pk
+            #         obj_without_pk._state.adding = False
+            #         obj_without_pk._state.db = self.db
+
+        return objs
 
     def bulk_get_or_create(self, objs, batch_size=None):
         """
@@ -41,7 +158,7 @@ class BulkCreateManager(models.Manager):
         objs = list(objs)
         try:
             with transaction.atomic():
-                return super().bulk_create(objs, batch_size=batch_size)
+                return self.bulk_create(objs, batch_size=batch_size)
         except IntegrityError:
             for i in range(len(objs)):
                 try:


### PR DESCRIPTION
This is a proof of concept mostly, it's functional but incomplete and still a bit messy / inelegant.  I just wanted to demonstrate that it's possible, and some estimation of the maintenance burden it would incur if we were to pull it in.  I haven't actually tested the performance impact yet since that would involve deeper changes to the content pipelines, but from previous experience I would imagine it would be quite substantial, as time spent in database save queries is a huge portion of sync time.

Basic strategy:

Create Content() objects directly, copy over any relevant values from the SomethingContent() objects, save them using a batched insert.

Then save the SomethingContent() objects using a batched insert, but only the fields specific to the SomethingContent type, so that the "content" table is not touched by this insert.