### PR TITLE
Remove settings file variable coercion

### DIFF
--- a/pulpcore/app/serializers/fields.py
+++ b/pulpcore/app/serializers/fields.py
@@ -201,8 +201,8 @@ class BaseURLField(serializers.CharField):
 
     def to_representation(self, value):
         base_path = value
-        host = settings.CONTENT_HOST or ''
-        prefix = settings.CONTENT_PATH_PREFIX or ''
+        host = settings.CONTENT_HOST
+        prefix = settings.CONTENT_PATH_PREFIX
         return '/'.join(
             (
                 host.strip('/'),


### PR DESCRIPTION
Coercing settings in various places in the code doesn't seem as good as
handling those problems in one place, the settings file. This variable
coercion doesn't make sense to me or seem to be needed at all. If we do
need this type of validation or coercion we can add it back later to the
settings file.

[noissue]

