### PR TITLE
Problem: publication's distributions are full URLs

### DIFF
--- a/pulpcore/app/serializers/publication.py
+++ b/pulpcore/app/serializers/publication.py
@@ -22,7 +22,7 @@ from pulpcore.app.serializers import (
 
 class PublicationSerializer(MasterModelSerializer):
     _href = DetailIdentityField()
-    _distributions = serializers.HyperlinkedRelatedField(
+    _distributions = RelatedField(
         help_text=_('This publication is currently being served as'
                     'defined by these distributions.'),
         many=True,


### PR DESCRIPTION
Solution: use RelatedField instead of HyperlinkedRelatedField

The serializer was using the wrong type of field for serializing the Publication's distrubtions field.

fixes: #4590
https://pulp.plan.io/issues/4590