### PR TITLE
Configures certguard tests to run with pulpcore

### DIFF
--- a/.travis/before_install.sh
+++ b/.travis/before_install.sh
@@ -33,6 +33,14 @@ if [ -n "$PULP_FILE_PR_NUMBER" ]; then
   cd ..
 fi
 
+git clone https://github.com/pulp/pulp-certguard.git
+if [ -n "$PULP_CERTGUARD_PR_NUMBER" ]; then
+  cd pulp_file
+  git fetch origin +refs/pull/$PULP_CERTGUARD_PR_NUMBER/merge
+  git checkout FETCH_HEAD
+  cd ..
+fi
+
 if [ -n "$PULP_SMASH_PR_NUMBER" ]; then
   pip uninstall -y pulp-smash
   git clone https://github.com/PulpQE/pulp-smash.git

--- a/.travis/playbook.yml
+++ b/.travis/playbook.yml
@@ -12,6 +12,9 @@
       pulp-file:
         app_label: "file"
         source_dir: "/home/travis/build/pulp/pulp_file"
+      pulp-certguard:
+        app_label: "certguard"
+        source_dir: "/home/travis/build/pulp/pulp-certguard"
     ansible_python_interpreter: '/opt/pyenv/shims/python3'
     pulp_user: 'travis'
     developer_user: 'travis'

--- a/.travis/script.sh
+++ b/.travis/script.sh
@@ -62,6 +62,7 @@ wait_for_pulp 20
 # Run functional tests
 pytest -v -r sx --color=yes --pyargs pulpcore.tests.functional || show_logs_and_return_non_zero
 pytest -v -r sx --color=yes --pyargs pulp_file.tests.functional || show_logs_and_return_non_zero
+pytest -v -r sx --color=yes pulp-certguard/tests/functional || show_logs_and_return_non_zero
 
 # Stop services to write coverage
 kill -SIGINT %?runserver


### PR DESCRIPTION
This makes three changes:
- Clone the pulp/pulp-certguard repo from source in Travis environments
- Configure the Ansible Installer to install that source checkout
- Have py.test run those functional tests to ensure they pass with
  pulpcore.

https://pulp.plan.io/issues/4596
closes #4596
