### PR TITLE
Fix pulp-certguard dir

### DIFF
--- a/.travis/before_install.sh
+++ b/.travis/before_install.sh
@@ -35,7 +35,7 @@ fi
 
 git clone https://github.com/pulp/pulp-certguard.git
 if [ -n "$PULP_CERTGUARD_PR_NUMBER" ]; then
-  cd pulp_file
+  cd pulp-certguard
   git fetch origin +refs/pull/$PULP_CERTGUARD_PR_NUMBER/merge
   git checkout FETCH_HEAD
   cd ..


### PR DESCRIPTION
Fix pulp-certguard dir allowing tests from this dir to run. Instead of
pulp-file tests.

'[noissue]'

