### PR TITLE
Revamps the git contributor page

### DIFF
--- a/docs/contributing/git.rst
+++ b/docs/contributing/git.rst
@@ -1,28 +1,16 @@
 Git
 ===
 
-Pulp source code lives on `GitHub <https://github.com/pulp>`_. This document is definitive for :term:`pulpcore` only, but some plugins may choose to
-follow the same strategies.
+Pulp source code lives on `GitHub <https://github.com/pulp/pulpcore>`_. This document is definitive
+for :term:`pulpcore` only, but some plugins may choose to follow the same strategies.
 
 .. _git-branch:
 
 Versions and Branches
 ---------------------
 
-Pulp uses a version scheme ``x.y.z``, which is based on `Semantic Versioning
-<http://semver.org/>`_. Briefly, ``x.y.z`` releases may only contain bugfixes (no features),
-``x.y`` releases may only contain backwards compatible changes (new features, bugfixes), and ``x``
-releases may break backwards compatibility.
-
-Most changes should be merged into the ``master`` branch only. When necessary, fixes can be
-cherry-picked into ``x.y`` stream.
-
-.. note::
-
-   For additional information on Pulp's branching strategy decision, please
-   refer to PUP-0003_
-
-.. _PUP-0003: https://github.com/pulp/pups/blob/master/pup-0003.md
+Code is submitted by a Pull Request on Github to merge the changes to ``master`` which represents
+the next ``pulpcore`` release. See :ref:`versioning` for more details.
 
 
 Commits

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -8,6 +8,7 @@ content type is provided by the corresponding plugin, which can be found in our
 Developers interested in writing plugins should reference the `Pulp Plugin API
 <../../pulpcore-plugin/nightly/>`_ documentation.
 
+
 Self-Guided Tour for New Users
 ------------------------------
 
@@ -17,6 +18,7 @@ pulp<installation/index>`, the simplest way to get concrete experience is to ins
 `plugins <https://pulpproject.org/pulp-3-plugins/>`_ and use its quickstart guide. Next it is
 recommended that users read through our :doc:`workflows/index` to find best practices for common
 use cases.
+
 
 .. _community:
 
@@ -44,9 +46,20 @@ make Pulp better, please reach out!
   * `plugin table <https://pulpproject.org/pulp-3-plugins/>`_
 
     * Ansible #pulp-ansible channel on Freenode
-    * Docker #pulp-dockerchannel on Freenode
+    * Docker #pulp-docker channel on Freenode
     * Python #pulp-python channel on Freenode
     * RPM #pulp-rpm channel on Freenode
+
+
+.. _versioning:
+
+Versioning
+----------
+
+Pulp uses a version scheme ``x.y.z``, which is based on `Semantic Versioning
+<http://semver.org/>`_. Briefly, ``x.y.z`` releases may only contain bugfixes (no features),
+``x.y`` releases may only contain backwards compatible changes (new features, bugfixes), and ``x``
+releases may break backwards compatibility.
 
 
 Table of Contents


### PR DESCRIPTION
This moves the version section to the homepage and then links to that
from the git page. The branching page now recommends all code be opened
in a Pull Request against the master branch.

https://pulp.plan.io/issues/4625
closes #4625
