### PR TITLE
Update distribution creation to use task_handler

### DIFF
--- a/pulpcore/tests/functional/api/using_plugin/test_auto_distribution.py
+++ b/pulpcore/tests/functional/api/using_plugin/test_auto_distribution.py
@@ -93,11 +93,10 @@ class AutoDistributionTestCase(unittest.TestCase):
         body = gen_distribution()
         body['repository'] = repo['_href']
         body['publisher'] = publisher['_href']
-
-        response_dict = self.client.post(DISTRIBUTION_PATH, body)
-        dist_task = self.client.get(response_dict['task'])
-        distribution_href = dist_task['created_resources'][0]
-        distribution = self.client.get(distribution_href)
+        distribution = self.client.using_handler(api.task_handler).post(
+            DISTRIBUTION_PATH,
+            body
+        )
         self.addCleanup(self.client.delete, distribution['_href'])
 
         last_version_href = get_versions(repo)[-1]['_href']
@@ -175,10 +174,10 @@ class SetupAutoDistributionTestCase(unittest.TestCase):
         body = gen_distribution()
         body['publisher'] = publisher['_href']
         body['repository'] = repo['_href']
-        response_dict = self.client.post(DISTRIBUTION_PATH, body)
-        dist_task = self.client.get(response_dict['task'])
-        distribution_href = dist_task['created_resources'][0]
-        distribution = self.client.get(distribution_href)
+        distribution = self.client.using_handler(api.task_handler).post(
+            DISTRIBUTION_PATH,
+            body
+        )
         self.addCleanup(self.client.delete, distribution['_href'])
 
         # Update the distribution.

--- a/pulpcore/tests/functional/api/using_plugin/test_content_app.py
+++ b/pulpcore/tests/functional/api/using_plugin/test_content_app.py
@@ -76,11 +76,10 @@ class ContentAppTestCase(unittest.TestCase):
         body = gen_distribution()
         body['repository'] = repo['_href']
         body['publisher'] = publisher['_href']
-
-        response_dict = self.client.post(DISTRIBUTION_PATH, body)
-        dist_task = self.client.get(response_dict['task'])
-        distribution_href = dist_task['created_resources'][0]
-        distribution = self.client.get(distribution_href)
+        distribution = self.client.using_handler(api.task_handler).post(
+            DISTRIBUTION_PATH,
+            body
+        )
         self.addCleanup(self.client.delete, distribution['_href'])
 
         last_version_href = get_versions(repo)[-1]['_href']

--- a/pulpcore/tests/functional/api/using_plugin/test_content_promotion.py
+++ b/pulpcore/tests/functional/api/using_plugin/test_content_promotion.py
@@ -74,10 +74,10 @@ class ContentPromotionTestCase(unittest.TestCase):
         for _ in range(2):
             body = gen_distribution()
             body['publication'] = publication['_href']
-            response_dict = client.post(DISTRIBUTION_PATH, body)
-            dist_task = client.get(response_dict['task'])
-            distribution_href = dist_task['created_resources'][0]
-            distribution = client.get(distribution_href)
+            distribution = client.using_handler(api.task_handler).post(
+                DISTRIBUTION_PATH,
+                body
+            )
             distributions.append(distribution)
             self.addCleanup(client.delete, distribution['_href'])
 

--- a/pulpcore/tests/functional/api/using_plugin/test_crd_publications.py
+++ b/pulpcore/tests/functional/api/using_plugin/test_crd_publications.py
@@ -140,10 +140,10 @@ class PublicationsTestCase(unittest.TestCase):
         """Read a publication by its distribution."""
         body = gen_distribution()
         body['publication'] = self.publication['_href']
-        response_dict = self.client.post(DISTRIBUTION_PATH, body)
-        dist_task = self.client.get(response_dict['task'])
-        distribution_href = dist_task['created_resources'][0]
-        distribution = self.client.get(distribution_href)
+        distribution = self.client.using_handler(api.task_handler).post(
+            DISTRIBUTION_PATH,
+            body
+        )
         self.addCleanup(self.client.delete, distribution['_href'])
 
         self.publication.update(self.client.get(self.publication['_href']))


### PR DESCRIPTION
Distribution creation it was modified to be an async task. A new
response_handler was added to pulp-smash to deal with those cases.
Update distribution creation to use this new response_handler.

'[noissue]'
