### PR TITLE
Remove test dependency on psycopg2

### DIFF
--- a/doc_requirements.txt
+++ b/doc_requirements.txt
@@ -5,7 +5,6 @@ django-filter
 drf-nested-routers
 plantuml
 pyyaml
-psycopg2
 sphinx<1.8.0
 sphinx-rtd-theme
 sphinxcontrib-openapi


### PR DESCRIPTION
The tests don't need psycopg2.

https://pulp.plan.io/issues/4639
closes #4639
