### PR TITLE
Preparing for Dynaconf 2.0.0 (released on April 8)

### DIFF
--- a/pulpcore/app/settings.py
+++ b/pulpcore/app/settings.py
@@ -13,50 +13,33 @@ from contextlib import suppress
 from importlib import import_module
 from pkg_resources import iter_entry_points
 
-from dynaconf import LazySettings
-
-
-# https://github.com/rochacbruno/dynaconf/issues/89
-settings = LazySettings(GLOBAL_ENV_FOR_DYNACONF='PULP',
-                        ENVVAR_FOR_DYNACONF='PULP_SETTINGS',
-                        SETTINGS_MODULE_FOR_DYNACONF='/etc/pulp/settings.py')
-
-GLOBAL_ENV_FOR_DYNACONF = settings.get('GLOBAL_ENV_FOR_DYNACONF', 'PULP')
-SETTINGS_MODULE_FOR_DYNACONF = settings.get('SETTINGS_MODULE_FOR_DYNACONF',
-                                            '/etc/pulp/settings.py')
-
 # Build paths inside the project like this: os.path.join(BASE_DIR, ...)
-BASE_DIR = settings.get('BASE_DIR', os.path.dirname(os.path.abspath(__file__)))
+BASE_DIR = os.path.dirname(os.path.abspath(__file__))
 
 # Quick-start development settings - unsuitable for production
 # See https://docs.djangoproject.com/en/1.11/howto/deployment/checklist/
 
 # SECURITY WARNING: don't run with debug turned on in production!
-DEBUG = settings.get('DEBUG', False, '@bool')
+DEBUG = False
 
-ALLOWED_HOSTS = settings.get('ALLOWED_HOSTS', ['*'])
+ALLOWED_HOSTS = ['*']
 
-MEDIA_ROOT = settings.get('MEDIA_ROOT', '/var/lib/pulp/')
-STATIC_ROOT = settings.get('STATIC_ROOT', os.path.join(MEDIA_ROOT, 'static/'))
+MEDIA_ROOT = '/var/lib/pulp/'
+STATIC_ROOT = os.path.join(MEDIA_ROOT, 'static/')
 
-DEFAULT_FILE_STORAGE = settings.get('DEFAULT_FILE_STORAGE',
-                                    'pulpcore.app.models.storage.FileSystem')
+DEFAULT_FILE_STORAGE = 'pulpcore.app.models.storage.FileSystem'
 
-FILE_UPLOAD_TEMP_DIR = settings.get('FILE_UPLOAD_TEMP_DIR', os.path.join(MEDIA_ROOT, 'tmp/'))
-WORKING_DIRECTORY = settings.get('WORKING_DIRECTORY', os.path.join(MEDIA_ROOT, 'tmp/'))
+FILE_UPLOAD_TEMP_DIR = os.path.join(MEDIA_ROOT, 'tmp/')
+WORKING_DIRECTORY = os.path.join(MEDIA_ROOT, 'tmp/')
 
 # List of upload handler classes to be applied in order.
-FILE_UPLOAD_HANDLERS = settings.get('FILE_UPLOAD_HANDLERS',
-                                    ('pulpcore.app.files.HashingFileUploadHandler',)
-                                    )
+FILE_UPLOAD_HANDLERS = ('pulpcore.app.files.HashingFileUploadHandler',)
 
-
-SECRET_KEY = settings.get('SECRET_KEY', True)
-
+SECRET_KEY = True
 
 # Application definition
 
-INSTALLED_APPS = settings.get('INSTALLED_APPS', [
+INSTALLED_APPS = [
     # django stuff
     'django.contrib.admin',
     'django.contrib.auth',
@@ -71,10 +54,10 @@ INSTALLED_APPS = settings.get('INSTALLED_APPS', [
     'drf_chunked_upload',
     # pulp core app
     'pulpcore.app',
-])
+]
 
 # Enumerate the installed Pulp plugins during the loading process for use in the status API
-INSTALLED_PULP_PLUGINS = settings.get('INSTALLED_PULP_PLUGINS', [])
+INSTALLED_PULP_PLUGINS = []
 
 for entry_point in iter_entry_points('pulpcore.plugin'):
     plugin_app_config = entry_point.load()
@@ -82,11 +65,11 @@ for entry_point in iter_entry_points('pulpcore.plugin'):
     INSTALLED_APPS.append(plugin_app_config)
 
 # Optional apps that help with development, or augment Pulp in some non-critical way
-OPTIONAL_APPS = settings.get('OPTIONAL_APPS', [
+OPTIONAL_APPS = [
     'crispy_forms',
     'django_extensions',
     'storages',
-])
+]
 
 for app in OPTIONAL_APPS:
     # only import if app is installed
@@ -94,7 +77,7 @@ for app in OPTIONAL_APPS:
         import_module(app)
         INSTALLED_APPS.append(app)
 
-MIDDLEWARE = settings.get('MIDDLEWARE', [
+MIDDLEWARE = [
     'django.middleware.security.SecurityMiddleware',
     'whitenoise.middleware.WhiteNoiseMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',
@@ -103,11 +86,11 @@ MIDDLEWARE = settings.get('MIDDLEWARE', [
     'django.contrib.auth.middleware.AuthenticationMiddleware',
     'django.contrib.messages.middleware.MessageMiddleware',
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
-])
+]
 
-ROOT_URLCONF = settings.get('ROOT_URLCONF', 'pulpcore.app.urls')
+ROOT_URLCONF = 'pulpcore.app.urls'
 
-TEMPLATES = settings.get('TEMPLATES', [
+TEMPLATES = [
     {
         'BACKEND': 'django.template.backends.django.DjangoTemplates',
         'DIRS': [os.path.join(BASE_DIR, 'templates')],
@@ -121,11 +104,11 @@ TEMPLATES = settings.get('TEMPLATES', [
             ],
         },
     },
-])
+]
 
-WSGI_APPLICATION = settings.get('WSGI_APPLICATION', 'pulpcore.app.wsgi.application')
+WSGI_APPLICATION = 'pulpcore.app.wsgi.application'
 
-REST_FRAMEWORK = settings.get('REST_FRAMEWORK', {
+REST_FRAMEWORK = {
     'URL_FIELD_NAME': '_href',
     'DEFAULT_FILTER_BACKENDS': ('django_filters.rest_framework.DjangoFilterBackend',),
     'DEFAULT_PAGINATION_CLASS': 'pulpcore.app.pagination.IDPagination',
@@ -137,12 +120,12 @@ REST_FRAMEWORK = settings.get('REST_FRAMEWORK', {
     ),
     'UPLOADED_FILES_USE_URL': False,
     'DEFAULT_VERSIONING_CLASS': 'rest_framework.versioning.URLPathVersioning',
-})
+}
 
 # Password validation
 # https://docs.djangoproject.com/en/dev/ref/settings/#auth-password-validators
 
-AUTH_PASSWORD_VALIDATORS = settings.get('AUTH_PASSWORD_VALIDATORS', [
+AUTH_PASSWORD_VALIDATORS = [
     {
         'NAME': 'django.contrib.auth.password_validation.UserAttributeSimilarityValidator',
     },
@@ -155,43 +138,43 @@ AUTH_PASSWORD_VALIDATORS = settings.get('AUTH_PASSWORD_VALIDATORS', [
     {
         'NAME': 'django.contrib.auth.password_validation.NumericPasswordValidator',
     },
-])
+]
 
 
 # Internationalization
 # https://docs.djangoproject.com/en/1.11/topics/i18n/
 
-LANGUAGE_CODE = settings.get('LANGUAGE_CODE', 'en-us')
+LANGUAGE_CODE = 'en-us'
 
-TIME_ZONE = settings.get('TIME_ZONE', 'UTC')
+TIME_ZONE = 'UTC'
 
-USE_I18N = settings.get('USE_I18N', True)
+USE_I18N = 'USE_I18N', True
 
-USE_L10N = settings.get('USE_L10N', True)
+USE_L10N = True
 
-USE_TZ = settings.get('USE_TZ', True)
+USE_TZ = True
 
 
 # Static files (CSS, JavaScript, Images)
 # https://docs.djangoproject.com/en/1.11/howto/static-files/
 
-STATIC_URL = settings.get('STATIC_URL', '/static/')
+STATIC_URL = '/static/'
 
 # A set of default settings to use if the configuration file in
 # /etc/pulp/ is missing or if it does not have values for every setting
 
 # https://docs.djangoproject.com/en/1.11/ref/settings/#databases
-DATABASES = settings.get('DATABASES', {
+DATABASES = {
     'default': {
         'ENGINE': 'django.db.backends.postgresql_psycopg2',
         'NAME': 'pulp',
         'USER': 'pulp',
         'CONN_MAX_AGE': 0,
     },
-})
+}
 # https://docs.djangoproject.com/en/1.11/ref/settings/#logging and
 # https://docs.python.org/3/library/logging.config.html
-LOGGING = settings.get('LOGGING', {
+LOGGING = {
     'version': 1,
     'disable_existing_loggers': False,
     'formatters': {
@@ -210,15 +193,28 @@ LOGGING = settings.get('LOGGING', {
             'level': 'INFO'
         },
     }
-})
+}
 
-CONTENT_HOST = settings.get('CONTENT_HOST', None)
-CONTENT_PATH_PREFIX = settings.get('CONTENT_PATH_PREFIX', '/pulp/content/')
+CONTENT_HOST = None
+CONTENT_PATH_PREFIX = '/pulp/content/'
 
-PROFILE_STAGES_API = settings.get('PROFILE_STAGES_API', False)
+PROFILE_STAGES_API = False
 
 SWAGGER_SETTINGS = {
     'DEFAULT_GENERATOR_CLASS': 'pulpcore.app.openapigenerator.PulpOpenAPISchemaGenerator',
     'DEFAULT_AUTO_SCHEMA_CLASS': 'pulpcore.app.openapigenerator.PulpAutoSchema',
     'DEFAULT_INFO': 'pulpcore.app.urls.api_info',
 }
+
+# HERE STARTS DYNACONF EXTENSION LOAD (Keep at the very bottom of settings.py)
+# Read more at https://dynaconf.readthedocs.io/en/latest/guides/django.html
+import dynaconf  # noqa
+settings = dynaconf.DjangoDynaconf(
+    __name__,
+    GLOBAL_ENV_FOR_DYNACONF='PULP',
+    ENV_SWITCHER_FOR_DYNACONF='PULP_ENV',
+    SETTINGS_MODULE_FOR_DYNACONF='/etc/pulp/settings.py',
+    INCLUDES_FOR_DYNACONF=['/etc/pulp/plugins/*'],
+    ENVVAR_FOR_DYNACONF='PULP_SETTINGS',
+)
+# HERE ENDS DYNACONF EXTENSION LOAD (No more code below this line)

--- a/pulpcore/rqconfig.py
+++ b/pulpcore/rqconfig.py
@@ -1,12 +1,6 @@
 import sys
 from pulpcore.app.settings import settings
 
-
-settings.configure()
-
 rq_settings = ['REDIS_URL', 'REDIS_HOST', 'REDIS_PORT', 'REDIS_DB', 'REDIS_PASSWORD', 'SENTINEL']
 
-for s in rq_settings:
-    value = settings.get(s, None)
-    if value:
-        setattr(sys.modules[__name__], s, value)
+settings.populate_obj(sys.modules[__name__], keys=rq_settings)

--- a/pulpcore/tests/unit/test_rqconfig.py
+++ b/pulpcore/tests/unit/test_rqconfig.py
@@ -1,7 +1,7 @@
 import importlib
 import os
 from unittest import TestCase
-
+from pulpcore.app import settings
 from pulpcore import rqconfig
 
 
@@ -12,7 +12,11 @@ class TestRQConfig(TestCase):
         os.environ['PULP_REDIS_HOST'] = 'redishost'
         os.environ['PULP_REDIS_PORT'] = '1234'
         os.environ['PULP_REDIS_PASSWORD'] = 'mypassword'
+
+        # Reload settings and rqconfig so new envvars are re-read
+        importlib.reload(settings)
         importlib.reload(rqconfig)
+
         self.assertEquals(rqconfig.REDIS_HOST, 'redishost')
         self.assertEquals(rqconfig.REDIS_PORT, 1234)
         self.assertEquals(rqconfig.REDIS_PASSWORD, 'mypassword')

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ requirements = [
     'rq>=0.12,<1.0',
     'redis<3.2.0',
     'setuptools',
-    'dynaconf>=1.0.4',
+    'dynaconf>=2.0.0',
     'whitenoise',
     'drf-chunked-upload'
 ]


### PR DESCRIPTION
## Dynaconf 2.0.0 is released

This release includes lots of improvements on performance
and changes the way dynaconf searched settings files.

> **NOTE**: This change is not required, Dynaconf must be backwards compatible, the [Pulp's current way](https://dynaconf.readthedocs.io/en/latest/guides/django.html#explicit-mode) of loading dynaconf is still supported

This PR includes:

- Fixed the way settings are loaded on `settings.py` (no more explicit `get(....)` and added dynaconf patching at the end of file with all dynaconf config options in one place)

- Added `INCLUDES_FOR_DYNACONF` pointing to `/etc/pulp/plugins/*`

  That means that any dynaconf supported settings file saved on that folder will be loaded,
  so plugin installer can drop a `pulp_foo.toml` on that path containing:

```toml
[default]
content_host = 'otherplace:9999'
```

or `pulp_foo.py`

```py
FOO = 'BAR'
```

Then dynaconf will load it, user does not have to mess with `/etc/pulp/settings.py` and plugin writers can provide config templates for installer, installer can just drop the file on that place.

It is also possible to force plugin writers to use specific config env like `[pulpfoo]` o settings file, then it will never override pulp settings but add additional for use only inside that specific plugin code. Which can be achieved using `with settings.using_env('pulpfoo'):` context manager.

Pulp is now part of Dynaconf's test matrix on Azure Pipelines and this changes has already been tested :)

Django Guide: https://dynaconf.readthedocs.io/en/latest/guides/django.html
Django example: https://github.com/rochacbruno/dynaconf/tree/master/example/django_example

Full Dynaconf 2.0.0 Changelog: https://github.com/rochacbruno/dynaconf/releases/tag/2.0.0


Related to https://pulp.plan.io/issues/4679

[noissue]

