### PR TITLE
Problem: inaccurate 'operation_summary' for status and task cancel

### DIFF
--- a/pulpcore/app/openapigenerator.py
+++ b/pulpcore/app/openapigenerator.py
@@ -256,7 +256,8 @@ class PulpAutoSchema(SwaggerAutoSchema):
         tags = self.get_tags(operation_keys)
 
         responses = self.get_responses()
-        summary = self.get_summary(operation_keys)
+        if 'operation_summary' not in self.overrides:
+            summary = self.get_summary(operation_keys)
         return openapi.Operation(
             operation_id=operation_id,
             description=force_real_str(description),

--- a/pulpcore/app/views/status.py
+++ b/pulpcore/app/views/status.py
@@ -1,4 +1,5 @@
 from gettext import gettext as _
+from drf_yasg.utils import swagger_auto_schema
 from pkg_resources import get_distribution
 from rest_framework.response import Response
 from rest_framework.views import APIView
@@ -22,6 +23,7 @@ class StatusView(APIView):
     authentication_classes = []
     permission_classes = []
 
+    @swagger_auto_schema(operation_summary="Inspect status of Pulp")
     def get(self, request, format=None):
         """
         Returns app information including the version of pulpcore and loaded pulp plugins,

--- a/pulpcore/app/viewsets/task.py
+++ b/pulpcore/app/viewsets/task.py
@@ -1,4 +1,5 @@
 from django_filters.rest_framework import filters, DjangoFilterBackend
+from drf_yasg.utils import swagger_auto_schema
 from rest_framework import status, mixins
 from rest_framework.decorators import detail_route
 from rest_framework.filters import OrderingFilter
@@ -46,6 +47,8 @@ class TaskViewSet(NamedModelViewSet,
     filter_backends = (OrderingFilter, DjangoFilterBackend)
     ordering = ('-_created')
 
+    @swagger_auto_schema(operation_description="This operation cancels a task.",
+                         operation_summary="Cancel a task")
     @detail_route(methods=('post',))
     def cancel(self, request, pk=None):
         task = self.get_object()


### PR DESCRIPTION
Solution: add operation summaries using swagger_auto_schema

This patch also improves the PulpAutoSchema inspector. The inspector only tries to generate a summary
when the summary is not already provided by swagger_auto_schema decorator.

[noissue]