### PR TITLE
 Change Pulp 3 Default Ports

### DIFF
--- a/.travis/publish_docs.sh
+++ b/.travis/publish_docs.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-django-admin runserver >> ~/django_runserver.log 2>&1 &
+django-admin runserver 24817 >> ~/django_runserver.log 2>&1 &
 sleep 5
 
 openssl aes-256-cbc -K $encrypted_d1a778bda808_key -iv $encrypted_d1a778bda808_iv -in .travis/pulp-infra.enc -out ~/.ssh/pulp-infra -d

--- a/.travis/pulp-smash-config.json
+++ b/.travis/pulp-smash-config.json
@@ -8,8 +8,8 @@
         {
             "hostname": "localhost",
             "roles": {
-                "api": {"port": 8000, "scheme": "http", "service": "nginx"},
-                "content": {"port": 8080, "scheme": "http", "service": "pulp_content_app"},
+                "api": {"port": 24817, "scheme": "http", "service": "nginx"},
+                "content": {"port": 24816, "scheme": "http", "service": "pulp_content_app"},
                 "pulp resource manager": {},
                 "pulp workers": {},
                 "redis": {},

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -51,7 +51,7 @@ diagrams:
 
 html:
 	mkdir -p $(BUILDDIR)/html
-	curl -o _build/html/api.json "http://localhost:8000/pulp/api/v3/docs/?format=openapi"
+	curl -o _build/html/api.json "http://localhost:24817/pulp/api/v3/docs/?format=openapi"
 	$(SPHINXBUILD) -b html $(ALLSPHINXOPTS) $(BUILDDIR)/html
 	@echo
 	@echo "Build finished. The HTML pages are in $(BUILDDIR)/html."

--- a/docs/components.rst
+++ b/docs/components.rst
@@ -23,7 +23,7 @@ things:
    A simple, but limited way to run the REST API as a standalone service using the built-in Django
    runserver.::
 
-      $ python django-admin runserver
+      $ python django-admin runserver 24817
 
 
 The REST API can be deployed with any any WSGI webserver like a normal Django application. See the

--- a/docs/contributing/architecture/rest-api.rst
+++ b/docs/contributing/architecture/rest-api.rst
@@ -302,7 +302,7 @@ To use this request:
 
 .. code-block:: bash
 
-    http 'http://192.168.121.134:8000/pulp/api/v3/repositories/?name=singing-gerbil'
+    http 'http://192.168.121.134:24817/pulp/api/v3/repositories/?name=singing-gerbil'
 
 This is what the ViewSet should look like:
 
@@ -322,7 +322,7 @@ that allows the same request:
 
 .. code-block:: bash
 
-    http 'http://192.168.121.134:8000/pulp/api/v3/repositories/?name=singing-gerbil'
+    http 'http://192.168.121.134:24817/pulp/api/v3/repositories/?name=singing-gerbil'
 
 
 .. code:: python
@@ -350,7 +350,7 @@ https://django-filter.readthedocs.io/en/latest/ref/filters.html#filters
 
 Simply define any filters in the `FilterSet` and then include them in `fields` in the Filter's Meta class.
 
-`http 'http://192.168.121.134:8000/pulp/api/v3/repositories/?name_contains=singing'`
+`http 'http://192.168.121.134:24817/pulp/api/v3/repositories/?name_contains=singing'`
 
 .. code-block:: python
 
@@ -373,7 +373,7 @@ custom filter based on the `BaseInFilter`.
 
 .. code-block:: bash
 
-    http 'http://192.168.121.134:8000/pulp/api/v3/repositories/?name_in_list=singing-gerbil,versatile-pudu'
+    http 'http://192.168.121.134:24817/pulp/api/v3/repositories/?name_in_list=singing-gerbil,versatile-pudu'
 
 
 .. code-block:: python

--- a/docs/contributing/runtests.rst
+++ b/docs/contributing/runtests.rst
@@ -14,7 +14,7 @@ Prerequisites
 If you want to run the functional tests, you need a running pulp instance that is allowed to be
 mixed up by the tests.
 For example, using the development vm (see :ref:`DevSetup`),
-this can be accomplished by `workon pulp; django-admin runserver`.
+this can be accomplished by `workon pulp; django-admin runserver 24817`.
 Also, you need a valid *pulp-smash*
 `config <https://pulp-smash.readthedocs.io/en/latest/configuration.html>`_ file.
 This can be created with `pulp-smash settings create`.

--- a/docs/installation/instructions.rst
+++ b/docs/installation/instructions.rst
@@ -83,7 +83,7 @@ PyPI Installation
 
 10. Run Pulp::
 
-    $ django-admin runserver
+    $ django-admin runserver 24817
 
 .. _database-install:
 

--- a/docs/workflows/upload-publish.rst
+++ b/docs/workflows/upload-publish.rst
@@ -7,21 +7,21 @@ Chunked Uploads
 For large file uploads, Pulp supports uploading files in chunks. To begin uploading a file in
 chunks, an initial PUT request must be sent to the ``/pulp/api/v3/uploads`` endpoint::
 
-    http --form PUT :8000/pulp/api/v3/uploads/ file@./chunkaa 'Content-Range:bytes 0-6291455/32095676'
+    http --form PUT :24817/pulp/api/v3/uploads/ file@./chunkaa 'Content-Range:bytes 0-6291455/32095676'
 
 This returns an upload href (e.g. ``/pulp/api/v3/uploads/a8b5a7f7-2f22-460d-ab20-d5616cb71cdd/``) that can
 be used for subsequent chunks::
 
-    http --form PUT :8000/pulp/api/v3/uploads/a8b5a7f7-2f22-460d-ab20-d5616cb71cdd/ file@./chunkbb 'Content-Range:bytes 6291456-10485759/32095676'
+    http --form PUT :24817/pulp/api/v3/uploads/a8b5a7f7-2f22-460d-ab20-d5616cb71cdd/ file@./chunkbb 'Content-Range:bytes 6291456-10485759/32095676'
 
 Once all chunks have been uploaded, a final POST request with the file md5 can be sent to complete the
 upload::
 
-    http POST :8000/pulp/api/v3/uploads/a8b5a7f7-2f22-460d-ab20-d5616cb71cdd/ md5=037a47d93670e64f2b1038e6f90e4cfd
+    http POST :24817/pulp/api/v3/uploads/a8b5a7f7-2f22-460d-ab20-d5616cb71cdd/ md5=037a47d93670e64f2b1038e6f90e4cfd
 
 Then the artifact may be created with the upload href::
 
-    http POST :8000/pulp/api/v3/artifacts/ upload=/pulp/api/v3/uploads/a8b5a7f7-2f22-460d-ab20-d5616cb71cdd/
+    http POST :24817/pulp/api/v3/artifacts/ upload=/pulp/api/v3/uploads/a8b5a7f7-2f22-460d-ab20-d5616cb71cdd/
 
 Note that after creating an artifact from an upload, the upload gets deleted and cannot be re-used.
 
@@ -29,7 +29,7 @@ Putting this altogether, here is an example that uploads a 1.iso file in two chu
 
    curl -O https://repos.fedorapeople.org/repos/pulp/pulp/fixtures/file-large/1.iso
    split --bytes=6M 1.iso chunk
-   export UPLOAD=$(http --form PUT :8000/pulp/api/v3/uploads/ file@./chunkaa 'Content-Range:bytes 0-6291455/32095676'  | jq -r '._href')
-   http --form PUT :8000$UPLOAD file@./chunkab 'Content-Range:bytes 6291456-10485759/32095676'
-   http POST :8000$UPLOAD md5=037a47d93670e64f2b1038e6f90e4cfd
-   http POST :8000/pulp/api/v3/artifacts/ upload=$UPLOAD
+   export UPLOAD=$(http --form PUT :24817/pulp/api/v3/uploads/ file@./chunkaa 'Content-Range:bytes 0-6291455/32095676'  | jq -r '._href')
+   http --form PUT :24817$UPLOAD file@./chunkab 'Content-Range:bytes 6291456-10485759/32095676'
+   http POST :24817$UPLOAD md5=037a47d93670e64f2b1038e6f90e4cfd
+   http POST :24817/pulp/api/v3/artifacts/ upload=$UPLOAD

--- a/pulpcore/app/viewsets/repository.py
+++ b/pulpcore/app/viewsets/repository.py
@@ -170,7 +170,7 @@ class RepositoryVersionFilter(BaseFilterSet):
     # /?number__range=4,6
     # /?_created__gte=2018-04-12T19:45
     # /?_created__range=2018-04-12T19:45,2018-04-13T20:00
-    # /?content=http://localhost:8000/pulp/api/v3/content/file/fb8ad2d0-03a8-4e36-a209-77763d4ed16c/
+    # /?content=/pulp/api/v3/content/file/fb8ad2d0-03a8-4e36-a209-77763d4ed16c/
     number = filters.NumberFilter()
     _created = IsoDateTimeFilter()
     content = RepositoryVersionContentFilter()


### PR DESCRIPTION
Change Pulp 3 Default Ports
https://pulp.plan.io/issues/4556

Update docs for changed Pulp 3 Default Ports
https://pulp.plan.io/issues/4594

Content: 8080 -> 24816
API: 8000 -> 24817

This commit includes a change to docs/Makefile that affects the build process.

Note: I am about to submit changes to ansible-pulp & several other repos too. The travis files exist in those other repos in addition to doc updates. They probably all need to be merged at the same time.

Required PR: https://github.com/pulp/pulpcore/pull/79