### PR TITLE
Expand tests related to task system

### DIFF
--- a/pulpcore/tests/functional/api/using_plugin/constants.py
+++ b/pulpcore/tests/functional/api/using_plugin/constants.py
@@ -66,7 +66,6 @@ FILE_URL = urljoin(FILE_FIXTURE_URL, '1.iso')
 FILE2_URL = urljoin(FILE2_FIXTURE_URL, '1.iso')
 """The URL to an ISO file at :data:`FILE2_FIXTURE_URL`."""
 
-
 RPM_PACKAGE_CONTENT_NAME = 'rpm.package'
 
 RPM_UPDATE_CONTENT_NAME = 'rpm.update'

--- a/pulpcore/tests/functional/api/using_plugin/test_tasking.py
+++ b/pulpcore/tests/functional/api/using_plugin/test_tasking.py
@@ -1,10 +1,14 @@
 # coding=utf-8
 """Tests related to the tasking system."""
 import unittest
+from urllib.parse import urljoin
 
-from pulp_smash import api, config
-from pulp_smash.pulp3.constants import REPO_PATH
+from requests.exceptions import HTTPError
+from pulp_smash import api, config, utils
+from pulp_smash.pulp3.constants import REPO_PATH, TASKS_PATH
 from pulp_smash.pulp3.utils import (
+    delete_orphans,
+    gen_remote,
     gen_repo,
     get_content_summary,
     sync,
@@ -61,3 +65,67 @@ class MultiResourceLockingTestCase(unittest.TestCase):
         remote = client.get(remote['_href'])
         self.assertEqual(remote['url'], url['url'])
         self.assertDictEqual(get_content_summary(repo), FILE_FIXTURE_SUMMARY)
+
+
+class CancelTaskTestCase(unittest.TestCase):
+    """Test to cancel a task in different states.
+
+    This test targets the following issue:
+
+    * `Pulp #3527 <https://pulp.plan.io/issues/3527>`_
+    * `Pulp #3634 <https://pulp.plan.io/issues/3634>`_
+    * `Pulp Smash #976 <https://github.com/PulpQE/pulp-smash/issues/976>`_
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        """Create class-wide variables."""
+        cls.cfg = config.get_config()
+        cls.client = api.Client(cls.cfg, api.page_handler)
+
+    def test_cancel_running_task(self):
+        """Cancel a running task."""
+        task = self.create_long_task()
+        self.cancel_task(task)
+        response = self.client.get(task['task'])
+        self.assertIsNone(response['finished_at'], response)
+        self.assertEqual(response['state'], 'canceled', response)
+
+    def test_cancel_nonexistent_task(self):
+        """Cancel a nonexistent task."""
+        task_href = urljoin(TASKS_PATH, utils.uuid4() + '/')
+        with self.assertRaises(HTTPError) as ctx:
+            self.client.post(urljoin(task_href, 'cancel/'))
+        for key in ('not', 'found'):
+            self.assertIn(
+                key,
+                ctx.exception.response.json()['detail'].lower(),
+                ctx.exception.response
+            )
+
+    def test_delete_running_task(self):
+        """Delete a running task."""
+        task = self.create_long_task()
+        with self.assertRaises(HTTPError):
+            self.client.delete(task['task'])
+
+    def create_long_task(self):
+        """Create a long task. Sync a repository with large files."""
+        # to force the download of files.
+        delete_orphans(self.cfg)
+
+        repo = self.client.post(REPO_PATH, gen_repo())
+        self.addCleanup(self.client.delete, repo['_href'])
+
+        body = gen_remote(url=FILE_LARGE_FIXTURE_MANIFEST_URL)
+        remote = self.client.post(FILE_REMOTE_PATH, body)
+        self.addCleanup(self.client.delete, remote['_href'])
+
+        # use code_handler to avoid wait to the task to be completed.
+        return self.client.using_handler(api.code_handler).post(
+            urljoin(remote['_href'], 'sync/'), {'repository': repo['_href']}
+        ).json()
+
+    def cancel_task(self, task):
+        """Cancel a task."""
+        return self.client.post(urljoin(task['task'], 'cancel/'))


### PR DESCRIPTION
Add test to cancel tasks, to delete a running task, and to delete a
nonexistent task.

closes: PulpQE/pulp-smash#976
https://pulp.plan.io/issues/3634
closes:#3634
