### PR TITLE
Tweak distribution creation in tests

### DIFF
--- a/pulpcore/tests/functional/api/test_crud_distributions.py
+++ b/pulpcore/tests/functional/api/test_crud_distributions.py
@@ -26,12 +26,10 @@ class CRUDDistributionsTestCase(unittest.TestCase):
     def test_01_create_distribution(self):
         """Create a distribution."""
         body = gen_distribution()
-        response_dict = self.client.post(
+        distribution = self.client.using_handler(api.task_handler).post(
             DISTRIBUTION_PATH, body
         )
-        dist_task = self.client.get(response_dict['task'])
-        distribution_href = dist_task['created_resources'][0]
-        type(self).distribution = self.client.get(distribution_href)
+        type(self).distribution = self.client.get(distribution['_href'])
         for key, val in body.items():
             with self.subTest(key=key):
                 self.assertEqual(self.distribution[key], val)
@@ -161,10 +159,10 @@ class DistributionBasePathTestCase(unittest.TestCase):
         cls.client = api.Client(cls.cfg, api.json_handler)
         body = gen_distribution()
         body['base_path'] = body['base_path'].replace('-', '/')
-        response_dict = cls.client.post(DISTRIBUTION_PATH, body)
-        dist_task = cls.client.get(response_dict['task'])
-        distribution_href = dist_task['created_resources'][0]
-        cls.distribution = cls.client.get(distribution_href)
+        distribution = api.Client(cls.cfg, api.task_handler).post(
+            DISTRIBUTION_PATH, body
+        )
+        cls.distribution = cls.client.get(distribution['_href'])
 
     @classmethod
     def tearDownClass(cls):

--- a/pulpcore/tests/functional/api/using_plugin/test_auto_distribution.py
+++ b/pulpcore/tests/functional/api/using_plugin/test_auto_distribution.py
@@ -94,8 +94,7 @@ class AutoDistributionTestCase(unittest.TestCase):
         body['repository'] = repo['_href']
         body['publisher'] = publisher['_href']
         distribution = self.client.using_handler(api.task_handler).post(
-            DISTRIBUTION_PATH,
-            body
+            DISTRIBUTION_PATH, body
         )
         self.addCleanup(self.client.delete, distribution['_href'])
 
@@ -175,8 +174,7 @@ class SetupAutoDistributionTestCase(unittest.TestCase):
         body['publisher'] = publisher['_href']
         body['repository'] = repo['_href']
         distribution = self.client.using_handler(api.task_handler).post(
-            DISTRIBUTION_PATH,
-            body
+            DISTRIBUTION_PATH, body
         )
         self.addCleanup(self.client.delete, distribution['_href'])
 

--- a/pulpcore/tests/functional/api/using_plugin/test_content_app.py
+++ b/pulpcore/tests/functional/api/using_plugin/test_content_app.py
@@ -77,8 +77,7 @@ class ContentAppTestCase(unittest.TestCase):
         body['repository'] = repo['_href']
         body['publisher'] = publisher['_href']
         distribution = self.client.using_handler(api.task_handler).post(
-            DISTRIBUTION_PATH,
-            body
+            DISTRIBUTION_PATH, body
         )
         self.addCleanup(self.client.delete, distribution['_href'])
 

--- a/pulpcore/tests/functional/api/using_plugin/test_content_promotion.py
+++ b/pulpcore/tests/functional/api/using_plugin/test_content_promotion.py
@@ -75,8 +75,7 @@ class ContentPromotionTestCase(unittest.TestCase):
             body = gen_distribution()
             body['publication'] = publication['_href']
             distribution = client.using_handler(api.task_handler).post(
-                DISTRIBUTION_PATH,
-                body
+                DISTRIBUTION_PATH, body
             )
             distributions.append(distribution)
             self.addCleanup(client.delete, distribution['_href'])

--- a/pulpcore/tests/functional/api/using_plugin/test_crd_publications.py
+++ b/pulpcore/tests/functional/api/using_plugin/test_crd_publications.py
@@ -141,8 +141,7 @@ class PublicationsTestCase(unittest.TestCase):
         body = gen_distribution()
         body['publication'] = self.publication['_href']
         distribution = self.client.using_handler(api.task_handler).post(
-            DISTRIBUTION_PATH,
-            body
+            DISTRIBUTION_PATH, body
         )
         self.addCleanup(self.client.delete, distribution['_href'])
 


### PR DESCRIPTION
Tweak in how distributions are created to assure that async tasks are
handled properly.
Adjust to use the `task_handler` response_handler.

See: https://pulp.plan.io/issues/3044
'[noissue]'
