### PR TITLE
Problem: OpenAPI schema for 'Artifact create' is ambiguous

### DIFF
--- a/docs/workflows/upload-publish.rst
+++ b/docs/workflows/upload-publish.rst
@@ -21,7 +21,7 @@ upload::
 
 Then the artifact may be created with the upload href::
 
-    http POST :24817/pulp/api/v3/artifacts/ upload=/pulp/api/v3/uploads/a8b5a7f7-2f22-460d-ab20-d5616cb71cdd/
+    http --form POST :24817/pulp/api/v3/artifacts/ upload=/pulp/api/v3/uploads/a8b5a7f7-2f22-460d-ab20-d5616cb71cdd/
 
 Note that after creating an artifact from an upload, the upload gets deleted and cannot be re-used.
 
@@ -32,4 +32,4 @@ Putting this altogether, here is an example that uploads a 1.iso file in two chu
    export UPLOAD=$(http --form PUT :24817/pulp/api/v3/uploads/ file@./chunkaa 'Content-Range:bytes 0-6291455/32095676'  | jq -r '._href')
    http --form PUT :24817$UPLOAD file@./chunkab 'Content-Range:bytes 6291456-10485759/32095676'
    http POST :24817$UPLOAD md5=037a47d93670e64f2b1038e6f90e4cfd
-   http POST :24817/pulp/api/v3/artifacts/ upload=$UPLOAD
+   http --form POST :24817/pulp/api/v3/artifacts/ upload=$UPLOAD

--- a/pulpcore/app/viewsets/content.py
+++ b/pulpcore/app/viewsets/content.py
@@ -2,7 +2,7 @@ from gettext import gettext as _
 
 from django.db import models
 from rest_framework import status, mixins
-from rest_framework.parsers import FormParser, JSONParser, MultiPartParser
+from rest_framework.parsers import FormParser, MultiPartParser
 from rest_framework.response import Response
 
 from pulpcore.app.models import Artifact, Content
@@ -39,7 +39,7 @@ class ArtifactViewSet(NamedModelViewSet,
     queryset = Artifact.objects.all()
     serializer_class = ArtifactSerializer
     filterset_class = ArtifactFilter
-    parser_classes = (MultiPartParser, FormParser, JSONParser)
+    parser_classes = (MultiPartParser, FormParser)
 
     def destroy(self, request, pk):
         """


### PR DESCRIPTION
Solution: Remove JSONParser from ArtifactViewset

The ArtifactViewset viewset was configured to use MultiPartParser, FormParser, and JSONParser. The
JSONParser was added when the ArtifactViewset was extended to accept uploads when creating an
Artifact. It was only needed to allow users to submit not form-encoded requests to the
/pulp/api/v3/artifacts/ endpoint. However, 'drf_yasg' does not support mixing multipart/form-data
and json fields. When such occurs, the body parameters for the operation are simply reported as
'data' dictionary. The bindings generated from such an OpenAPI schema don't form-encode requests
for the 'artifacts_create' operation. This results in a 400 error being returned by the server.

fixes: #4683
https://pulp.plan.io/issues/4683