### PR TITLE
Problem: OpenAPI schema for distribution delete is wrong

### DIFF
--- a/pulpcore/app/views/orphans.py
+++ b/pulpcore/app/views/orphans.py
@@ -1,12 +1,18 @@
+from drf_yasg.utils import swagger_auto_schema
 from rest_framework.views import APIView
 
 from pulpcore.app.response import OperationPostponedResponse
+from pulpcore.app.serializers import AsyncOperationResponseSerializer
 from pulpcore.app.tasks import orphan_cleanup
 from pulpcore.tasking.tasks import enqueue_with_reservation
 
 
 class OrphansView(APIView):
 
+    @swagger_auto_schema(operation_description="Trigger an asynchronous task that deletes all"
+                                               "orphaned content and artifacts.",
+                         operation_summary="Delete orphans",
+                         responses={202: AsyncOperationResponseSerializer})
     def delete(self, request, format=None):
         """
         Cleans up all the Content and Artifact orphans in the system

--- a/pulpcore/app/viewsets/publication.py
+++ b/pulpcore/app/viewsets/publication.py
@@ -134,7 +134,7 @@ class DistributionViewSet(NamedModelViewSet,
 
     @swagger_auto_schema(operation_description="Trigger an asynchronous delete task",
                          responses={202: AsyncOperationResponseSerializer})
-    def delete(self, request, pk, *args, **kwargs):
+    def destroy(self, request, pk, *args, **kwargs):
         """
         Dispatches a task with reservation for deleting a distribution.
         """


### PR DESCRIPTION
Solution: rename 'delete' method on the ViewSet to 'destroy'

This patch also updates the schema for orphan delete.

fixes: #4638
https://pulp.plan.io/issues/4638
