### PR TITLE
Problem: bindings break all the time

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,12 +10,15 @@ env:
     - DB=postgres TEST=pulp
     - DB=mariadb TEST=pulp
     - DB=postgres TEST=docs
+    - DB=postgres TEST=bindings
 matrix:
   exclude:
     - python: '3.6'
       env: DB=postgres TEST=docs
     - python: '3.6'
       env: DB=mariadb TEST=pulp
+    - python: '3.7'
+      env: DB=postgres TEST=bindings
   fast_finish: true
 services:
   - postgresql

--- a/.travis/script.sh
+++ b/.travis/script.sh
@@ -33,6 +33,18 @@ if [ "$TEST" = 'docs' ]; then
   exit
 fi
 
+if [ "$TEST" = 'bindings' ]; then
+  cd ..
+  git clone https://github.com/pulp/pulp-swagger-codegen.git
+  cd pulp-swagger-codegen
+  sudo ./generate.sh pulpcore python
+  sudo ./generate.sh pulp_file python
+  pip install ./pulpcore-client
+  pip install ./pulp_file-client
+  python test_bindings.py
+  exit
+fi
+
 # check the commit message
 ./.travis/check_commit.sh
 


### PR DESCRIPTION
Solution: build and test bindings continuosly

This patch adds another job to the Travis build matrix. This new build installs pulpcore and pulp_file
and then builds a client library for each. The client libraries are built using pulp-swagger-codegen,
a thin wrapper around swagger-codegen-cli. After building the bindings, this job installs them and runs
a script that performs the following:

- Create a File Remote
- Create a Repository
- Sync a Repository
- Monitor the sync task
- Create an artifact from a local file
- Create a FileContent from the artifact
- Add the new FileContent to a repository version
- Monitor the repo version creation task
- Create a FilePublisher
- Create a publication from the latest version of the repository
- Monitor the publish task
- Create a distribution pointint to the publication

fixes: #4123
https://pulp.plan.io/issues/4123