### PR TITLE
Problem: validation exception does not specify field name

### DIFF
--- a/pulpcore/app/serializers/base.py
+++ b/pulpcore/app/serializers/base.py
@@ -40,13 +40,14 @@ class ModelSerializer(QueryFieldsMixin, serializers.HyperlinkedModelSerializer):
         read_only=True
     )
 
-    def _validate_relative_path(self, path):
+    def _validate_relative_path(self, path, param_name):
         """
         Validate a relative path (eg from a url) to ensure it forms a valid url and does not begin
         or end with slashes nor contain spaces
 
         Args:
             path (str): A relative path to validate
+            param_name (str): Name of parameter being validated
 
         Returns:
             str: the validated path
@@ -59,14 +60,15 @@ class ModelSerializer(QueryFieldsMixin, serializers.HyperlinkedModelSerializer):
         base = "http://localhost"  # use a scheme/hostname we know are valid
 
         if ' ' in path:
-            raise serializers.ValidationError(detail=_("Relative path cannot contain spaces."))
+            raise serializers.ValidationError({param_name: _("Relative path cannot contain "
+                                                             "spaces.")})
 
         validate = URLValidator()
         validate(urljoin(base, path))
 
         if path != path.strip("/"):
-            raise serializers.ValidationError(detail=_("Relative path cannot begin or end with "
-                                                       "slashes."))
+            raise serializers.ValidationError({param_name: _("Relative path cannot begin or end "
+                                                             "with slashes.")})
 
         return path
 

--- a/pulpcore/app/serializers/publication.py
+++ b/pulpcore/app/serializers/publication.py
@@ -187,7 +187,7 @@ class DistributionSerializer(BaseDistributionSerializer):
         model = models.Distribution
         fields = BaseDistributionSerializer.Meta.fields + ('base_path', 'base_url')
 
-    def _validate_path_overlap(self, path):
+    def _validate_path_overlap(self, path, param_name):
         # look for any base paths nested in path
         search = path.split("/")[0]
         q = Q(base_path=search)
@@ -204,11 +204,11 @@ class DistributionSerializer(BaseDistributionSerializer):
 
         match = qs.first()
         if match:
-            raise serializers.ValidationError(detail=_("Overlaps with existing distribution '"
-                                                       "{}'").format(match.name))
+            raise serializers.ValidationError({param_name: _("Overlaps with existing distribution'"
+                                                             " {}'").format(match.name)})
 
         return path
 
     def validate_base_path(self, path):
-        self._validate_relative_path(path)
-        return self._validate_path_overlap(path)
+        self._validate_relative_path(path, 'base_path')
+        return self._validate_path_overlap(path, 'base_path')


### PR DESCRIPTION

Prior to this patch the user would receive the following when creating a Distribution with an invalid base_path:
```
{
    "non_field_errors": [
        "Relative path cannot begin or end with slashes."
    ]
}
```
Now the user receives:
```
{
    "base_path": [
        "Relative path cannot begin or end with slashes."
    ]
}
```
re: #4669
https://pulp.plan.io/issues/4669