### PR TITLE
Problem: pulpcore-client ruby gem published too often

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -67,4 +67,4 @@ jobs:
       env:
         - DB=postgres
         - TEST=bindings
-      if: type != pull_request
+      if: type = cron


### PR DESCRIPTION
Solution: only publish when cron is building the project

closes: #4695
https://pulp.plan.io/issues/4695