### PR TITLE
Add core pagination test cases - issue 4221

### DIFF
--- a/pulpcore/tests/functional/api/test_pagination.py
+++ b/pulpcore/tests/functional/api/test_pagination.py
@@ -1,0 +1,153 @@
+# coding=utf-8
+"""Tests related to core pagination."""
+import unittest
+
+from random import randint
+
+from pulp_smash import api, config
+from pulp_smash.pulp3.constants import REPO_PATH
+from pulp_smash.pulp3.utils import gen_repo
+from pulp_smash.utils import ensure_teardownclass
+
+from pulpcore.tests.functional.api.using_plugin.utils import set_up_module as setUpModule  # noqa
+
+
+class PaginationTestCase(unittest.TestCase):
+    """Test pagination.
+
+    This test case assumes that Pulp returns 100 elements in each page of
+    results. This is configurable, but the current default set by all known
+    Pulp installers.
+
+    This test targets the following issues:
+
+    * `Pulp #4221 <https://pulp.plan.io/issues/4221>`_
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        """Create class-wide variables."""
+        cls.cfg = config.get_config()
+        cls.client = api.Client(cls.cfg, api.json_handler)
+        cls.teardown_cleanups = []
+        cls.number_to_create = 21
+
+        # Perform a sanity check.
+        repos = cls.client.using_handler(api.page_handler).get(REPO_PATH)
+        assert len(repos) == 0, repos  # AssertEqual not available here yet
+
+        with ensure_teardownclass(cls):
+            # Create repos
+            for _ in range(cls.number_to_create):
+                repo = cls.client.post(REPO_PATH, gen_repo())
+                cls.teardown_cleanups.append(
+                    (cls.client.delete, repo['_href'])
+                )
+
+    @classmethod
+    def tearDownClass(cls):
+        """Clean registered cleanups."""
+        for function, argument in cls.teardown_cleanups:
+            function(argument)
+
+    def test_raw_pagination(self):
+        """Assert content can be paginated page by page.
+
+        Do the following:
+
+        1. Without using page_handler request content
+        2. Save collected_results and assert it is equal the per_page param
+        3. Assert there is a next link but not a previous link
+        4. Loop pages "number_to_create / per_page" (3)
+        5. For each page request next link and assert length equals per_page
+        6. For each page assert the presence of next and previous links
+        7. Assert last page is reached
+        8. Assert the final count equals number_to_create
+        """
+
+        per_page = 7  # will result in 3 pages
+        resp = self.client.get(REPO_PATH, params={'page_size': per_page})
+        collected_results = resp['results']
+        # First call returns 7 results
+        self.assertEqual(len(collected_results), per_page, collected_results)
+        # no previous but there is a next
+        self.assertIsNone(resp['previous'], resp['previous'])
+        self.assertIsNotNone(resp['next'], resp['next'])
+
+        # paginate pages 2 and 3
+        for page in range(int(self.number_to_create / per_page)):  # [0, 1, 2]
+            if page == 1:
+                # there is a previous and a next
+                self.assertIsNotNone(resp['previous'], resp['previous'])
+                self.assertIsNotNone(resp['next'], resp['next'])
+                # must have twice the size
+                self.assertEqual(
+                    len(collected_results),
+                    per_page * 2,
+                    collected_results
+                )
+            if page == 2:
+                # last page there is no next but there is a previous
+                self.assertIsNone(resp['next'], resp['next'])
+                self.assertIsNotNone(resp['previous'], resp['previous'])
+                # must have 3 x the size
+                self.assertEqual(
+                    len(collected_results),
+                    per_page * 3,
+                    collected_results
+                )
+                break  # last page reached
+            resp = self.client.get(resp['next'])
+            page_results = resp['results']
+            self.assertEqual(len(page_results), per_page, page_results)
+            collected_results.extend(page_results)
+
+        # Assert the final count
+        self.assertEqual(
+            len(collected_results), self.number_to_create, collected_results
+        )
+
+    def test_skip_pages(self):
+        """Test jump from page 1 to page 3 (skipping page 2).
+
+        Do the following:
+
+        1. Request all the existing repos.
+        2. Request the 7 repos on page 1 and assert equals first 7 of all.
+        3. Skip page 2.
+        4. Request the 7 items on page 3 and assert equals last 7 of all.
+        """
+        per_page = 7  # will result in 3 pages
+        all_repos = self.client.using_handler(api.page_handler).get(REPO_PATH)
+        self.assertEqual(len(all_repos), self.number_to_create, all_repos)
+
+        first_page = self.client.get(
+            REPO_PATH, params={'page_size': per_page, 'page': 1}
+        )
+        last_page = self.client.get(
+            REPO_PATH, params={'page_size': per_page, 'page': 3}
+        )
+
+        for index in range(0, 7):
+            # Assert page 1 contains the first 7 items from _all
+            self.assertEqual(first_page['results'][index], all_repos[index])
+
+            # skip page 2
+
+            # Assert page 3 contains the last 7 items from _all
+            self.assertEqual(
+                last_page['results'][index], all_repos[index + per_page * 2]
+            )
+
+    def test_page_handler_pagination(self):
+        """Assert page handler returns all items independent of page_size.
+
+        This test asserts that pulp-smash page_handler will collect results
+        from all pages and return it in the same call independent of the
+        page_size provided.
+        """
+        # assert results
+        repos = self.client.using_handler(api.page_handler).get(
+            REPO_PATH, params={'page_size': randint(2, 11)}
+        )
+        self.assertEqual(len(repos), self.number_to_create, repos)

--- a/pulpcore/tests/functional/api/using_plugin/test_pagination.py
+++ b/pulpcore/tests/functional/api/using_plugin/test_pagination.py
@@ -1,5 +1,5 @@
 # coding=utf-8
-"""Tests related to pagination."""
+"""Tests related to file plugin pagination."""
 import unittest
 from random import sample
 
@@ -17,7 +17,7 @@ from pulpcore.tests.functional.api.using_plugin.utils import set_up_module as se
 
 
 class PaginationTestCase(unittest.TestCase):
-    """Test pagination.
+    """Test file plugin pagination.
 
     This test case assumes that Pulp returns 100 elements in each page of
     results. This is configurable, but the current default set by all known
@@ -30,24 +30,7 @@ class PaginationTestCase(unittest.TestCase):
         cls.cfg = config.get_config()
         cls.client = api.Client(cls.cfg, api.page_handler)
 
-    def test_repos(self):
-        """Test pagination for repositories."""
-        # Perform a sanity check.
-        repos = self.client.get(REPO_PATH)
-        self.assertEqual(len(repos), 0, repos)
-
-        number_to_create = 21
-
-        # Create repos
-        for _ in range(number_to_create):
-            repo = self.client.post(REPO_PATH, gen_repo())
-            self.addCleanup(self.client.delete, repo['_href'])
-
-        # assert results
-        repos = self.client.get(REPO_PATH, params={'page_size': 10})
-        self.assertEqual(len(repos), number_to_create, repos)
-
-    def test_content(self):
+    def test_file_content(self):
         """Test pagination for repository versions."""
         # Add content to Pulp, create a repo, and add content to repo. We
         # sample 21 contents, because with page_size set to 10, this produces 3


### PR DESCRIPTION
- Add core pagination test cases as per issue 4221
- Keep only plugin related pagination test on using_plugin folder

https://pulp.plan.io/issues/4221
closes #4221