### PR TITLE
Problem: publish to rubygems.org and pypi.org can fail

### DIFF
--- a/.travis/publish_pulpcore_client_gem.sh
+++ b/.travis/publish_pulpcore_client_gem.sh
@@ -11,10 +11,16 @@ export REPORTED_VERSION=$(http :24817/pulp/api/v3/status/ | jq --arg plugin pulp
 export COMMIT_COUNT="$(git rev-list ${REPORTED_VERSION}^..HEAD | wc -l)"
 export VERSION=${REPORTED_VERSION}.dev.${COMMIT_COUNT}
 
+export response=$(curl --write-out %{http_code} --silent --output /dev/null https://rubygems.org/gems/pulpcore_client/versions/$VERSION)
+
+if [ "$response" == "200" ];
+then
+    exit
+fi
+
 cd
 git clone https://github.com/pulp/pulp-swagger-codegen.git
 cd pulp-swagger-codegen
-
 
 sudo ./generate.sh pulpcore ruby $VERSION
 sudo chown travis:travis pulpcore-client

--- a/.travis/publish_pulpcore_client_pypi.sh
+++ b/.travis/publish_pulpcore_client_pypi.sh
@@ -10,6 +10,13 @@ export REPORTED_VERSION=$(http :24817/pulp/api/v3/status/ | jq --arg plugin pulp
 export COMMIT_COUNT="$(git rev-list ${REPORTED_VERSION}^..HEAD | wc -l)"
 export VERSION=${REPORTED_VERSION}.dev.${COMMIT_COUNT}
 
+export response=$(curl --write-out %{http_code} --silent --output /dev/null https://pypi.org/project/pulpcore-client/$VERSION/)
+
+if [ "$response" == "200" ];
+then
+    exit
+fi
+
 cd
 git clone https://github.com/pulp/pulp-swagger-codegen.git
 cd pulp-swagger-codegen


### PR DESCRIPTION
Solution: check if the version of the client already exists

This patch adds an additional step to each of the pulpcore-client publish scripts.
This step checks if the version of the client that is about to be built already exists.
If the client version exists, the script exits without trying to build the package again.

re: #4694
https://pulp.plan.io/issues/4694
re: #4695
https://pulp.plan.io/issues/4695