### PR TITLE
Problem: OpenAPI schema for RepositoryVersion is wrong

### DIFF
--- a/pulpcore/app/viewsets/repository.py
+++ b/pulpcore/app/viewsets/repository.py
@@ -186,7 +186,6 @@ class RepositoryVersionFilter(BaseFilterSet):
 
 class RepositoryVersionViewSet(NamedModelViewSet,
                                mixins.CreateModelMixin,
-                               mixins.UpdateModelMixin,
                                mixins.RetrieveModelMixin,
                                mixins.ListModelMixin,
                                mixins.DestroyModelMixin):


### PR DESCRIPTION
Solution: remove UpdateModelMixin from RepositoryVersionViewSet

closes: #4750
https://pulp.plan.io/issues/4750