### PR TITLE
3.0.0rc2 version bump and release notes

### DIFF
--- a/docs/release-notes/pulpcore/3.0.x.rst
+++ b/docs/release-notes/pulpcore/3.0.x.rst
@@ -1,6 +1,29 @@
 Pulp 3.0 Release Notes
 ======================
 
+3.0.0rc2
+========
+
+`Comprehensive list of changes and bugfixes for rc 2 <https://github.com/pulp/pulpcore/compare/3.0.0rc1...3.0.0rc2>`_.
+
+Breaking Changes
+----------------
+
+Default port changes happened in the `Ansible Installer for Pulp <https://github.com/pulp/
+ansible-pulp>`_ and pulpcore was updated to match with `this PR <https://github.com/pulp/pulpcore/
+pull/75>`_
+
+Publications are now Master/Detail which causes any Publication URL endpoint to change. To give an
+example from `pulp_file <https://github.com/pulp/pulp_file>`_ see the URL changes made
+`here <https://github.com/pulp/pulp_file/pull/205/files#diff-88b99bb28683bd5b7e3a204826ead112R200>`_
+as an example. See plugin docs compatible with 3.0.0rc2 for more details.
+
+The semantics of :term:`Remote` attributes ``ssl_ca_certificate``, ``ssl_client_certificate``, and
+``ssl_client_key`` changed even though the field names didn't. Now these assets are saved directly
+in the database instead of on the filesystem, and they are prevented from being read back out to
+users after being set for security reasons. This was done with `these changes <https://github.com/
+pulp/pulpcore/pull/99/>`_.
+
 3.0.0rc1
 ========
 

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ requirements = [
 
 setup(
     name='pulpcore',
-    version='3.0.0rc1',
+    version='3.0.0rc2',
     description='Pulp Django Application and Related Modules',
     long_description=long_description,
     long_description_content_type="text/markdown",


### PR DESCRIPTION
This bumps the version to 3.0.0rc2.

It also adds release notes with the current breaking changes written in
their own section.

[noissue]
