### PR TITLE
Problem: travis config is using old repo name

### DIFF
--- a/.travis/before_install.sh
+++ b/.travis/before_install.sh
@@ -8,7 +8,7 @@ export PULP_SMASH_PR_NUMBER=$(echo $COMMIT_MSG | grep -oP 'Required\ PR:\ https\
 export PULP_PLUGIN_PR_NUMBER=$(echo $COMMIT_MSG | grep -oP 'Required\ PR:\ https\:\/\/github\.com\/pulp\/pulpcore-plugin\/pull\/(\d+)' | awk -F'/' '{print $7}')
 export PULP_ROLES_PR_NUMBER=$(echo $COMMIT_MSG | grep -oP 'Required\ PR:\ https\:\/\/github\.com\/pulp\/ansible-pulp\/pull\/(\d+)' | awk -F'/' '{print $7}')
 export PULP_CERTGUARD_PR_NUMBER=$(echo $COMMIT_MSG | grep -oP 'Required\ PR:\ https\:\/\/github\.com\/pulp\/pulp-certguard\/pull\/(\d+)' | awk -F'/' '{print $7}')
-export PULP_BINDINGS_PR_NUMBER=$(echo $COMMIT_MSG | grep -oP 'Required\ PR:\ https\:\/\/github\.com\/pulp\/pulp-swagger-codegen\/pull\/(\d+)' | awk -F'/' '{print $7}')
+export PULP_BINDINGS_PR_NUMBER=$(echo $COMMIT_MSG | grep -oP 'Required\ PR:\ https\:\/\/github\.com\/pulp\/pulp-openapi-generator\/pull\/(\d+)' | awk -F'/' '{print $7}')
 
 cd ..
 git clone https://github.com/pulp/ansible-pulp.git
@@ -54,8 +54,8 @@ if [ -n "$PULP_SMASH_PR_NUMBER" ]; then
 fi
 
 if [ "$TEST" = 'bindings' ]; then
-  git clone https://github.com/pulp/pulp-swagger-codegen.git
-  cd pulp-swagger-codegen
+  git clone https://github.com/pulp/pulp-openapi-generator.git
+  cd pulp-openapi-generator
 
   if [ -n "$PULP_BINDINGS_PR_NUMBER" ]; then
     git fetch origin +refs/pull/$PULP_BINDINGS_PR_NUMBER/merge

--- a/.travis/publish_pulpcore_client_gem.sh
+++ b/.travis/publish_pulpcore_client_gem.sh
@@ -19,8 +19,8 @@ then
 fi
 
 cd
-git clone https://github.com/pulp/pulp-swagger-codegen.git
-cd pulp-swagger-codegen
+git clone https://github.com/pulp/pulp-openapi-generator.git
+cd pulp-openapi-generator
 
 sudo ./generate.sh pulpcore ruby $VERSION
 sudo chown travis:travis pulpcore-client

--- a/.travis/publish_pulpcore_client_pypi.sh
+++ b/.travis/publish_pulpcore_client_pypi.sh
@@ -18,8 +18,8 @@ then
 fi
 
 cd
-git clone https://github.com/pulp/pulp-swagger-codegen.git
-cd pulp-swagger-codegen
+git clone https://github.com/pulp/pulp-openapi-generator.git
+cd pulp-openapi-generator
 
 sudo ./generate.sh pulpcore python $VERSION
 sudo chown -R travis:travis pulpcore-client

--- a/.travis/script.sh
+++ b/.travis/script.sh
@@ -34,7 +34,7 @@ if [ "$TEST" = 'docs' ]; then
 fi
 
 if [ "$TEST" = 'bindings' ]; then
-  cd ../pulp-swagger-codegen
+  cd ../pulp-openapi-generator
   sudo ./generate.sh pulpcore python
   sudo ./generate.sh pulp_file python
   pip install ./pulpcore-client


### PR DESCRIPTION
Solution: update to using pulp-openapi-generator

The repo name change because the tooling it uses change.

re: #4691
https://pulp.plan.io/issues/4691