### PR TITLE
containers: Update to support Pulp 3.0 rc2

### DIFF
--- a/containers/README.md
+++ b/containers/README.md
@@ -1,6 +1,6 @@
 # Pulp 3 Containers
 
-This directory contains assets and tooling for building Pulp 3 container images. The current image is an all-in-one image with different runtime scripts to assume each of the roles: pulp-core, pulp-worker and pulp-resource-manager.
+This directory contains assets and tooling for building Pulp 3 container images. The current image is an all-in-one image with different runtime scripts to assume each of the roles: pulp-api, pulp-content, pulp-worker and pulp-resource-manager.
 
 ## Build
 
@@ -10,7 +10,9 @@ The base image can be built with the help of an Ansible script. To build the bas
 
 The image can be customized to include any number of plugins as a build argument:
 
-    ansible-playbook build.yaml -e '{"plugins": ["pulp_file", "pulp_ansible"]}'
+    ansible-playbook build.yaml -e '{"plugins": ["pulp_file", "pulp_ansible", "pulp_cookbook", "pulp_docker", "pulp_maven", "pulp_python"]}'
+
+    ansible-playbook build.yaml -e '{"plugins": ["git+https://github.com/pulp/pulp_file.git", "git+https://github.com/pulp/pulp_ansible.git", "git+https://github.com/gmbnomis/pulp_cookbook.git", "git+https://github.com/pulp/pulp_docker.git", "git+https://github.com/pulp/pulp_maven.git", "git+https://github.com/pulp/pulp_python.git"]}'
 
 ## Push Image to Registry
 

--- a/containers/images/pulp-api/Dockerfile
+++ b/containers/images/pulp-api/Dockerfile
@@ -2,9 +2,15 @@ FROM centos:7
 
 ARG PLUGINS=""
 
+# mariadb_devel needed to avoid error installing pulpcore[mysql] (post-rc1)
+# otherwise, `mysql_config` is not found
+# It also needs gcc at least, so we install the dev tools package group.
+# And it needs Python.h
 RUN echo "tsflags=nodocs" >> /etc/yum.conf && \
+		yum -y update && \
 		yum -y install epel-release centos-release-scl && \
 		yum -y install wget git rh-python36-python-pip && \
+		yum -y install @development mariadb-devel rh-python36-python-devel && \
 		yum clean all
 
 ENV LANG=en_US.UTF-8
@@ -16,15 +22,25 @@ ENV DJANGO_SETTINGS_MODULE=pulpcore.app.settings
 RUN mkdir -p /etc/pulp
 
 RUN scl enable rh-python36 'pip install gunicorn'
-RUN scl enable rh-python36 'pip install pulpcore'
-RUN scl enable rh-python36 'pip install pulpcore-plugin pulpcore[postgres] pulpcore[mysql]'
+RUN scl enable rh-python36 'pip install git+https://github.com/pulp/pulpcore.git'
+RUN scl enable rh-python36 'pip install git+https://github.com/pulp/pulpcore-plugin.git'
+RUN scl enable rh-python36 'pip install git+https://github.com/pulp/pulpcore.git#egg=pulpcore[postgres]'
+RUN scl enable rh-python36 'pip install git+https://github.com/pulp/pulpcore.git#egg=pulpcore[mysql]'
 RUN scl enable rh-python36 'pip install $PLUGINS'
 
-RUN scl enable rh-python36 "django-admin collectstatic --noinput"
+RUN mkdir -p /opt/rh/rh-python36/root/usr/lib/python3.6/site-packages/pulpcore/app/migrations
+RUN mkdir -p /opt/rh/rh-python36/root/usr/lib/python3.6/site-packages/pulpcore/app/migrations
+RUN mkdir -p /opt/rh/rh-python36/root/usr/lib/python3.6/site-packages/pulp_file/app/migrations
+RUN mkdir -p /opt/rh/rh-python36/root/usr/lib/python3.6/site-packages/pulp_ansible/app/migrations
+RUN mkdir -p /opt/rh/rh-python36/root/usr/lib/python3.6/site-packages/pulp_cookbook/app/migrations
+RUN mkdir -p /opt/rh/rh-python36/root/usr/lib/python3.6/site-packages/pulp_docker/app/migrations
+RUN mkdir -p /opt/rh/rh-python36/root/usr/lib/python3.6/site-packages/pulp_maven/app/migrations
+RUN mkdir -p /opt/rh/rh-python36/root/usr/lib/python3.6/site-packages/pulp_python/app/migrations
 
 COPY container-assets/wait_on_postgres.py /usr/bin/wait_on_postgres.py
 COPY container-assets/wait_on_database_migrations.sh /usr/bin/wait_on_database_migrations.sh
+COPY container-assets/pulp-common-entrypoint.sh /pulp-common-entrypoint.sh
 COPY container-assets/pulp-api /usr/bin/pulp-api
 
-
+ENTRYPOINT ["/pulp-common-entrypoint.sh"]
 CMD ["/usr/bin/pulp-api"]

--- a/containers/images/pulp-api/container-assets/pulp-api
+++ b/containers/images/pulp-api/container-assets/pulp-api
@@ -2,6 +2,17 @@
 
 /usr/bin/wait_on_postgres.py
 
-scl enable rh-python36 'django-admin migrate --noinput'
+# Generating /var/lib/pulp/static at runtime rather than at container build time
+# facilitates all of /var/lib/pulp being a separate volume.
+scl enable rh-python36 "django-admin collectstatic --noinput"
 
-exec scl enable rh-python36 "gunicorn -b 0.0.0.0:8000 pulpcore.app.wsgi:application"
+#TODO: Determine list of installed plugins by inspecting image contents
+scl enable rh-python36 "django-admin makemigrations file ansible cookbook docker maven python"
+scl enable rh-python36 "django-admin migrate --noinput"
+scl enable rh-python36 "django-admin migrate auth --noinput"
+
+if [ -n "${PULP_ADMIN_PASSWORD}" ]; then
+    scl enable rh-python36 "django-admin reset-admin-password --password '${PULP_ADMIN_PASSWORD}'"
+fi
+
+exec scl enable rh-python36 "gunicorn -b 0.0.0.0:24817 pulpcore.app.wsgi:application"

--- a/containers/images/pulp-api/container-assets/pulp-common-entrypoint.sh
+++ b/containers/images/pulp-api/container-assets/pulp-common-entrypoint.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+export DJANGO_SETTINGS_MODULE=pulpcore.app.settings
+
+exec "$@"

--- a/containers/images/pulp-api/container-assets/wait_on_database_migrations.sh
+++ b/containers/images/pulp-api/container-assets/wait_on_database_migrations.sh
@@ -4,7 +4,7 @@ database_migrated=false
 
 echo "Checking for database migrations"
 while [ $database_migrated = false ]; do
-  scl enable rh-python36 "pulp-manager showmigrations | grep '\[ \]'"
+  scl enable rh-python36 "django-admin showmigrations | grep '\[ \]'"
   if [ $? -gt 0 ]; then
     echo "Database migrated!"
     database_migrated=true

--- a/containers/images/pulp-content/container-assets/pulp-content
+++ b/containers/images/pulp-content/container-assets/pulp-content
@@ -3,4 +3,8 @@
 /usr/bin/wait_on_postgres.py
 /usr/bin/wait_on_database_migrations.sh
 
-exec scl enable rh-python36 "gunicorn -b 0.0.0.0:8000 pulpcore.content:server"
+exec scl enable rh-python36 "gunicorn pulpcore.content:server \
+--bind 0.0.0.0:24816 \
+--worker-class 'aiohttp.GunicornWebWorker' \
+-w 2 \
+--access-logfile -"

--- a/containers/images/pulp-resource-manager/container-assets/pulp-resource-manager
+++ b/containers/images/pulp-resource-manager/container-assets/pulp-resource-manager
@@ -3,4 +3,4 @@
 /usr/bin/wait_on_postgres.py
 /usr/bin/wait_on_database_migrations.sh
 
-exec scl enable rh-python36 "rq worker --url 'redis://$REDIS_SERVICE_HOST:$REDIS_SERVICE_PORT' -n resource_manager@%h -w 'pulpcore.tasking.worker.PulpWorker'"
+exec scl enable rh-python36 "rq worker --url 'redis://$REDIS_SERVICE_HOST:$REDIS_SERVICE_PORT' -n resource-manager@%h -w 'pulpcore.tasking.worker.PulpWorker' -c 'pulpcore.rqconfig'"

--- a/containers/images/pulp-worker/container-assets/pulp-worker
+++ b/containers/images/pulp-worker/container-assets/pulp-worker
@@ -3,4 +3,6 @@
 /usr/bin/wait_on_postgres.py
 /usr/bin/wait_on_database_migrations.sh
 
-exec scl enable rh-python36 "rq worker --url 'redis://${REDIS_SERVICE_HOST}:${REDIS_SERVICE_PORT}' -n reserved_resource_worker_${PULP_WORKER_NUMBER}@${HOSTNAME} -w 'pulpcore.tasking.worker.PulpWorker'"
+# TODO: Set ${PULP_WORKER_NUMBER} to the Pod Number
+# In the meantime, the hostname provides uniqueness.
+exec scl enable rh-python36 "rq worker --url 'redis://${REDIS_SERVICE_HOST}:${REDIS_SERVICE_PORT}' -n reserved-resource-worker-${PULP_WORKER_NUMBER}@${HOSTNAME} -w 'pulpcore.tasking.worker.PulpWorker' -c 'pulpcore.rqconfig'"


### PR DESCRIPTION
Update to support installation from git nightly
Also some changes necessary for pulp-operator to work
Also some badly needed fixes that were always needed

Other/included fixes/improvements:

> 
> README.md: Update container list
> List all of those that currently can be installed at container build
> time.
> 
> Update for new Pulp 3 default ports
> 
> Update commands to start services; including them matching the systemd
> unit more closely
> 
> Set DJANGO_SETTINGS_MODULE in all container images
> 
> Fix possibly applicable security vulns in images by running `yum update`
> 
> Install nightly version of Pulp (currently limited to always doing so)
> 
> run migrations
> 
> Set pulp admin password if defined
> 
> Run django-admin collectstatic at runtime (so that /var/lib/pulp
> can be a persistent volume. i.e., so that stopping a container
> does not delete all your data.)
> 

These have been successfully used with the entire operator:
https://github.com/mikedep333/pulp-operator/tree/summit-demo
And the patched redis only from here:
https://github.com/mikedep333/carafe/tree/summit-demo

Also, to clarify, these are not supposed to be in a perfect state. Just a significantly better state. Much more work remains to be done in the operator, and a moderate amount remains here. Largely because the containers are dependent on each other, they need to be used with an operator. Theoretically you could use another solution as well.