### PR TITLE
Problem: pulpcore-client version string can be wrong

### DIFF
--- a/.travis/publish_pulpcore_client_gem.sh
+++ b/.travis/publish_pulpcore_client_gem.sh
@@ -8,8 +8,8 @@ sleep 5
 
 cd /home/travis/build/pulp/pulpcore/
 export REPORTED_VERSION=$(http :24817/pulp/api/v3/status/ | jq --arg plugin pulpcore -r '.versions[] | select(.component == $plugin) | .version')
-export COMMIT_COUNT="$(git rev-list ${REPORTED_VERSION}^..HEAD | wc -l)"
-export VERSION=${REPORTED_VERSION}.dev.${COMMIT_COUNT}
+export EPOCH="$(date +%s)"
+export VERSION=${REPORTED_VERSION}.dev.${EPOCH}
 
 export response=$(curl --write-out %{http_code} --silent --output /dev/null https://rubygems.org/gems/pulpcore_client/versions/$VERSION)
 

--- a/.travis/publish_pulpcore_client_pypi.sh
+++ b/.travis/publish_pulpcore_client_pypi.sh
@@ -7,8 +7,8 @@ sleep 5
 
 cd /home/travis/build/pulp/pulpcore/
 export REPORTED_VERSION=$(http :24817/pulp/api/v3/status/ | jq --arg plugin pulpcore -r '.versions[] | select(.component == $plugin) | .version')
-export COMMIT_COUNT="$(git rev-list ${REPORTED_VERSION}^..HEAD | wc -l)"
-export VERSION=${REPORTED_VERSION}.dev.${COMMIT_COUNT}
+export EPOCH="$(date +%s)"
+export VERSION=${REPORTED_VERSION}.dev.${EPOCH}
 
 export response=$(curl --write-out %{http_code} --silent --output /dev/null https://pypi.org/project/pulpcore-client/$VERSION/)
 


### PR DESCRIPTION
Solution: switch to using epoch in the version string

The script that generates the version string for the client library assumed that the version in setup.py would always
correspond to a tag in the repository. However, this is not true in days leading up to a release.

This patch is meant as a temporary solution to this problem. In the future, we should reduce the time window between
the update of the version in setup.py and tag creation. When that is done, we can go back to counting commits between
tag and the commit being built.

[noissue]