### PR TITLE
The distribution code doesn't filter incomplete repo versions

### DIFF
--- a/pulpcore/content/handler.py
+++ b/pulpcore/content/handler.py
@@ -11,7 +11,14 @@ from aiohttp.web_exceptions import HTTPForbidden, HTTPFound, HTTPNotFound
 from django.conf import settings
 from django.core.exceptions import MultipleObjectsReturned, ObjectDoesNotExist
 from django.db import IntegrityError, transaction
-from pulpcore.app.models import Artifact, ContentArtifact, BaseDistribution, Remote, RemoteArtifact
+from pulpcore.app.models import (
+    Artifact,
+    BaseDistribution,
+    ContentArtifact,
+    Remote,
+    RemoteArtifact,
+    RepositoryVersion,
+)
 
 
 log = logging.getLogger(__name__)
@@ -216,7 +223,7 @@ class Handler:
 
         if repository or repo_version:
             if repository:
-                repo_version = distro.repository.versions.get(number=distro.repository.last_version)
+                repo_version = RepositoryVersion.latest(distro.repository)
 
             try:
                 ca = ContentArtifact.objects.get(


### PR DESCRIPTION
The code that gets the latest repo version doesn't filter out incomplete
repo versions. Use the RepositoryVersion latest method to get the
lastest repo version instead.

[noissue]

Please be sure you have read our documentation on creating PRs:
https://docs.pulpproject.org/en/3.0/nightly/contributing/pull-request-walkthrough.html
