### PR TITLE
Problem: OpenAPI schema can't be generated for some plugins

### DIFF
--- a/pulpcore/app/openapigenerator.py
+++ b/pulpcore/app/openapigenerator.py
@@ -93,7 +93,14 @@ class PulpOpenAPISchemaGenerator(OpenAPISchemaGenerator):
                     resource_path = '%s}/' % path.rsplit(sep='}', maxsplit=1)[0]
                     resource_other_path = self.get_resource_from_path(path)
                     if resource_other_path in endpoints:
-                        resource_model = endpoints[resource_other_path][0].queryset.model
+                        view = endpoints[resource_other_path][0]
+                        if not hasattr(view, 'queryset') or view.queryset is None:
+                            if hasattr(view, 'model'):
+                                resource_model = view.model
+                            else:
+                                continue
+                        else:
+                            resource_model = view.queryset.model
                         resource_name = self.get_parameter_name(resource_model)
                         param_name = self.get_parameter_slug_from_model(resource_model)
                         if resource_path in resources:


### PR DESCRIPTION
Solution: generate schema from Views without querysets

This patch also skips generating schema for views without models associated with them.

fixes: #4794
https://pulp.plan.io/issues/4794
