### PR TITLE
Add flake8-docstrings to test_requirements

### DIFF
--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -3,6 +3,7 @@ asynctest
 codecov
 coverage
 flake8
+flake8-docstrings
 mock
 pytest
 git+https://github.com/PulpQE/pulp-smash.git#egg=pulp-smash


### PR DESCRIPTION
When running flake8 linting without this package, flake reports less
errors than the automatic ci pipeline. Putting i here will ensure, that
is is installed on all pulplift development boxes.

[noissue]