### PR TITLE
Problem: docs for RC are published to 'beta' directory

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -51,7 +51,7 @@ jobs:
           tags: true
       if: tag IS present
     - stage: publish-beta-docs
-      script: bash .travis/publish_docs.sh beta
+      script: bash .travis/publish_docs.sh rc
       env:
         - DB=postgres
         - TEST=docs

--- a/.travis/docs-builder.py
+++ b/.travis/docs-builder.py
@@ -83,8 +83,8 @@ def main():
     parser = argparse.ArgumentParser()
     parser.add_argument("--build-type", required=True, help="Build type: nightly or beta.")
     opts = parser.parse_args()
-    if opts.build_type not in ['nightly', 'beta']:
-        raise RuntimeError("Build type must be either 'nightly' or 'beta'.")
+    if opts.build_type not in ['nightly', 'beta', 'rc']:
+        raise RuntimeError("Build type must be either 'nightly' or 'beta' or 'rc'.")
 
     build_type = opts.build_type
 


### PR DESCRIPTION
Solution: publish tagged builds to 'rc' directory

This patch is a temporary solution to the problem. We will need to make this machinery
more robust before we start publishing GA builds and new betas with 3.1. This effort is
being tracked as https://pulp.plan.io/issues/4853

re: #4821
https://pulp.plan.io/issues/4821