### PR TITLE
Remove tests related to remote from publications

### DIFF
--- a/pulpcore/tests/functional/api/using_plugin/test_crd_publications.py
+++ b/pulpcore/tests/functional/api/using_plugin/test_crd_publications.py
@@ -168,17 +168,6 @@ class PublicationsTestCase(unittest.TestCase):
         with self.assertRaises(HTTPError):
             self.client.get(self.publication['_href'])
 
-    def test_negative_create_file_remote_with_invalid_parameter(self):
-        """Attempt to create file remote passing invalid parameter.
-
-        Assert response returns an error 400 including ["Unexpected field"].
-        """
-        response = api.Client(self.cfg, api.echo_handler).post(
-            FILE_REMOTE_PATH, gen_file_remote(foo='bar')
-        )
-        assert response.status_code == 400
-        assert response.json()['foo'] == ['Unexpected field']
-
 
 class PublicationRepositoryParametersTestCase(unittest.TestCase):
     """Create a publication using repository and repository version.


### PR DESCRIPTION
Remove test related to remote from publications tests.

See:https://github.com/pulp/pulp_file/pull/228

'[noissue]'

