### PR TITLE
Not use editable with pip install

### DIFF
--- a/.travis/playbook.yml
+++ b/.travis/playbook.yml
@@ -22,6 +22,7 @@
     pulp_db_user: 'travis'
     pulp_db_password: ''
     pulp_preq_packages: []
+    pulp_pip_editable: no
   environment:
     DJANGO_SETTINGS_MODULE: pulpcore.app.settings
   roles:


### PR DESCRIPTION
Do not use editable option when pip installing packages
in pulp build environment.

Required PR: https://github.com/pulp/pulp-certguard/pull/22

closes: #4245
https://pulp.plan.io/issues/4245

Signed-off-by: Pavel Picka <ppicka@redhat.com>

Please be sure you have read our documentation on creating PRs:
https://docs.pulpproject.org/en/3.0/nightly/contributing/pull-request-walkthrough.html
