### PR TITLE
Problem: OpenAPI schema for status API is missing a response

### DIFF
--- a/pulpcore/app/views/status.py
+++ b/pulpcore/app/views/status.py
@@ -23,7 +23,9 @@ class StatusView(APIView):
     authentication_classes = []
     permission_classes = []
 
-    @swagger_auto_schema(operation_summary="Inspect status of Pulp")
+    @swagger_auto_schema(operation_summary="Inspect status of Pulp",
+                         operation_id="status_read",
+                         responses={200: StatusSerializer})
     def get(self, request, format=None):
         """
         Returns app information including the version of pulpcore and loaded pulp plugins,


### PR DESCRIPTION
Solution: add the response to the OpenAPI schema

This patch also change the operation_id from 'status_list' to 'status_read'.

fixes: #4870
https://pulp.plan.io/issues/4870