### PR TITLE
Fix serialization of repository field on Publications

### DIFF
--- a/pulpcore/app/serializers/publication.py
+++ b/pulpcore/app/serializers/publication.py
@@ -28,12 +28,13 @@ class PublicationSerializer(MasterModelSerializer):
         queryset=models.RepositoryVersion.objects.all(),
         required=False,
     )
-    repository = serializers.HyperlinkedRelatedField(
+    repository = RelatedField(
         help_text=_('A URI of the repository to be published.'),
         required=False,
         label=_('Repository'),
         queryset=models.Repository.objects.all(),
         view_name='repositories-detail',
+        write_only=True
     )
 
     def validate(self, data):


### PR DESCRIPTION
closes #4792
https://pulp.plan.io/issues/4792

Since all publications are have a repository version, there is no need to display the repository field on read ops.  We just want to be able to create one from the latest version of a repo.