### PR TITLE
Expand create publication distribution test case

### DIFF
--- a/pulpcore/tests/functional/api/using_plugin/test_distributions.py
+++ b/pulpcore/tests/functional/api/using_plugin/test_distributions.py
@@ -3,12 +3,25 @@
 import unittest
 
 from pulp_smash import api, config, utils
-from pulp_smash.pulp3.utils import gen_distribution
+from pulp_smash.pulp3.constants import REPO_PATH
+from pulp_smash.pulp3.utils import (
+    gen_distribution,
+    gen_repo,
+    get_versions,
+    sync,
+)
+
+from requests.exceptions import HTTPError
 
 from pulpcore.tests.functional.api.using_plugin.constants import (
     FILE_DISTRIBUTION_PATH,
+    FILE_REMOTE_PATH,
 )
-from pulpcore.tests.functional.api.using_plugin.utils import skip_if
+from pulpcore.tests.functional.api.using_plugin.utils import (
+    create_file_publication,
+    gen_file_remote,
+    skip_if,
+)
 from pulpcore.tests.functional.api.using_plugin.utils import set_up_module as setUpModule  # noqa
 
 
@@ -17,7 +30,8 @@ class CRUDPublicationDistributionTestCase(unittest.TestCase):
 
     This test targets the following issue:
 
-    `Pulp #4862 <https://pulp.plan.io/issues/4862>`_
+    * `Pulp #4839 <https://pulp.plan.io/issues/4839>`_
+    * `Pulp #4862 <https://pulp.plan.io/issues/4862>`_
     """
 
     @classmethod
@@ -25,13 +39,79 @@ class CRUDPublicationDistributionTestCase(unittest.TestCase):
         """Create class-wide variables."""
         cls.cfg = config.get_config()
         cls.client = api.Client(cls.cfg)
-        cls.distribution = {}
         cls.attr = ('name', 'base_path',)
+        cls.distribution = {}
+        cls.publication = {}
+        cls.remote = {}
+        cls.repo = {}
+
+    @classmethod
+    def tearDownClass(cls):
+        """Clean class-wide variables."""
+        for resource in (cls.publication, cls.remote, cls.repo):
+            if resource:
+                cls.client.delete(resource['_href'])
 
     def test_01_create(self):
-        """Create a publication distribution."""
+        """Create a publication distribution.
+
+        Do the following:
+
+        1. Create a repository and 3 repository versions with at least 1 file
+           content in it. Create a publication using the second repository
+           version.
+        2. Create a distribution with 'publication' field set to
+           the publication from step (1).
+        3. Assert the distribution got created correctly with the correct
+           base_path, name, and publication. Assert that content guard is
+           unset.
+        4. Assert that publication has a 'distributions' reference to the
+           distribution (it's backref).
+
+        """
+        self.repo.update(self.client.post(REPO_PATH, gen_repo()))
+        self.remote.update(
+            self.client.post(FILE_REMOTE_PATH, gen_file_remote())
+        )
+        # create 3 repository versions
+        for _ in range(3):
+            sync(self.cfg, self.remote, self.repo)
+        self.repo = self.client.get(self.repo['_href'])
+
+        versions = get_versions(self.repo)
+
+        self.publication.update(create_file_publication(
+            self.cfg,
+            self.repo,
+            versions[1]['_href']
+        ))
+
         self.distribution.update(
-            self.client.post(FILE_DISTRIBUTION_PATH, gen_distribution())
+            self.client.post(
+                FILE_DISTRIBUTION_PATH,
+                gen_distribution(publication=self.publication['_href'])
+            )
+        )
+
+        self.publication = self.client.get(self.publication['_href'])
+
+        # content_guard is the only parameter unset.
+        for key, val in self.distribution.items():
+            if key == 'content_guard':
+                self.assertIsNone(val, self.distribution)
+            else:
+                self.assertIsNotNone(val, self.distribution)
+
+        self.assertEqual(
+            self.distribution['publication'],
+            self.publication['_href'],
+            self.distribution
+        )
+
+        self.assertEqual(
+            self.publication['distributions'][0],
+            self.distribution['_href'],
+            self.publication
         )
 
     @skip_if(bool, 'distribution', False)
@@ -60,6 +140,8 @@ class CRUDPublicationDistributionTestCase(unittest.TestCase):
     def test_04_delete_distribution(self):
         """Delete a distribution."""
         self.client.delete(self.distribution['_href'])
+        with self.assertRaises(HTTPError):
+            self.client.get(self.distribution['_href'])
 
     def do_fully_update_attr(self, attr):
         """Update a distribution attribute using HTTP PUT.
@@ -76,7 +158,7 @@ class CRUDPublicationDistributionTestCase(unittest.TestCase):
         self.assertEqual(string, distribution[attr], distribution)
 
     def do_partially_update_attr(self, attr):
-        """Update a distribution using HTTP patch.
+        """Update a distribution using HTTP PATCH.
 
         :param attr: The name of the attribute to update.
         """


### PR DESCRIPTION
Expand create publication distribution test case. Use a publication
field when creating a distribution. Update assertions about just created
distribution.

closes:#4839

