### PR TITLE
Update RPM constants advisory

### DIFF
--- a/pulpcore/tests/functional/api/using_plugin/constants.py
+++ b/pulpcore/tests/functional/api/using_plugin/constants.py
@@ -70,24 +70,24 @@ FILE2_URL = urljoin(FILE2_FIXTURE_URL, '1.iso')
 
 RPM_PACKAGE_CONTENT_NAME = 'rpm.package'
 
-RPM_UPDATE_CONTENT_NAME = 'rpm.update'
+RPM_ADVISORY_CONTENT_NAME = 'rpm.advisory'
 
 RPM_REMOTE_PATH = urljoin(BASE_REMOTE_PATH, 'rpm/rpm/')
 
 RPM_UNSIGNED_FIXTURE_URL = urljoin(PULP_FIXTURES_BASE_URL, 'rpm-unsigned/')
 """The URL to a repository with unsigned RPM packages."""
 
-RPM_PACKAGES_COUNT = 35
+RPM_PACKAGE_COUNT = 35
 """The number of packages available at
 :data:`RPM_SIGNED_FIXTURE_URL` and :data:`RPM_UNSIGNED_FIXTURE_URL`
 """
 
-RPM_UPDATE_COUNT = 4
+RPM_ADVISORY_COUNT = 4
 """The number of updated record units."""
 
 RPM_FIXTURE_SUMMARY = {
-    RPM_PACKAGE_CONTENT_NAME: RPM_PACKAGES_COUNT,
-    RPM_UPDATE_CONTENT_NAME: RPM_UPDATE_COUNT
+    RPM_PACKAGE_CONTENT_NAME: RPM_PACKAGE_COUNT,
+    RPM_ADVISORY_CONTENT_NAME: RPM_ADVISORY_COUNT
 }
 """The breakdown of how many of each type of content unit are present in the
 standard repositories, i.e. :data:`RPM_SIGNED_FIXTURE_URL` and


### PR DESCRIPTION
Update RPM constants to be according to the new changes added to RPM
plugin.

See: https://github.com/pulp/pulp_rpm/pull/1354

'[noissue]'
