### PR TITLE
Add new changelog process

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,0 +1,16 @@
+=========
+Changelog
+=========
+
+..
+    You should *NOT* be adding new change log entries to this file, this
+    file is managed by towncrier. You *may* edit previous change logs to
+    fix problems like typo corrections or such.
+    To add a new change log entry, please see
+    https://docs.pulpproject.org/en/3.0/nightly/contributing/git.html#changelog-update
+
+    WARNING: Don't drop the next directive!
+
+.. towncrier release notes start
+
+

--- a/CHANGES/.TEMPLATE.rst
+++ b/CHANGES/.TEMPLATE.rst
@@ -1,0 +1,37 @@
+{# TOWNCRIER TEMPLATE #}
+{% for section, _ in sections.items() %}
+{% set underline = underlines[0] %}{% if section %}{{section}}
+{{ underline * section|length }}{% set underline = underlines[1] %}
+
+{% endif %}
+
+{% if sections[section] %}
+{% for category, val in definitions.items() if category in sections[section]%}
+{{ definitions[category]['name'] }}
+{{ underline * definitions[category]['name']|length }}
+
+{% if definitions[category]['showcontent'] %}
+{% for text, values in sections[section][category].items() %}
+- {{ text }}
+  {{ values|join(',\n  ') }}
+{% endfor %}
+
+{% else %}
+- {{ sections[section][category]['']|join(', ') }}
+
+{% endif %}
+{% if sections[section][category]|length == 0 %}
+No significant changes.
+
+{% else %}
+{% endif %}
+
+{% endfor %}
+{% else %}
+No significant changes.
+
+
+{% endif %}
+{% endfor %}
+----
+

--- a/CHANGES/.gitignore
+++ b/CHANGES/.gitignore
@@ -1,0 +1,2 @@
+!.gitignore
+

--- a/CHANGES/4875.doc
+++ b/CHANGES/4875.doc
@@ -1,0 +1,1 @@
+Switch to using `towncrier <https://github.com/hawkowl/towncrier>`_ for better release notes.

--- a/doc_requirements.txt
+++ b/doc_requirements.txt
@@ -8,3 +8,4 @@ pyyaml
 sphinx<1.8.0
 sphinx-rtd-theme
 sphinxcontrib-openapi
+towncrier

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -1,0 +1,5 @@
+.. _pulpcore-changes:
+
+.. include:: ../CHANGES.rst
+
+.. include:: ../HISTORY.rst

--- a/docs/contributing/git.rst
+++ b/docs/contributing/git.rst
@@ -88,3 +88,27 @@ when testing your Pull Request. See :ref:`continuous-integration` for details.
 
    A good candidate for a ``noissue`` tag is a one line fix or a typo, otherwise we encourage
    you to open an issue.
+
+
+.. _changelog-update:
+
+Changelog update
+****************
+
+The CHANGES.rst file is managed using the `towncrier tool <https://github.com/hawkowl/towncrier>`_
+and all non trivial changes must be accompanied by a news entry.
+
+To add an entry to the news file, you first need an issue in pulp.plan.io describing the change you
+want to make. Once you have an issue, take its number and create a file inside of the ``CHANGES/``
+directory named after that issue number with an extension of .feature, .bugfix, .doc, .removal, or
+.misc. So if your issue is 3543 and it fixes a bug, you would create the file
+``CHANGES/3543.bugfix``.
+
+PRs can span multiple categories by creating multiple files (for instance, if you added a feature
+and deprecated an old feature at the same time, you would create CHANGES/NNNN.feature and
+CHANGES/NNNN.removal). Likewise if a PR touches multiple issues/PRs you may create a file for each
+of them with the exact same contents and Towncrier will deduplicate them.
+
+The contents of this file are reStructuredText formatted text that will be used as the content of
+the news file entry. You do not need to reference the issue or PR numbers here as towncrier will
+automatically add a reference to all of the affected issues when rendering the news file.

--- a/docs/contributing/index.rst
+++ b/docs/contributing/index.rst
@@ -5,6 +5,17 @@ Contribution documentation generally assumes that the reader is familiar with
 :doc:`Pulp basics</concepts>`. If you have problems, you can :ref:`contact us<community>`
 or :doc:`file an issue</bugs-features>`.
 
+Workflow
+--------
+
+1. Clone the GitHub repo
+2. Make a change
+3. Make sure all tests passed
+4. Add a file into CHANGES folder (Changelog update).
+5. Commit changes to own aiohttp clone
+6. Make pull request from github page for your clone against master branch
+
+
 Fundamentals
 ------------
 

--- a/docs/contributing/pull-request-walkthrough.rst
+++ b/docs/contributing/pull-request-walkthrough.rst
@@ -25,7 +25,7 @@ Checklist
 #. Update relevent :doc:`documentation`. Please build the docs to test!
 #. If your change would benefit from integration testing, write a `pulp smash issue
    <https://github.com/PulpQE/pulp-smash/issues/new>`_.
-#. If you are adding a new feature, add a release note.
+#. Add a :ref:`changelog update <changelog-update>`.
 #. :ref:`Rebase and squash<rebase>` to a single commit, if appropriate.
 #. Write an excellent :ref:`commit-message`. Make sure you reference and link to the issue.
 #. Push your branch to your fork and open a `Pull request across forks

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -106,3 +106,4 @@ Table of Contents
    troubleshooting
    bugs-features
    glossary
+   changes

--- a/pulpcore/__init__.py
+++ b/pulpcore/__init__.py
@@ -1,2 +1,8 @@
+import pkg_resources
+
+__version__ = pkg_resources.get_distribution("pulpcore").version
+
+
 from pkgutil import extend_path
+
 __path__ = extend_path(__path__, __name__)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,7 @@
+[tool.towncrier]
+package = "pulpcore"
+filename = "CHANGES.rst"
+directory = "CHANGES/"
+title_format = "{version} ({project_date})"
+template = "CHANGES/.TEMPLATE.rst"
+issue_format = "`#{issue} <https://pulp.plan.io/issues/{issue}>`_"


### PR DESCRIPTION
- Adds a changelog update section to the docs
- creates the base CHANGES.rst file
- creates the CHANGES directory for news updates and indicates to git to
  store the dir even if empty with a .gitignore.
- adds a release note for this change
- adds a docs section that loads the CHANGES.rst file on the website

https://pulp.plan.io/issues/4875
re #4875
