### PR TITLE
Permissions & related docs updates

### DIFF
--- a/docs/installation/configuration.rst
+++ b/docs/installation/configuration.rst
@@ -15,6 +15,19 @@ optional. The expected location and format can be changed by specifying the ``PU
 environment variable. Dynaconf supports `settings in multiple file formats <https://dynaconf.
 readthedocs.io/en/latest/guides/examples.html>`_
 
+This file should have permissions of:
+
+* mode: 640
+* owner: root
+* group: pulp
+* SELinux context: system_u:object_r:etc_t:s0
+
+If it is in its own directory like ``/etc/pulp``, the directory should have permissions of:
+
+* mode: 750
+* owner: root
+* group: pulp
+* SELinux context: unconfined_u:object_r:etc_t:s0
 
 By Environment Variables
 ------------------------
@@ -85,6 +98,13 @@ MEDIA_ROOT
    If you're using S3, point this to the path in your bucket you want to save files. See the
    :ref:`storage documentation <storage>` for more info.
 
+   It should have permissions of:
+
+   * mode: 750
+   * owner: pulp
+   * group: pulp
+   * SELinux context: system_u:object_r:var_lib_t:s0
+
 LOGGING
 ^^^^^^^
 
@@ -142,6 +162,13 @@ WORKING_DIRECTORY
 
    The directory used by workers to stage files temporarily. This defaults to
    ``/var/lib/pulp/tmp/``.
+
+   It should have permissions of:
+
+   * mode: 755
+   * owner: pulp
+   * group: pulp
+   * SELinux context: unconfined_u:object_r:var_lib_t:s0
 
 .. note::
 

--- a/docs/installation/configuration.rst
+++ b/docs/installation/configuration.rst
@@ -19,14 +19,14 @@ This file should have permissions of:
 
 * mode: 640
 * owner: root
-* group: pulp
+* group: pulp (the group of the account that pulp runs under)
 * SELinux context: system_u:object_r:etc_t:s0
 
 If it is in its own directory like ``/etc/pulp``, the directory should have permissions of:
 
 * mode: 750
 * owner: root
-* group: pulp
+* group: pulp (the group of the account that pulp runs under)
 * SELinux context: unconfined_u:object_r:etc_t:s0
 
 By Environment Variables
@@ -101,8 +101,8 @@ MEDIA_ROOT
    It should have permissions of:
 
    * mode: 750
-   * owner: pulp
-   * group: pulp
+   * owner: pulp (the account that pulp runs under)
+   * group: pulp (the group of the account that pulp runs under)
    * SELinux context: system_u:object_r:var_lib_t:s0
 
 LOGGING
@@ -166,8 +166,8 @@ WORKING_DIRECTORY
    It should have permissions of:
 
    * mode: 755
-   * owner: pulp
-   * group: pulp
+   * owner: pulp (the account that pulp runs under)
+   * group: pulp (the group of the account that pulp runs under)
    * SELinux context: unconfined_u:object_r:var_lib_t:s0
 
 .. note::

--- a/docs/installation/instructions.rst
+++ b/docs/installation/instructions.rst
@@ -69,7 +69,10 @@ PyPI Installation
 
 5. Follow the :ref:`configuration instructions <configuration>` to set the ``SECRET_KEY``.
 
-6. Go through the :ref:`database-install`, :ref:`redis-install`, and :ref:`systemd-setup` sections
+6. Create the ``MEDIA_ROOT`` & ``WORKING_DIRECTORY`` with the prescribed permissions from the
+   :ref:`configuration instructions. <configuration>`
+
+7. Go through the :ref:`database-install`, :ref:`redis-install`, and :ref:`systemd-setup` sections
 
 .. note::
 
@@ -80,16 +83,16 @@ PyPI Installation
     $ /path/to/python/bin/rq worker -n 'reserved-resource-worker-1@%h' -w 'pulpcore.tasking.worker.PulpWorker' -c 'pulpcore.rqconfig'
     $ /path/to/python/bin/rq worker -n 'reserved-resource-worker-2@%h' -w 'pulpcore.tasking.worker.PulpWorker' -c 'pulpcore.rqconfig'
 
-7. Run Django Migrations::
+8. Run Django Migrations::
 
    $ django-admin migrate --noinput
    $ django-admin reset-admin-password --password admin
 
-8. Collect Static Media for live docs and browsable API::
+9. Collect Static Media for live docs and browsable API::
 
    $ django-admin collectstatic --noinput
 
-9. Run Pulp::
+10. Run Pulp::
 
     $ pulp-content  # The Pulp Content service (listening on port 24816)
     $ django-admin runserver 24817  # The Pulp API service

--- a/docs/installation/instructions.rst
+++ b/docs/installation/instructions.rst
@@ -29,9 +29,17 @@ To use ansible roles to install Pulp 3 instead of manual setup refer to
 PyPI Installation
 -----------------
 
-1. Install python3.6(+) and pip.
+1. (Optional) Create a user account & group for Pulp 3 to run under, rather than using root. The following values are recommended:
 
-2. Create a pulp venv::
+   * name: pulp
+   * shell: The path to the `nologin` executable
+   * home: ``MEDIA_ROOT``
+   * system account: yes
+   * create corresponding private group: yes
+
+2. Install python3.6(+) and pip.
+
+3. Create a pulp venv::
 
    $ python3 -m venv pulpvenv
    $ source pulpvenv/bin/activate
@@ -43,7 +51,7 @@ PyPI Installation
 
    $ sudo apt-get install python3-venv
 
-3. Install Pulp with the set of packages for the relational database you prefer to use. Right now we
+4. Install Pulp with the set of packages for the relational database you prefer to use. Right now we
    have extra sets for postgresql or MySQL/mariadb::
 
    $ pip install pulpcore-plugin pulpcore[postgres]
@@ -59,9 +67,9 @@ PyPI Installation
    $ pip install -e ./pulpcore-plugin
 
 
-4. Follow the :ref:`configuration instructions <configuration>` to set the ``SECRET_KEY``.
+5. Follow the :ref:`configuration instructions <configuration>` to set the ``SECRET_KEY``.
 
-5. Go through the :ref:`database-install`, :ref:`redis-install`, and :ref:`systemd-setup` sections
+6. Go through the :ref:`database-install`, :ref:`redis-install`, and :ref:`systemd-setup` sections
 
 .. note::
 
@@ -72,16 +80,16 @@ PyPI Installation
     $ /path/to/python/bin/rq worker -n 'reserved-resource-worker-1@%h' -w 'pulpcore.tasking.worker.PulpWorker' -c 'pulpcore.rqconfig'
     $ /path/to/python/bin/rq worker -n 'reserved-resource-worker-2@%h' -w 'pulpcore.tasking.worker.PulpWorker' -c 'pulpcore.rqconfig'
 
-8. Run Django Migrations::
+7. Run Django Migrations::
 
    $ django-admin migrate --noinput
    $ django-admin reset-admin-password --password admin
 
-9. Collect Static Media for live docs and browsable API::
+8. Collect Static Media for live docs and browsable API::
 
    $ django-admin collectstatic --noinput
 
-10. Run Pulp::
+9. Run Pulp::
 
     $ pulp-content  # The Pulp Content service (listening on port 24816)
     $ django-admin runserver 24817  # The Pulp API service


### PR DESCRIPTION
1 commit resolves:

Document permissions for installation (without Ansible installer)

https://pulp.plan.io/issues/2881

The 2 other commits resolve the 2 other lack of documentation issues that I discovered while implementing it.

https://pulp.plan.io/issues/4918

https://pulp.plan.io/issues/4919