### PR TITLE
Problem: task cancel API is incorrect

### DIFF
--- a/CHANGES/4883.feature
+++ b/CHANGES/4883.feature
@@ -1,0 +1,2 @@
+The task API now accepts PATCH requests that update the state of the task to 'canceled'. This
+replaces the previous task cancelation API.

--- a/CHANGES/4883.removal
+++ b/CHANGES/4883.removal
@@ -1,0 +1,1 @@
+The task cancelation REST API has been removed.

--- a/pulpcore/app/serializers/__init__.py
+++ b/pulpcore/app/serializers/__init__.py
@@ -49,4 +49,4 @@ from .repository import (  # noqa
     RepositoryVersionSerializer,
     RepositoryVersionCreateSerializer
 )
-from .task import MinimalTaskSerializer, TaskSerializer, WorkerSerializer  # noqa
+from .task import MinimalTaskSerializer, TaskSerializer, TaskCancelSerializer, WorkerSerializer  # noqa

--- a/pulpcore/app/serializers/task.py
+++ b/pulpcore/app/serializers/task.py
@@ -101,6 +101,16 @@ class MinimalTaskSerializer(TaskSerializer):
                                                 'worker', 'parent')
 
 
+class TaskCancelSerializer(ModelSerializer):
+    state = serializers.CharField(
+        help_text=_("The desired state of the task. Only 'canceled' is accepted."),
+    )
+
+    class Meta:
+        model = models.Task
+        fields = ('state',)
+
+
 class WorkerSerializer(ModelSerializer):
     _href = IdentityField(view_name='workers-detail')
 

--- a/pulpcore/tasking/util.py
+++ b/pulpcore/tasking/util.py
@@ -56,6 +56,7 @@ def cancel(task_id):
         _delete_incomplete_resources(task_status)
 
     _logger.info(_('Task canceled: {id}.').format(id=task_id))
+    return task_status
 
 
 def _delete_incomplete_resources(task):

--- a/pulpcore/tests/functional/api/using_plugin/test_tasking.py
+++ b/pulpcore/tests/functional/api/using_plugin/test_tasking.py
@@ -86,8 +86,7 @@ class CancelTaskTestCase(unittest.TestCase):
     def test_cancel_running_task(self):
         """Cancel a running task."""
         task = self.create_long_task()
-        self.cancel_task(task)
-        response = self.client.get(task['task'])
+        response = self.cancel_task(task)
         self.assertIsNone(response['finished_at'], response)
         self.assertEqual(response['state'], 'canceled', response)
 
@@ -95,7 +94,7 @@ class CancelTaskTestCase(unittest.TestCase):
         """Cancel a nonexistent task."""
         task_href = urljoin(TASKS_PATH, utils.uuid4() + '/')
         with self.assertRaises(HTTPError) as ctx:
-            self.client.post(urljoin(task_href, 'cancel/'))
+            self.client.patch(task_href, json={'state': 'canceled'})
         for key in ('not', 'found'):
             self.assertIn(
                 key,
@@ -128,4 +127,4 @@ class CancelTaskTestCase(unittest.TestCase):
 
     def cancel_task(self, task):
         """Cancel a task."""
-        return self.client.post(urljoin(task['task'], 'cancel/'))
+        return self.client.patch(task['task'], json={'state': 'canceled'})


### PR DESCRIPTION
Solution: switch it to a PATCH method of the task

This patch changes REST API for task cancelation. Users will now be able to make a PATCH
request to the task href and specify the state='canceled'. The response is the fully
serialized task.

fixes: #4883
https://pulp.plan.io/issues/4883