### PR TITLE
Problem: Content-Range regex not compatible with Ruby

### DIFF
--- a/pulpcore/app/viewsets/upload.py
+++ b/pulpcore/app/viewsets/upload.py
@@ -19,11 +19,11 @@ class UploadViewSet(GenericViewSet, ChunkedUploadView, CreateModelMixin, Destroy
 
     content_range_parameter = \
         Parameter(name='Content-Range', in_='header', required=True, type='string',
-                  pattern=r"^bytes (?P<start>\d+)-(?P<end>\d+)/(?P<total>\d+)$",
+                  pattern=r'^bytes (\d+)-(\d+)\/(\d+)$',
                   description='The Content-Range header specifies the location of the file chunk '
                               'within the file.')
 
-    @swagger_auto_schema(operation_summary="Start Upload",
+    @swagger_auto_schema(operation_summary="Start an Upload",
                          operation_id="uploads_create",
                          request_body=UploadPUTSerializer,
                          manual_parameters=[content_range_parameter],


### PR DESCRIPTION
Solution: remove 'pattern' property

This patch removes the 'pattern' attribute from the OpenAPI schema for the Content-Range
header in the Uploads APIs. The regex is now provided as part of the description. The
generated clients no longer will use the regex to enforce correctness of the header.

[noissue]