### PR TITLE
Add REMOTE_USER support

### DIFF
--- a/CHANGES/3808.doc
+++ b/CHANGES/3808.doc
@@ -1,0 +1,3 @@
+Adds an `authentication section <https://docs.pulpproject.org/en/3.0/nightly/installation/
+authentication.html>`_ to the installation guide. Also add two documented settings:
+``AUTHENTICATION_BACKENDS`` and ``REMOTE_USER_ENVIRON_NAME``.

--- a/CHANGES/3808.feature
+++ b/CHANGES/3808.feature
@@ -1,0 +1,3 @@
+Pulp now works with webserver configured authentication that use the ``REMOTE_USER`` method. Also a
+new setting ``REMOTE_USER_ENVIRON_NAME`` is introduced allowing webserver authentication to work in
+reverse proxy deployments.

--- a/docs/glossary.rst
+++ b/docs/glossary.rst
@@ -6,6 +6,11 @@ Glossary
     :class:`~pulpcore.app.models.Artifact`
         A file that belongs to a :term:`content unit<content>`.
 
+    :class:`~pulpcore.plugin.models.ContentGuard`
+        A pluggable content protection mechanism that can be added to a :term:`Distribution`, and
+        is used exclusively by the :term:`content app` to only had out binary data to trusted
+        clients. "Trusted users" are defined by the type of ContentGuard used.
+
     :class:`~pulpcore.app.models.Content`
     content unit
         Content are the smallest units of data that can be added and removed from

--- a/docs/installation/authentication.rst
+++ b/docs/installation/authentication.rst
@@ -1,0 +1,121 @@
+.. _authentication:
+
+API Authentication
+==================
+
+By default, Pulp has two types of authentication enabled, and both are tried before rejecting a
+request as unauthenticated.
+
+   1. Basic Authentication, which is checked against an internal users database
+   2. Webserver authentication that relies on the webserver to perform the authentication.
+
+.. note::
+    This authentication is only for the REST API. Client's fetching binary data have their identity
+    verified and authorization checked using a :term:`ContentGuard`.
+
+
+Which URLs Require Authentication?
+----------------------------------
+
+All URLs in the REST API require authentication except the Status API, ``/pulp/api/v3/status/``,
+which is served to unauthenticated users too. This is true regardless of the type of authentication
+you configure.
+
+
+Basic Auth
+----------
+
+Pulp by default uses `Basic Auth <https://tools.ietf.org/html/rfc7617>`_ authentication which checks
+the user submitted header against an internal database of users. If the username and password match,
+the request is considered authenticated as that username.
+
+.. warning::
+
+    For the 3.0 release, Pulp expects the user table to have exactly 1 user in it named 'admin',
+    which is created automatically when the initial migration is applied. The password for this user
+    can be set with the ``django-admin reset-admin-password`` command, but defaults to 'password'.
+    To articulate what you'd like to see future versions of Pulp file a feature request
+    `here <https://pulp.plan.io/projects/pulp/issues/new>`_ or reach out via
+    `pulp-list@redhat.com <https://www.redhat.com/mailman/listinfo/pulp-list>`_.
+
+
+Disabling Basic Auth
+********************
+
+To disable Basic Auth, remove the ``'django.contrib.auth.backends.ModelBackend'`` from the
+``AUTHENTICATION_BACKENDS`` setting in Pulp.
+
+You can configure Django Rest Framework to not trust users authenticated with Basic Auth by removing
+``'rest_framework.authentication.BasicAuthentication'`` from the
+``REST_FRAMEWORK['DEFAULT_AUTHENTICATION_CLASSES']`` .
+
+
+.. _webserver-auth:
+
+Webserver Auth
+--------------
+
+Pulp by default can use authentication configured in the webserver, e.g. Apache 2.4 configured with
+`mod_ldap <https://httpd.apache.org/docs/2.4/mod/mod_ldap.html>`_. By default Pulp trusts a WSGI
+environment variable named ``REMOTE_USER``, and will create a Django user in the user list to
+represent that user. These are the typical behaviors provided by Django's `REMOTE_USER middleware
+<https://docs.djangoproject.com/en/2.2/howto/auth-remote-user/>`_ which is enabled by default with
+Pulp.
+
+
+.. _webserver-auth-with-reverse-proxy:
+
+Webserver Auth with Reverse Proxy
+*********************************
+
+For example purposes, assume you're using Nginx with LDAP authentication required and after
+authenticating it reverse proxies your request to the gunicorn process running the pulpcore.app.wsgi
+application. That would look like this::
+
+    nginx <----> gunicorn <----> pulpcore.app.wsgi application
+
+
+With nginx knowing ``REMOTE_USER`` and acting as a proxy it can't set the environment variable
+for the wsgi request because that happens in gunicorn. To give the REMOTE_USER information to Pulp
+a header should be used, and the nginx config should include a line like::
+
+    proxy_set_header REMOTE_USER $remote_user;
+
+Per the `WSGI standard <https://www.python.org/dev/peps/pep-0333/#environ-variables>`_, any incoming
+headers will be prepended with a ``HTTP_``. The above line would send the header named
+``REMOTE_USER`` to gunicorn, and the WSGI application would receive it as ``HTTP_REMOTE_USER``. The
+default configuration of Pulp is expecting ``REMOTE_USER`` in the WSGI environment not
+``HTTP_REMOTE_USER``, so this won't work.
+
+Pulp provides a setting named `REMOTE_USER_ENVIRON_NAME <remote-user-environ-name>`_ which allows
+you to specify another WSGI environment variable to read the authenticated username from.
+
+.. warning::
+
+    Configuring this has serious security implications. See the `Django warning at the end of this
+    section in their docs <https://docs.djangoproject.com/en/2.2/howto/auth-remote-user/
+    #configuration>`_ for more details.
+
+
+Disabling Webserver Auth
+************************
+
+To disable Pulp from using webserver authentication remove the
+``'django.contrib.auth.backends.RemoteUserBackend'`` from the ``AUTHENTICATION_BACKENDS`` setting in
+Pulp.
+
+You can configure Django Rest Framework to not trust webserver authenticated users by removing
+``'rest_framework.authentication.RemoteUserAuthentication'`` from the
+``REST_FRAMEWORK['DEFAULT_AUTHENTICATION_CLASSES']`` .
+
+
+Custom Authentication
+---------------------
+
+Pulp is a Django app, so additional Django authentication can be added as long as it's correctly
+configured for both Django and Django Rest Frameowork.
+
+See the `Django docs on configuring custom authentication <https://docs.djangoproject.com/en/2.2/
+topics/auth/customizing/#customizing-authentication-in-django>`_ and the `Django Rest Framework docs
+on configuring custom authentication <https://www.django-rest-framework.org/api-guide/authentication
+/#custom-authentication>`_.

--- a/docs/installation/configuration.rst
+++ b/docs/installation/configuration.rst
@@ -92,6 +92,17 @@ LOGGING
    refer to `Django documenation on logging <https://docs.djangoproject.com/en/2
    .1/topics/logging/#configuring-logging>`_.
 
+AUTHENTICATION_BACKENDS
+^^^^^^^^^^^^^^^^^^^^^^^
+
+   By default, Pulp has two types of authentication enabled, and they fall back for each other:
+
+   1. Basic Auth which is checked against an internal users database
+   2. Webserver authentication that relies on the webserver to perform the authentication.
+
+   To change the authentication types Pulp will use, modify the ``AUTHENTICATION_BACKENDS``
+   settings. See the `Django authentication documentation <https://docs.djangoproject.com/en/2.2/
+   topics/auth/customizing/#authentication-backends>`_ for more information.
 
 .. _rq-settings:
 
@@ -170,6 +181,23 @@ CONTENT_PATH_PREFIX
    to match incoming URLs.
 
    Defaults to ``'/pulp/content/'``.
+
+
+.. _remote-user-environ-name:
+
+REMOTE_USER_ENVIRON_NAME
+^^^^^^^^^^^^^^^^^^^^^^^^
+
+   The name of the WSGI environment variable to read for :ref:`webserver authentication
+   <webserver-auth>`.
+
+   .. warning::
+
+      Configuring this has serious security implications. See the `Django warning at the end of this
+      section in their docs <https://docs.djangoproject.com/en/2.2/howto/auth-remote-user/
+      #configuration>`_ for more details.
+
+   Defaults to ``'REMOTE_USER'``.
 
 
 PROFILE_STAGES_API

--- a/docs/installation/index.rst
+++ b/docs/installation/index.rst
@@ -9,6 +9,7 @@ Installation
    instructions
    configuration
    storage
+   authentication
    distributed-installation
    migration
 

--- a/pulpcore/app/middleware.py
+++ b/pulpcore/app/middleware.py
@@ -1,0 +1,7 @@
+from django.contrib.auth.middleware import RemoteUserMiddleware
+
+from pulpcore.app import settings
+
+
+class PulpRemoteUserMiddleware(RemoteUserMiddleware):
+    header = settings.REMOTE_USER_ENVIRON_NAME

--- a/pulpcore/app/settings.py
+++ b/pulpcore/app/settings.py
@@ -84,8 +84,14 @@ MIDDLEWARE = [
     'django.middleware.common.CommonMiddleware',
     'django.middleware.csrf.CsrfViewMiddleware',
     'django.contrib.auth.middleware.AuthenticationMiddleware',
+    'pulpcore.app.middleware.PulpRemoteUserMiddleware',
     'django.contrib.messages.middleware.MessageMiddleware',
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
+]
+
+AUTHENTICATION_BACKENDS = [
+    'django.contrib.auth.backends.ModelBackend',
+    'django.contrib.auth.backends.RemoteUserBackend',
 ]
 
 ROOT_URLCONF = 'pulpcore.app.urls'
@@ -116,6 +122,7 @@ REST_FRAMEWORK = {
     'DEFAULT_PERMISSION_CLASSES': ('rest_framework.permissions.IsAuthenticated',),
     'DEFAULT_AUTHENTICATION_CLASSES': (
         'rest_framework.authentication.SessionAuthentication',
+        'rest_framework.authentication.RemoteUserAuthentication',
         'rest_framework.authentication.BasicAuthentication',
     ),
     'UPLOADED_FILES_USE_URL': False,
@@ -197,6 +204,8 @@ LOGGING = {
 
 CONTENT_HOST = None
 CONTENT_PATH_PREFIX = '/pulp/content/'
+
+REMOTE_USER_ENVIRON_NAME = "REMOTE_USER"
 
 PROFILE_STAGES_API = False
 


### PR DESCRIPTION
This adds REMOTE_USER support which is enabled by default. For
reverse proxy deployments, a new setting is introduced controlling
which WSGI environment var contains the trusted authenticated
username.

A new authentication section is added which contains docs on the
default authentication, how to customize or disable them, and how to
install custom authentication.

https://pulp.plan.io/issues/3808
closes #3808
