### PR TITLE
Allow json to be used to create artifacts from upload

### DIFF
--- a/CHANGES/5016.bug
+++ b/CHANGES/5016.bug
@@ -1,0 +1,1 @@
+Allow artifacts to be created using json

--- a/docs/workflows/upload-publish.rst
+++ b/docs/workflows/upload-publish.rst
@@ -23,7 +23,7 @@ upload::
 
 Then the artifact may be created with the upload href::
 
-    http --form POST :24817/pulp/api/v3/artifacts/ upload=/pulp/api/v3/uploads/a8b5a7f7-2f22-460d-ab20-d5616cb71cdd/
+    http POST :24817/pulp/api/v3/artifacts/ upload=/pulp/api/v3/uploads/a8b5a7f7-2f22-460d-ab20-d5616cb71cdd/
 
 Note that after creating an artifact from an upload, the upload gets deleted and cannot be re-used.
 
@@ -35,4 +35,4 @@ Putting this altogether, here is an example that uploads a 1.iso file in two chu
    http --form PUT :24817$UPLOAD file@./chunkab 'Content-Range:bytes 6291456-10485759/*'
    http --form PUT :24817$UPLOAD file@./chunkaa 'Content-Range:bytes 0-6291455/*'
    http PUT :24817${UPLOAD}commit/ sha256=`sha256sum 1.iso | cut -d ' ' -f1`
-   http --form POST :24817/pulp/api/v3/artifacts/ upload=$UPLOAD
+   http POST :24817/pulp/api/v3/artifacts/ upload=$UPLOAD

--- a/pulpcore/app/viewsets/content.py
+++ b/pulpcore/app/viewsets/content.py
@@ -2,7 +2,6 @@ from gettext import gettext as _
 
 from django.db import models
 from rest_framework import mixins, status
-from rest_framework.parsers import FormParser, MultiPartParser
 from rest_framework.response import Response
 
 from pulpcore.app.models import Artifact, Content
@@ -50,7 +49,6 @@ class ArtifactViewSet(NamedModelViewSet,
     queryset = Artifact.objects.all()
     serializer_class = ArtifactSerializer
     filterset_class = ArtifactFilter
-    parser_classes = (MultiPartParser, FormParser)
 
     def destroy(self, request, pk):
         """


### PR DESCRIPTION
I confirmed that the REST API docs display 'multipart/form-data'.

fixes #5016
https://pulp.plan.io/issues/5016

Please be sure you have read our documentation on creating PRs:
https://docs.pulpproject.org/en/3.0/nightly/contributing/pull-request-walkthrough.html
