### PR TITLE
Problem: client is failing to publish to PyPI

### DIFF
--- a/.travis/playbook.yml
+++ b/.travis/playbook.yml
@@ -19,6 +19,7 @@
     pulp_db_user: 'travis'
     pulp_db_password: ''
     pulp_preq_packages: []
+    pulp_content_host: 'localhost:24816'
   environment:
     DJANGO_SETTINGS_MODULE: pulpcore.app.settings
   roles:

--- a/.travis/publish_client_gem.sh
+++ b/.travis/publish_client_gem.sh
@@ -14,7 +14,7 @@ if [[ $DESCRIPTION == 'tags/'$REPORTED_VERSION ]]; then
   export VERSION=${REPORTED_VERSION}
 else
   export EPOCH="$(date +%s)"
-  export VERSION=${REPORTED_VERSION}.${EPOCH}
+  export VERSION=${REPORTED_VERSION}${EPOCH}
 fi
 
 export response=$(curl --write-out %{http_code} --silent --output /dev/null https://rubygems.org/gems/pulpcore_client/versions/$VERSION)

--- a/.travis/publish_client_pypi.sh
+++ b/.travis/publish_client_pypi.sh
@@ -12,7 +12,7 @@ if [[ $DESCRIPTION == 'tags/'$REPORTED_VERSION ]]; then
   export VERSION=${REPORTED_VERSION}
 else
   export EPOCH="$(date +%s)"
-  export VERSION=${REPORTED_VERSION}.${EPOCH}
+  export VERSION=${REPORTED_VERSION}${EPOCH}
 fi
 
 export response=$(curl --write-out %{http_code} --silent --output /dev/null https://pypi.org/project/pulp-file-client/$VERSION/)

--- a/.travis/pulpcore_playbook.yml
+++ b/.travis/pulpcore_playbook.yml
@@ -22,6 +22,7 @@
     pulp_db_user: 'travis'
     pulp_db_password: ''
     pulp_preq_packages: []
+    pulp_content_host: 'localhost:24816'
   environment:
     DJANGO_SETTINGS_MODULE: pulpcore.app.settings
   roles:


### PR DESCRIPTION
Solution: remove extra . from the version string

This also brings in the 'pulp_content_host' setting for the playbook used
to install pulpcore on Travis.

[noissue]