### PR TITLE
Remove unused field Remote.validate

### DIFF
--- a/pulpcore/app/models/repository.py
+++ b/pulpcore/app/models/repository.py
@@ -58,7 +58,6 @@ class Remote(MasterModel):
 
         name (models.CharField): The remote name.
         url (models.TextField): The URL of an external content source.
-        validate (models.BooleanField): If True, the plugin will validate imported files.
         ssl_ca_certificate (models.FileField): A PEM encoded CA certificate used to validate the
             server certificate presented by the external source.
         ssl_client_certificate (models.FileField): A PEM encoded client certificate used
@@ -97,7 +96,6 @@ class Remote(MasterModel):
     name = models.CharField(db_index=True, unique=True, max_length=255)
 
     url = models.TextField()
-    validate = models.BooleanField(default=True)
 
     ssl_ca_certificate = models.TextField(null=True)
     ssl_client_certificate = models.TextField(null=True)

--- a/pulpcore/app/serializers/repository.py
+++ b/pulpcore/app/serializers/repository.py
@@ -55,10 +55,6 @@ class RemoteSerializer(MasterModelSerializer):
     url = serializers.CharField(
         help_text='The URL of an external content source.',
     )
-    validate = serializers.BooleanField(
-        help_text='If True, the plugin will validate imported artifacts.',
-        required=False,
-    )
     ssl_ca_certificate = SecretCharField(
         help_text='A string containing the PEM encoded CA certificate used to validate the server '
                   'certificate presented by the remote server. All new line characters must be '
@@ -121,9 +117,10 @@ class RemoteSerializer(MasterModelSerializer):
         abstract = True
         model = models.Remote
         fields = MasterModelSerializer.Meta.fields + (
-            'name', 'url', 'validate', 'ssl_ca_certificate', 'ssl_client_certificate',
-            'ssl_client_key', 'ssl_validation', 'proxy_url', 'username', 'password',
-            '_last_updated', 'download_concurrency', 'policy')
+            'name', 'url', 'ssl_ca_certificate', 'ssl_client_certificate', 'ssl_client_key',
+            'ssl_validation', 'proxy_url', 'username', 'password', '_last_updated',
+            'download_concurrency', 'policy'
+        )
 
 
 class RepositorySyncURLSerializer(serializers.Serializer):


### PR DESCRIPTION
This field was intended for plugin use, but so far plugins validate
unconditionally. For now, we remove the field from core but plugins can
add it on their own if they have a use for it.

https://pulp.plan.io/issues/4714
fixes #4714