### PR TITLE
Core's Remote only validates 'immediate'

### DIFF
--- a/CHANGES/4990.bugfix
+++ b/CHANGES/4990.bugfix
@@ -1,0 +1,1 @@
+Core's serializer should only validate when policy='immediate' (the default).

--- a/CHANGES/4990.doc
+++ b/CHANGES/4990.doc
@@ -1,0 +1,1 @@
+The term 'lazy' and 'Lazy' is replaced with 'on-demand' and 'On-Demand' respectively.

--- a/docs/components.rst
+++ b/docs/components.rst
@@ -38,8 +38,9 @@ Content Serving Application
 
 An aiohttp.server based application that serves content to clients. The content could be
 :term:`Artifacts<artifact>` already downloaded and saved in Pulp, or
-:term:`lazy content units<lazy content>`. When serving :term:`lazy content units<lazy content>` the
-downloading also happens from within this component as well.
+:term:`on-demand content units<on-demand content>`. When serving
+:term:`on-demand content units<on-demand content>` the downloading also happens from within this
+component as well.
 
 .. note::
 

--- a/docs/glossary.rst
+++ b/docs/glossary.rst
@@ -27,10 +27,10 @@ Glossary
         :term:`Repository Version <RepositoryVersion>`, a :term:`Repository`, or a
         :term:`publications<publication>`.
 
-    lazy content
+    on-demand content
         A :term:`content unit<content>` that was synchronized into Pulp but is missing one or more
-        :term:`Artifacts<artifact>`. Lazy content is associated with a :term:`Remote` that knows how
-        to download those :term:`Artifacts<artifact>`.
+        :term:`Artifacts<artifact>`. On-demand content is associated with a :term:`Remote` that
+        knows how to download those :term:`Artifacts<artifact>`.
 
     plugin
         A `Django <https://docs.djangoproject.com>`_ app that exends :term:`pulpcore` to manage one

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -28,7 +28,7 @@ documenting all workflows**. Some common plugin workflows the are:
 * synchronize from an external repository
 * add/remove content manually
 * publish and host a repository version, enabling a client to download content
-* deferred download (aka, lazy sync)
+* deferred download (aka, on-demand sync)
 * lifecycle management
 
 Pulpcore Documentation

--- a/docs/workflows/index.rst
+++ b/docs/workflows/index.rst
@@ -11,7 +11,7 @@ assumes that the reader is familiar with the fundamentals discussed in the :doc:
    :maxdepth: 2
 
    upload-publish
-   lazy-downloading
+   on-demand-downloading
    promotion
    scheduling-tasks
    exposing-content

--- a/docs/workflows/on-demand-downloading.rst
+++ b/docs/workflows/on-demand-downloading.rst
@@ -1,5 +1,5 @@
-Lazy Downloading
-================
+On-Demand Downloading
+=====================
 
 Overview
 --------
@@ -24,7 +24,7 @@ on_demand
 
   This mode is ideal for saving disk space because Pulp never downloads and stores
   :term:`Artifacts<artifact>` that clients don't need. Units created from this mode are
-  :term:`lazy content units<lazy content>`.
+  :term:`on-demand content units<on-demand content>`.
 
 streamed
   When performing the sync, do not download any :term:`Artifacts<artifact>` now. Download all
@@ -35,21 +35,26 @@ streamed
 
   This mode is ideal for content that you especially don't want Pulp to store over time. For
   instance, syncing from a nightly repo would cause Pulp to store every nightly ever produced which
-  is likely not valuable. Units created from this mode are :term:`lazy content units<lazy content>`.
+  is likely not valuable. Units created from this mode are
+  :term:`on-demand content units<on-demand content>`.
 
 
-Does Plugin X Support Lazy?
----------------------------
+Does Plugin X Support 'on_demand' or 'streamed'?
+------------------------------------------------
 
-Plugins do have to enable support for these modes, so check that plugin's documentation to be sure.
-See the `Pulp Plugin API <../../pulpcore-plugin/nightly/>`_ documentation for more details on how to
-add lazy support to a plugin.
+Unless a plugin has enabled either the 'on_demand' or 'streamed' values for the `policy` attribute
+you will receive an error. Check that plugin's documentation also.
+
+.. note::
+
+   Want to add on-demand support to your plugin? See the `Pulp Plugin API <../../pulpcore-plugin/
+   nightly/>`_ documentation for more details on how to add on-demand support to a plugin.
 
 
-Associating Lazy Content with Additional Repository Versions
-------------------------------------------------------------
+Associating On-Demand Content with Additional Repository Versions
+-----------------------------------------------------------------
 
-A :term:`lazy content unit<lazy content>` can be associated and unassociated from a
+An :term:`on-demand content unit<on-demand content>` can be associated and unassociated from a
 :term:`repository version<RepositoryVersion>` just like a normal unit. Note that the original
 :term:`Remote` will be used to download content should a client request it, even as that content is
 made available in multiple places.

--- a/pulpcore/app/serializers/repository.py
+++ b/pulpcore/app/serializers/repository.py
@@ -111,9 +111,10 @@ class RemoteSerializer(MasterModelSerializer):
         min_value=1
     )
     policy = serializers.ChoiceField(
-        help_text="The policy to use when downloading content. The possible values include: "
-                  "'immediate', 'on_demand', and 'cache_only'. 'immediate' is the default.",
-        choices=models.Remote.POLICY_CHOICES,
+        help_text="The policy to use when downloading content.",
+        choices=(
+            (models.Remote.IMMEDIATE, 'When syncing, download all metadata and content now.')
+        ),
         default=models.Remote.IMMEDIATE
     )
 


### PR DESCRIPTION
The core's default mode policy='immediate' is the only one that is
guaranteed by all plugins to implement. Users of plugins that haven't
enabled additional modes should receive an error when then create a
Remote.

Now users using policy != 'immediate' will receive an error.

https://pulp.plan.io/issues/4990
closes #4990
