### PR TITLE
Check out PR after fetching it

### DIFF
--- a/.travis/pre_before_install.sh
+++ b/.travis/pre_before_install.sh
@@ -6,6 +6,7 @@ git clone https://github.com/pulp/pulp_file.git
 if [ -n "$PULP_FILE_PR_NUMBER" ]; then
   cd pulp_file
   git fetch origin +refs/pull/$PULP_FILE_PR_NUMBER/merge
+  git checkout FETCH_HEAD
   cd ..
 fi
 
@@ -13,6 +14,7 @@ git clone https://github.com/pulp/pulp-certguard.git
 if [ -n "$PULP_CERTGUARD_PR_NUMBER" ]; then
   cd pulp-certguard
   git fetch origin +refs/pull/$PULP_CERTGUARD_PR_NUMBER/merge
+  git checkout FETCH_HEAD
   cd ..
 fi
 


### PR DESCRIPTION
In our travis scripts, we're only fetching pulp_file and certguards PRs
but we're not actually checking them out.

[noissue]

Please be sure you have read our documentation on creating PRs:
https://docs.pulpproject.org/en/3.0/nightly/contributing/pull-request-walkthrough.html
