### PR TITLE
Adjust CONTENT_HOST setting default to ''

### DIFF
--- a/CHANGES/4945.bugfix
+++ b/CHANGES/4945.bugfix
@@ -1,0 +1,2 @@
+GET of a ``Distribution`` without configuring the ``CONTENT_HOST`` setting no longer causes a 500
+error.

--- a/CHANGES/4945.removal
+++ b/CHANGES/4945.removal
@@ -1,0 +1,1 @@
+Switched the default of the ``CONTENT_HOST`` setting from ``None`` to ``''``.

--- a/pulpcore/app/settings.py
+++ b/pulpcore/app/settings.py
@@ -201,7 +201,7 @@ LOGGING = {
     }
 }
 
-CONTENT_HOST = None
+CONTENT_HOST = ''
 CONTENT_PATH_PREFIX = '/pulp/content/'
 CONTENT_APP_TTL = 30
 


### PR DESCRIPTION
The CONTENT_HOST setting was hard to use with the default of `None`. It
would first be checked in many places, and for example with
``Distribution`` it would give a 500.

This makes the default '' which should be much easier to use in many
places.

https://pulp.plan.io/issues/4945
closes #4945

Please be sure you have read our documentation on creating PRs:
https://docs.pulpproject.org/en/3.0/nightly/contributing/pull-request-walkthrough.html
