### PR TITLE
Pin DRF to < 3.10 due to breaking changes

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ requirements = [
     'coreapi',
     'Django~=2.2',  # LTS version, switch only if we have a compelling reason to
     'django-filter',
-    'djangorestframework',
+    'djangorestframework<3.10',
     'djangorestframework-queryfields',
     'drf-nested-routers',
     'drf-yasg',


### PR DESCRIPTION
We cannot fix the incompatibility yet because another dependency,
drf-yasg does not support drf 3.10 yet.
https://github.com/axnsan12/drf-yasg/issues/410

https://pulp.plan.io/issues/5125
re #5125