### PR TITLE
Implement delete method for uploads

### DIFF
--- a/CHANGES/5092.bugfix
+++ b/CHANGES/5092.bugfix
@@ -1,0 +1,1 @@
+Allow user to delete uploaded content from a local file system when the artifact creation fails

--- a/pulpcore/app/models/upload.py
+++ b/pulpcore/app/models/upload.py
@@ -49,6 +49,17 @@ class Upload(Model):
             self._sha256 = sha256.hexdigest()
         return self._sha256
 
+    def delete(self, *args, **kwargs):
+        """
+        Deletes Upload model and the file associated with the model
+
+        Args:
+            args (list): list of positional arguments for Model.delete()
+            kwargs (dict): dictionary of keyword arguments to pass to Model.delete()
+        """
+        super().delete(*args, **kwargs)
+        self.file.delete(save=False)
+
 
 class UploadChunk(Model):
     """


### PR DESCRIPTION
The method delete() was redefined in order to prevent
an accumulation of an uploaded content which was not
associated with an artifact. Before this commit, data
were deleted from the database, but not from the local
file system.

closes #5092
https://pulp.plan.io/issues/5092
