### PR TITLE
pin drf-yasg due to breaking changes on DRF

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ requirements = [
     'djangorestframework<3.10',
     'djangorestframework-queryfields',
     'drf-nested-routers',
-    'drf-yasg',
+    'drf-yasg<1.16.1',
     'gunicorn',
     'PyYAML',
     'rq~=1.0',


### PR DESCRIPTION
`drf-yasg` was updated due to `DRF 3.10`:
https://github.com/axnsan12/drf-yasg/releases
Which now breaks like this:
```
Traceback (most recent call last):
  File "/usr/local/lib/pulp/lib64/python3.6/site-packages/rest_framework/settings.py", line 183, in import_from_string
    module = import_module(module_path)
  File "/usr/lib64/python3.6/importlib/__init__.py", line 126, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
  File "<frozen importlib._bootstrap>", line 994, in _gcd_import
  File "<frozen importlib._bootstrap>", line 971, in _find_and_load
  File "<frozen importlib._bootstrap>", line 955, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 665, in _load_unlocked
  File "<frozen importlib._bootstrap_external>", line 678, in exec_module
  File "<frozen importlib._bootstrap>", line 219, in _call_with_frames_removed
  File "/home/vagrant/devel/pulpcore/pulpcore/app/openapigenerator.py", line 6, in <module>
    from drf_yasg.generators import OpenAPISchemaGenerator
  File "/usr/local/lib/pulp/lib64/python3.6/site-packages/drf_yasg/generators.py", line 16, in <module>
    from packaging.version import Version
ModuleNotFoundError: No module named 'packaging'
```