### PR TITLE
Fix broken urls on configuration page

### DIFF
--- a/CHANGES/5160.doc
+++ b/CHANGES/5160.doc
@@ -1,0 +1,1 @@
+Fix broken urls in the ``/installation/configuration.html#settings`` area.

--- a/docs/installation/configuration.rst
+++ b/docs/installation/configuration.rst
@@ -42,9 +42,9 @@ Settings
 
 Pulp uses three types of settings:
 
-* `Django settings <django-settings>`_ Pulp is configuring
-* `Pulp defined settings <pulp-settings>`_
-* `RQ settings <rq-settings>`_ Pulp is using
+* :ref:`Django settings <django-settings>` Pulp is configuring
+* :ref:`Pulp defined settings <pulp-settings>`
+* :ref:`RQ settings <rq-settings>` Pulp is using
 
 
 .. _django-settings:


### PR DESCRIPTION
Three urls were broken due to using an absolute url style instead of a
`:ref:` syntax.

https://pulp.plan.io/issues/5160
closes #5160

