### PR TITLE
Fetch all fields when initializing a serializer

### DIFF
--- a/CHANGES/4722.bugfix
+++ b/CHANGES/4722.bugfix
@@ -1,0 +1,1 @@
+Allow user to filter created resources without providing _href in a query

--- a/pulpcore/app/serializers/task.py
+++ b/pulpcore/app/serializers/task.py
@@ -23,9 +23,11 @@ class CreatedResourceSerializer(RelatedField):
                 return None
         except AttributeError:
             pass
-        request = self.context['request']
         viewset = get_viewset_for_model(data.content_object)
-        serializer = viewset.serializer_class(data.content_object, context={'request': request})
+
+        # serializer contains all serialized fields because we are passing
+        # 'None' to the request's context
+        serializer = viewset.serializer_class(data.content_object, context={'request': None})
         return serializer.data.get('_href')
 
     class Meta:


### PR DESCRIPTION
When a user used _href within the fields selection,
the serializer could fetch a correct value from
_href. This commit removes a need to specify _href
while filtering fields from the response.

When the data model will change, this may cause
performance drawbacks due to serializing all fields
of Task objects.

closes #4722
https://pulp.plan.io/issues/4722
