### PR TITLE
Change the download_concurrency to fix test failures

### DIFF
--- a/pulpcore/tests/functional/api/using_plugin/utils.py
+++ b/pulpcore/tests/functional/api/using_plugin/utils.py
@@ -63,6 +63,8 @@ def gen_file_remote(url=None, **kwargs):
     if url is None:
         url = FILE_FIXTURE_MANIFEST_URL
 
+    kwargs['download_concurrency'] = 2
+
     return gen_remote(url, **kwargs)
 
 


### PR DESCRIPTION
Pulp is failing in Travis due to connection problems. It appears that
the environment is overwhelmed and will not issue new sockets for
connections to fedorapeople.

fixes #5221

Please be sure you have read our documentation on creating PRs:
https://docs.pulpproject.org/en/3.0/nightly/contributing/pull-request-walkthrough.html
