### PR TITLE
containers: Support pip install from Travis host dirs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,6 @@ docs/api.yaml
 
 # Overriden variables
 containers/vars/vars.yaml
+
+# Generated Dockerfiles
+containers/images/pulp/Dockerfile.*

--- a/containers/README.md
+++ b/containers/README.md
@@ -21,6 +21,8 @@ The images can be built with the help of an Ansible playbook. To build the image
 
 See `vars/defaults.yaml` for how to customize the "images" variable (data structure.)
 
+WARNING: Due to a limitation of Docker (but not Podman), Docker will copy the entire parent directory of "pulpcore" during build (the "build context.") This could slow your system down, exhaust disk space, or copy sensitive data you do not want copied. If using Docker, you probably want to clone pulpcore into a new parent directory, or one with the other pulp repos under it.
+
 ## Push Image to Registry
 
 The built image can be pushed to a registry using an Ansible playbook. The default configuration will attempt to push the images to `quay.io/pulp`:

--- a/containers/build.yaml
+++ b/containers/build.yaml
@@ -8,10 +8,17 @@
   tasks:
     - import_tasks: common_tasks.yaml
 
+    - name: Generate per-image Dockerfiles from the Dockerfile template
+      template:
+        src: images/pulp/Dockerfile.j2
+        dest: "images/pulp/Dockerfile.{{ item.key }}"
+      with_dict: "{{ images }}"
+
     - name: 'Build images'
-      command: "{{ container_cli }} build --network host --no-cache --build-arg VERSION={{ item.value.tag }} --build-arg PULPCORE={{ item.value.pulpcore | default('pulpcore') }} --build-arg PULPCORE_PLUGIN={{ item.value.pulpcore_plugin | default('pulpcore-plugin') }} --build-arg PLUGINS=\"{{ item.value.plugins | default([]) | join(' ') }}\" -t {{ item.value.image_name }}:{{ item.value.tag }} ."
-      args:
-        chdir: images/pulp
+      # We build from the ../.. (parent dir of pulpcore git repo) Docker build
+      # "context" so that repos like pulpcore-plugin are accessible to Docker
+      # build. So that PR branches can be used via relative paths.
+      command: "{{ container_cli }} build --network host --no-cache -t {{ item.value.image_name }}:{{ item.value.tag }} -f images/pulp/Dockerfile.{{ item.key }} ../.."
       with_dict: "{{ images }}"
 
     - name: 'Tag images'

--- a/containers/images/pulp/Dockerfile.j2
+++ b/containers/images/pulp/Dockerfile.j2
@@ -1,9 +1,5 @@
 FROM fedora:30
 
-ARG PULPCORE
-ARG PULPCORE_PLUGIN
-ARG PLUGINS
-
 # https://superuser.com/questions/959380/how-do-i-install-generate-all-locales-on-fedora
 # This may not be necessary anymore because Fedora 30, unlike CentOS 7, has
 # glibc subpackages like glibc-langpack-en.
@@ -52,10 +48,38 @@ RUN ln -s /usr/bin/pip3 /usr/local/bin/pip
 RUN mkdir -p /etc/pulp
 
 RUN pip install gunicorn
-RUN pip install $PULPCORE
-RUN pip install $PULPCORE_PLUGIN
-RUN pip install ${PULPCORE}[postgres]
-RUN test -z "$PLUGINS" || pip install $PLUGINS
+
+{% if ( item.value.pulpcore is defined and
+        item.value.pulpcore.startswith('./') ) %}
+COPY {{ item.value.pulpcore }} /tmp/{{ item.value.pulpcore | basename }}
+RUN pip install /tmp/{{ item.value.pulpcore | basename }}
+RUN pip install /tmp/{{ item.value.pulpcore | basename }}[postgres]
+RUN rm -rf /tmp/{{ item.value.pulpcore | basename }}
+{% else %}
+RUN pip install {{ item.value.pulpcore | default('pulpcore') }}
+RUN pip install {{ item.value.pulpcore | default('pulpcore') }}[postgres]
+{% endif %}
+
+{% if ( ( item.value.pulpcore_plugin is defined ) and
+        ( item.value.pulpcore_plugin.startswith('./') ) ) %}
+COPY {{ item.value.pulpcore_plugin }} /tmp/{{ item.value.pulpcore_plugin | basename }}
+RUN pip install /tmp/{{ item.value.pulpcore_plugin | basename }}
+RUN rm -rf /tmp/{{ item.value.pulpcore_plugin | basename }}
+{% else %}
+RUN pip install {{ item.value.pulpcore_plugin | default('pulpcore-plugin') }}
+{% endif %}
+
+{% if item.value.plugins is defined %}
+{% for plugin in item.value.plugins %}
+{% if plugin.startswith('./') %}
+COPY {{ plugin }} /tmp/{{ plugin | basename }}
+RUN pip install /tmp/{{ plugin | basename }}
+RUN rm -rf /tmp/{{ plugin | basename }}
+{% else %}
+RUN pip install {{ plugin }}
+{% endif %}
+{% endfor %}
+{% endif %}
 
 RUN mkdir -p /usr/local/lib/python3.7/site-packages/pulpcore/app/migrations
 RUN mkdir -p /usr/local/lib/python3.7/site-packages/pulp_file/app/migrations
@@ -66,13 +90,13 @@ RUN mkdir -p /usr/local/lib/python3.7/site-packages/pulp_maven/app/migrations
 RUN mkdir -p /usr/local/lib/python3.7/site-packages/pulp_python/app/migrations
 RUN mkdir -p /usr/local/lib/python3.7/site-packages/pulp_rpm/app/migrations
 
-COPY container-assets/wait_on_postgres.py /usr/bin/wait_on_postgres.py
-COPY container-assets/wait_on_database_migrations.sh /usr/bin/wait_on_database_migrations.sh
-COPY container-assets/pulp-common-entrypoint.sh /pulp-common-entrypoint.sh
-COPY container-assets/pulp-api /usr/bin/pulp-api
-COPY container-assets/pulp-content /usr/bin/pulp-content
-COPY container-assets/pulp-resource-manager /usr/bin/pulp-resource-manager
-COPY container-assets/pulp-worker /usr/bin/pulp-worker
+COPY pulpcore/containers/images/pulp/container-assets/wait_on_postgres.py /usr/bin/wait_on_postgres.py
+COPY pulpcore/containers/images/pulp/container-assets/wait_on_database_migrations.sh /usr/bin/wait_on_database_migrations.sh
+COPY pulpcore/containers/images/pulp/container-assets/pulp-common-entrypoint.sh /pulp-common-entrypoint.sh
+COPY pulpcore/containers/images/pulp/container-assets/pulp-api /usr/bin/pulp-api
+COPY pulpcore/containers/images/pulp/container-assets/pulp-content /usr/bin/pulp-content
+COPY pulpcore/containers/images/pulp/container-assets/pulp-resource-manager /usr/bin/pulp-resource-manager
+COPY pulpcore/containers/images/pulp/container-assets/pulp-worker /usr/bin/pulp-worker
 
 
 ENTRYPOINT ["/pulp-common-entrypoint.sh"]

--- a/containers/vars/defaults.yaml
+++ b/containers/vars/defaults.yaml
@@ -18,12 +18,20 @@
 #           appended to the end, so for git URLs, keep #egg=pulpcore on the end.
 #           Defaults to "pulpcore" (latest stable from PyPi) via playbook logic.
 #           To keep the default, leave undefined, do not let it be a null value.
+#           For paths on disk, specify paths relative to the parent dir of
+#           "pulpcore", beginning with "./", such as "./pulpcore".
 # pulpcore-plugin: The pip install string for pulpcore-plugin.
 #                  Defaults to "pulpcore-plugin" (latest stable from PyPi) via
 #                  playbook logic. To keep the default, leave undefined, do not
 #                  let it be a null value.
+#                  For paths on disk, specify paths relative to the parent dir
+#                  of "pulpcore", beginning with "./", such as
+#                  "./pulpcore-plugin".
 # plugins: List of pip install strings for plugins.
 #          To specify no plugins, leave undefined, do not let it be a null value.
+#          For paths on disk, specify paths relative to the parent dir
+#          of "pulpcore", beginning with "./", such as
+#          "./pulp_rpm".
 #
 # registry: The image registry to push to, and to tag for.
 # project: The project (username/organization) on the registry to push to,


### PR DESCRIPTION
Implementation includes:
Copying the host dirs into the Docker build environment

Setting the Docker build "context" to the parent dir of the checked out pulpcore
(So that it and all the other cloned repos can be accessed during docker build.)

Users must specify host dirs as relative to the parent dir of pulpcore,
and begin them with "./". This triggers copying logic.

Templating the Dockerfile with jinja2, with some Ansible-bundled filters.
(We've outgrown what env vars in the Dockerfile can do.)

Remove unused Dockerfile variable VERSION

.travis/post_script.sh: Build pulpcore & pulpcore-plugin from Travis host dirs

[noissue]

Partially implements:
re: #5062
https://pulp.plan.io/issues/5062
Create pulpcore and pulp_file container images automatically via CI
