### PR TITLE
Avoid collisions between plugin models

### DIFF
--- a/CHANGES/4681.misc
+++ b/CHANGES/4681.misc
@@ -1,0 +1,1 @@
+Avoid collisions between plugin models.


### PR DESCRIPTION
Making mandatory declaring default_related_name
closes #4681

https://pulp.plan.io/issues/4681

# NOTE: DO NOT MERGE UNTIL AUGUST 19, 2019
