### PR TITLE
Return a list of reserved resources

### DIFF
--- a/pulpcore/app/viewsets/publication.py
+++ b/pulpcore/app/viewsets/publication.py
@@ -86,4 +86,4 @@ class BaseDistributionViewSet(NamedModelViewSet,
 
     def async_reserved_resources(self, instance):
         """Return resource that locks all Distributions."""
-        return "/api/v3/distributions/"
+        return ["/api/v3/distributions/"]


### PR DESCRIPTION
In this commit, a list is returned from the method,
instead of a string. In the past, the string was
decomposed into mutliple characters. These characters
were used as unique identifiers that locked resources
(https://github.com/pulp/pulpcore/blob/452ab51d6195a0c0c4cdeb8220b37afb2a747ca5/pulpcore/tasking/tasks.py#L192).

[noissue]
