### PR TITLE
Add test to sync different remotes same repository

### DIFF
--- a/pulpcore/tests/functional/api/using_plugin/constants.py
+++ b/pulpcore/tests/functional/api/using_plugin/constants.py
@@ -10,6 +10,22 @@ from pulp_smash.pulp3.constants import (
     CONTENT_PATH,
 )
 
+
+DOCKER_V2_FEED_URL = 'https://registry-1.docker.io'
+"""The URL to a V2 Docker registry."""
+
+# hello-world is the smallest docker image available on docker hub 1.84kB
+DOCKER_UPSTREAM_NAME = 'hello-world'
+"""The name of a Docker repository"""
+
+DOCKER_CONTENT_MANIFEST_NAME = 'docker.manifest'
+
+DOCKER_CONTENT_BLOB_NAME = 'docker.manifest-blob'
+
+DOCKER_CONTENT_TAG_NAME = 'docker.manifest-tag'
+
+DOCKER_REMOTE_PATH = urljoin(BASE_REMOTE_PATH, 'docker/docker/')
+
 FILE_CONTENT_NAME = 'file.file'
 
 FILE_CONTENT_PATH = urljoin(CONTENT_PATH, 'file/files/')


### PR DESCRIPTION
Add tests to sync different remotes: docker, rpm, file in the same
repository.

https://pulp.plan.io/issues/4274
closes:#4274
