### PR TITLE
Switch Pagination default to LimitOffset Style

### DIFF
--- a/CHANGES/5324.bugfix
+++ b/CHANGES/5324.bugfix
@@ -1,0 +1,1 @@
+Switch default DRF pagination to use LimitOffset style instead of Page ID.

--- a/CHANGES/5324.removal
+++ b/CHANGES/5324.removal
@@ -1,0 +1,2 @@
+All previous bindings expect a different pagination style and are not compatible with the pagination
+changes made. Newer bindings are available and should be used.

--- a/pulpcore/app/pagination.py
+++ b/pulpcore/app/pagination.py
@@ -1,22 +1,6 @@
 from rest_framework import pagination
 
 
-class IDPagination(pagination.PageNumberPagination):
-    """
-    Paginate an API view naively, based on the ID of objects being iterated over.
-
-    This assumes that the objects being iterated over have an 'id' field, that the value of this
-    field is a int, and that the field is indexed.
-
-    This assumption should be True for all Models inheriting `pulpcore.app.models.Model`, the Pulp
-    base Model class.
-
-    """
-    ordering = 'id'
-    page_size_query_param = 'page_size'
-    max_page_size = 5000
-
-
 class NamePagination(pagination.PageNumberPagination):
     """
     Paginate an API view based on the value of the 'name' field of objects being iterated over.

--- a/pulpcore/app/settings.py
+++ b/pulpcore/app/settings.py
@@ -116,7 +116,7 @@ WSGI_APPLICATION = 'pulpcore.app.wsgi.application'
 REST_FRAMEWORK = {
     'URL_FIELD_NAME': '_href',
     'DEFAULT_FILTER_BACKENDS': ('django_filters.rest_framework.DjangoFilterBackend',),
-    'DEFAULT_PAGINATION_CLASS': 'pulpcore.app.pagination.IDPagination',
+    'DEFAULT_PAGINATION_CLASS': 'rest_framework.pagination.LimitOffsetPagination',
     'PAGE_SIZE': 100,
     'DEFAULT_PERMISSION_CLASSES': ('rest_framework.permissions.IsAuthenticated',),
     'DEFAULT_AUTHENTICATION_CLASSES': (


### PR DESCRIPTION
The previous pagination was Page ID style and used a custom class from
Pulp to do so. This switches the default pagination class to a limit
offset style by default instead.

https://pulp.plan.io/issues/5324
closes #5324
