### PR TITLE
 Problem: container images randomly fail to build

### DIFF
--- a/containers/README.md
+++ b/containers/README.md
@@ -21,6 +21,8 @@ The images can be built with the help of an Ansible playbook. To build the image
 
 See `vars/defaults.yaml` for how to customize the "images" variable (data structure.)
 
+You can add `-e cache=false` to that command to prevent outdated image layers from being used.
+
 WARNING: Due to a limitation of Docker (but not Podman), Docker will copy the entire parent directory of "pulpcore" during build (the "build context.") This could slow your system down, exhaust disk space, or copy sensitive data you do not want copied. If using Docker, you probably want to clone pulpcore into a new parent directory, or one with the other pulp repos under it.
 
 ## Push Image to Registry

--- a/containers/build.yaml
+++ b/containers/build.yaml
@@ -20,6 +20,11 @@
       # build. So that PR branches can be used via relative paths.
       command: "{{ container_cli }} build --network host --no-cache -t {{ item.value.image_name }}:{{ item.value.tag }} -f images/pulp/Dockerfile.{{ item.key }} ../.."
       with_dict: "{{ images }}"
+      # Try 3x due to random failures to download RPMs from Fedora. Due to 2 bug
+      # so far that are getting fixed, but break builds in the meantime.
+      retries: 2
+      register: result
+      until: result.rc == 0
 
     - name: 'Tag images'
       command: "{{ container_cli }} tag {{ item.value.image_name }}:{{ item.value.tag }} {{ registry }}/{{ project }}/{{ item.value.image_name }}:{{ item.value.tag }}"

--- a/containers/build.yaml
+++ b/containers/build.yaml
@@ -18,7 +18,12 @@
       # We build from the ../.. (parent dir of pulpcore git repo) Docker build
       # "context" so that repos like pulpcore-plugin are accessible to Docker
       # build. So that PR branches can be used via relative paths.
-      command: "{{ container_cli }} build --network host --no-cache -t {{ item.value.image_name }}:{{ item.value.tag }} -f images/pulp/Dockerfile.{{ item.key }} ../.."
+      #
+      # We default to using the docker build / podman buildah cache, for
+      # 1-off-builds and Travis CI purposes (which has no cache across CI runs.)
+      # Run build.yaml with -e cache=false if your builds are using outdated
+      # layers.
+      command: "{{ container_cli }} build --network host --no-cache={{ not cache | default(true) | bool }} -t {{ item.value.image_name }}:{{ item.value.tag }} -f images/pulp/Dockerfile.{{ item.key }} ../.."
       with_dict: "{{ images }}"
       # Try 3x due to random failures to download RPMs from Fedora. Due to 2 bug
       # so far that are getting fixed, but break builds in the meantime.


### PR DESCRIPTION
Due to 2 bugs so far with accessing Fedora mirrors or servers via dnf.
Fedora is fixing them, but disrupts our development temporarily as we
implement specific workarounds.

Solution: Implement the generic workaround of retrying the image
build.

[noissue]