### PR TITLE
Problem: Container images randomly fail to build due to dnf HTTP2 error

### DIFF
--- a/containers/images/pulp/Dockerfile.j2
+++ b/containers/images/pulp/Dockerfile.j2
@@ -11,6 +11,12 @@ ENV LC_ALL=en_US.UTF-8
 ENV PYTHONUNBUFFERED=0
 ENV DJANGO_SETTINGS_MODULE=pulpcore.app.settings
 
+# We need this workaround to avoid random build failures until the Errata is
+# released and the F30 image is updated (last updated: 2019-08-25)
+# https://bodhi.fedoraproject.org/updates/FEDORA-2019-ae52a20ff6
+# avoid reporting spurious error in the HTTP2 framing layer (RHBZ#1690971)
+RUN rpm -q curl --queryformat=%{VERSION}-%{RELEASE} | grep -v 7.65.3-2 || dnf -y update curl --enablerepo=updates-testing || dnf -y update curl --enablerepo=updates-testing || dnf -y update curl --enablerepo=updates-testing || dnf -y update curl --enablerepo=updates-testing || dnf -y update curl --enablerepo=updates-testing && dnf clean all
+
 # The Fedora 30 image already has tsflags=nodocs set in dnf.conf
 # It already has pip
 #

--- a/containers/images/pulp/Dockerfile.j2
+++ b/containers/images/pulp/Dockerfile.j2
@@ -11,12 +11,6 @@ ENV LC_ALL=en_US.UTF-8
 ENV PYTHONUNBUFFERED=0
 ENV DJANGO_SETTINGS_MODULE=pulpcore.app.settings
 
-# We need this workaround / to avoid random build failures until the F30 image
-# is updated (last updated: 2019-08-01)
-# https://bodhi.fedoraproject.org/updates/FEDORA-2019-13479b151a
-# Allow to try baseurl multiple times (RhBug:1678588)
-# So that it will try different mirrors if one is in a bad (rsync) state
-RUN rpm -q librepo --queryformat=%{VERSION} | grep -v 1.10.2 || dnf -y update || dnf -y update || dnf -y update || dnf -y update || dnf -y update && dnf clean all
 # The Fedora 30 image already has tsflags=nodocs set in dnf.conf
 # It already has pip
 #


### PR DESCRIPTION
And we are currently working around it with a generic workaround
of retrying the image build.

solution: Implement a temporary workaround of installing the Fedora
curl Errata that fixes the dnf HTTP2 error:
https://bodhi.fedoraproject.org/updates/FEDORA-2019-ae52a20ff6

[noissue]