### PR TITLE
Problem: HTTP requests to containers hang over IPv6

### DIFF
--- a/containers/images/pulp/container-assets/pulp-api
+++ b/containers/images/pulp/container-assets/pulp-api
@@ -18,4 +18,9 @@ if [ -n "${PULP_ADMIN_PASSWORD}" ]; then
     django-admin reset-admin-password --password "${PULP_ADMIN_PASSWORD}"
 fi
 
-exec gunicorn -b 0.0.0.0:24817 pulpcore.app.wsgi:application
+# NOTE: Due to the Linux dual-stack functionality, this will listen on both IPv4
+# IPv6, even though netstat may seem to indicate it is IPv6 only.
+# Due to containers using network namespaces, even if the host has this disabled
+# with /proc/sys/net/ipv6/bindv6only=1, the container will still have
+# it enabled with /proc/sys/net/ipv6/bindv6only=0 .
+exec gunicorn --bind '[::]:24817' pulpcore.app.wsgi:application

--- a/containers/images/pulp/container-assets/pulp-content
+++ b/containers/images/pulp/container-assets/pulp-content
@@ -1,10 +1,15 @@
-#!/bin/bash
+#!/bin/bash -x
 
 /usr/bin/wait_on_postgres.py
 /usr/bin/wait_on_database_migrations.sh
 
+# NOTE: Due to the Linux dual-stack functionality, this will listen on both IPv4
+# IPv6, even though netstat may seem to indicate it is IPv6 only.
+# Due to containers using network namespaces, even if the host has this disabled
+# with /proc/sys/net/ipv6/bindv6only=1, the container will still have
+# it enabled with /proc/sys/net/ipv6/bindv6only=0 .
 exec gunicorn pulpcore.content:server \
---bind 0.0.0.0:24816 \
+--bind '[::]:24816' \
 --worker-class 'aiohttp.GunicornWebWorker' \
 -w 2 \
 --access-logfile -

--- a/containers/images/pulp/container-assets/pulp-resource-manager
+++ b/containers/images/pulp/container-assets/pulp-resource-manager
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/bash -x
 
 /usr/bin/wait_on_postgres.py
 /usr/bin/wait_on_database_migrations.sh

--- a/containers/images/pulp/container-assets/pulp-worker
+++ b/containers/images/pulp/container-assets/pulp-worker
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/bash -x
 
 /usr/bin/wait_on_postgres.py
 /usr/bin/wait_on_database_migrations.sh


### PR DESCRIPTION
Solution: Bind to IPv6, and thus impliclty IPv4.
This implicit listen can reliably happen in containers because of
network namespaces.

Also, standardize container script syntax.

Fixes: #5414
HTTP requests to containers hang over IPv6
https://pulp.plan.io/issues/5414

re: #5375
As a user, I can use a single script to install k3s and launch pulp-operator
https://pulp.plan.io/issues/5375