### PR TITLE
Problem: Containers are built when publishing plugin to PyPI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -53,6 +53,7 @@ after_failure:
 jobs:
   include:
     - stage: deploy-plugin-to-pypi
+      install: skip
       script: bash .travis/publish_plugin_pypi.sh
       if: tag IS present
     - stage: publish-beta-docs


### PR DESCRIPTION
Solution: Disable install phase for all deploy & publish steps.

Which is unnecessary, and slows down the CI.

Solution: regenerate with latest plugin-template

[noissue]

Note: I am only able to partially test this. On Travis mikeded333/pulpcore, the publishing task does not attempt to run the install script. However, it cannot push the docs due to lack of credentials (in Travis env vars.)
https://travis-ci.com/mikedep333/pulpcore/jobs/231988570#L565