### PR TITLE
Update REST API docs for `uploads_commit`

### DIFF
--- a/CHANGES/5190.doc
+++ b/CHANGES/5190.doc
@@ -1,0 +1,1 @@
+Update REST API docs for `uploads_commit`.

--- a/pulpcore/app/viewsets/upload.py
+++ b/pulpcore/app/viewsets/upload.py
@@ -97,7 +97,7 @@ class UploadViewSet(NamedModelViewSet,
     @action(detail=True, methods=['post'])
     def commit(self, request, pk):
         """
-        Generates a Task to commit the upload and create an artifact
+        Queues a Task that creates an Artifact, and the Upload gets deleted and cannot be re-used.
         """
         try:
             sha256 = request.data['sha256']


### PR DESCRIPTION
closes #5190
https://pulp.plan.io/issues/5190

Please be sure you have read our documentation on creating PRs:
https://docs.pulpproject.org/en/3.0/nightly/contributing/pull-request-walkthrough.html
