### PR TITLE
Remove the relative_path if not on serializer fields

### DIFF
--- a/pulpcore/app/serializers/content.py
+++ b/pulpcore/app/serializers/content.py
@@ -57,7 +57,7 @@ class SingleArtifactContentSerializer(BaseContentSerializer):
             validated_data (dict): Data to save to the database
         """
         artifact = validated_data.pop('artifact')
-        if "relative_path" in self.fields and self.fields["relative_path"].write_only:
+        if "relative_path" not in self.fields or self.fields["relative_path"].write_only:
             relative_path = validated_data.pop('relative_path')
         else:
             relative_path = validated_data.get('relative_path')


### PR DESCRIPTION
We also should pop the relative_path off validated_data if the
serializer doesn't have the relative_path as a field.

fixes #5445
https://pulp.plan.io/issues/5445

Please be sure you have read our documentation on creating PRs:
https://docs.pulpproject.org/en/3.0/nightly/contributing/pull-request-walkthrough.html
