### PR TITLE
Expose exclude_fields in the REST API schema

### DIFF
--- a/CHANGES/5519.feature
+++ b/CHANGES/5519.feature
@@ -1,0 +1,1 @@
+Expose `exclude_fields` the api schema and bindings to allow users to filter out fields.

--- a/CHANGES/5519.removal
+++ b/CHANGES/5519.removal
@@ -1,0 +1,1 @@
+Renamed `fields!` to `exclude_fields` since exclamation mark is a special char in many languages.

--- a/pulpcore/app/openapigenerator.py
+++ b/pulpcore/app/openapigenerator.py
@@ -274,6 +274,14 @@ class PulpAutoSchema(SwaggerAutoSchema):
                 type="string",
             )
             query.append(fields_paramenter)
+            not_fields_paramenter = Parameter(
+                name="exclude_fields",
+                in_="query",
+                description="A list of fields to exclude from the response.",
+                required=False,
+                type="string",
+            )
+            query.append(not_fields_paramenter)
         parameters = body + query
         parameters = filter_none(parameters)
         parameters = self.add_manual_parameters(parameters)

--- a/pulpcore/app/serializers/base.py
+++ b/pulpcore/app/serializers/base.py
@@ -31,6 +31,9 @@ class ModelSerializer(QueryFieldsMixin, serializers.HyperlinkedModelSerializer):
     This ensures that all Serializers provide values for the '_href` field.
     """
 
+    # default is 'fields!' which doesn't work in the bindings for some langs
+    exclude_arg_name = "exclude_fields"
+
     class Meta:
         fields = ('_href', '_created')
 

--- a/pulpcore/tests/functional/api/test_crud_repos.py
+++ b/pulpcore/tests/functional/api/test_crud_repos.py
@@ -76,7 +76,7 @@ class CRUDRepoTestCase(unittest.TestCase):
     def test_02_read_repo_without_specific_fields(self):
         """Read a repo by its href excluding specific fields."""
         # requests doesn't allow the use of != in parameters.
-        url = '{}?fields!=created,name'.format(self.repo['_href'])
+        url = '{}?exclude_fields=created,name'.format(self.repo['_href'])
         repo = self.client.get(url)
         response_fields = repo.keys()
         self.assertNotIn('created', response_fields)

--- a/pulpcore/tests/functional/api/test_tasks.py
+++ b/pulpcore/tests/functional/api/test_tasks.py
@@ -66,7 +66,7 @@ class TasksTestCase(unittest.TestCase):
     def test_02_read_task_without_specific_fields(self):
         """Read a task by its href excluding specific fields."""
         # requests doesn't allow the use of != in parameters.
-        url = '{}?fields!=state'.format(self.task['_href'])
+        url = '{}?exclude_fields=state'.format(self.task['_href'])
         task = self.client.get(url)
         self.assertNotIn('state', task.keys())
 

--- a/pulpcore/tests/functional/api/using_plugin/test_crd_publications.py
+++ b/pulpcore/tests/functional/api/using_plugin/test_crd_publications.py
@@ -85,7 +85,7 @@ class PublicationsTestCase(unittest.TestCase):
     def test_02_read_publication_without_specific_fields(self):
         """Read a publication by its href excluding specific fields."""
         # requests doesn't allow the use of != in parameters.
-        url = '{}?fields!=distributions'.format(self.publication['_href'])
+        url = '{}?exclude_fields=distributions'.format(self.publication['_href'])
         publication = self.client.get(url)
         self.assertNotIn('distributions', publication.keys())
 


### PR DESCRIPTION
fixes #5519

Please be sure you have read our documentation on creating PRs:
https://docs.pulpproject.org/en/3.0/nightly/contributing/pull-request-walkthrough.html
