### PR TITLE
Fix Detail viewsets erroneous namespacing

### DIFF
--- a/CHANGES/5533.bugfix
+++ b/CHANGES/5533.bugfix
@@ -1,0 +1,1 @@
+Fix erroneous namespacing for Detail viewsets that don't inherit from Master viewsets.

--- a/CHANGES/5533.removal
+++ b/CHANGES/5533.removal
@@ -1,0 +1,1 @@
+Removed the logic that automatically defines the namespace for Detail model viewsets when there is no Master viewset.

--- a/pulpcore/app/viewsets/base.py
+++ b/pulpcore/app/viewsets/base.py
@@ -189,12 +189,16 @@ class NamedModelViewSet(viewsets.GenericViewSet):
             # so start finding parents at the second item, index 1.
             for eldest in reversed(cls.mro()):
                 try:
-                    if eldest.endpoint_name is not None:
+                    if eldest is not cls and eldest.endpoint_name is not None:
                         master_endpoint_name = eldest.endpoint_name
                         break
                 except AttributeError:
                     # no endpoint_name defined, need to get more specific in the MRO
                     continue
+
+            # if there is no master viewset or master endpoint name, just use endpoint_name
+            if master_endpoint_name is None:
+                return [cls.endpoint_name]
 
             # prepend endpoint of a plugin model with its Django app label
             app_label = cls.queryset.model._meta.app_label


### PR DESCRIPTION
If there is no Master viewset, don't automatically try to namespace the
viewset endpoint as it erroneously namespaces the endpoint with the
detail viewset's endpoint_name.

fixes #5533
https://pulp.plan.io/issues/5533

Please be sure you have read our documentation on creating PRs:
https://docs.pulpproject.org/en/3.0/nightly/contributing/pull-request-walkthrough.html
