### PR TITLE
Fix open API generator crash on hidden field

### DIFF
--- a/pulpcore/app/openapigenerator.py
+++ b/pulpcore/app/openapigenerator.py
@@ -258,7 +258,9 @@ class PulpAutoSchema(SwaggerAutoSchema):
 
         multipart = ['multipart/form-data', 'application/x-www-form-urlencoded']
         if self.method != 'GET':
-            if 'file' in [param['type'] for param in self.get_request_body_parameters(multipart)]:
+            request_params = self.get_request_body_parameters(multipart)
+            type_list = [param['type'] for param in request_params if param]
+            if 'file' in type_list:
                 # automatically set the media type to form data if there's a file
                 # needed due to https://github.com/axnsan12/drf-yasg/issues/386
                 consumes = multipart


### PR DESCRIPTION
If a plugin uses a serializer with a HiddenField, the generator
crashed because it did not expect a None value for a field.

Fix this by catching the None case.

[noissue]
