### PR TITLE
Problem: Container builds fail on Ansible 2.9

### DIFF
--- a/containers/common_tasks.yaml
+++ b/containers/common_tasks.yaml
@@ -6,7 +6,7 @@
 
 - set_fact:
     container_cli: 'podman'
-  when: podman_exists | success
+  when: podman_exists is success
 
 - name: Check if vars.yaml was created by the user
   stat:


### PR DESCRIPTION
Solution: Use Ansible 2.5+ test syntax rather than the deprecated test
syntax, which is now removed (and gets confused with filter syntax) on
 2.9.

[noissue]

Please be sure you have read our documentation on creating PRs:
https://docs.pulpproject.org/en/3.0/nightly/contributing/pull-request-walkthrough.html
