### PR TITLE
Add repo_key support for `add_content`

### DIFF
--- a/CHANGES/5008.misc
+++ b/CHANGES/5008.misc
@@ -1,0 +1,1 @@
+Adding the internals of `repo_key` to `add_content_unit` implementation.

--- a/pulpcore/app/models/content.py
+++ b/pulpcore/app/models/content.py
@@ -244,6 +244,7 @@ class Content(MasterModel, QueryMixin):
         _artifacts (models.ManyToManyField): Artifacts related to Content through ContentArtifact
     """
     TYPE = 'content'
+    repo_key = ()
 
     _artifacts = models.ManyToManyField(Artifact, through='ContentArtifact')
 


### PR DESCRIPTION
The `Content` model now supports a `repo_key` attribute which defaults
to (). Plugin writers can specify this, and the tuple field names will
automatically replace another unit of the same type with these field
names.

Required PR: https://github.com/pulp/pulp_file/pull/290

https://pulp.plan.io/issues/5008
closes #5008