### PR TITLE
Moving method from pulpcore-plugin models

### DIFF
--- a/CHANGES/5353.misc
+++ b/CHANGES/5353.misc
@@ -1,0 +1,1 @@
+Moving all the methods for `Content`, `ContentGuard`, `Remote` and `Publisher` from pulpcore-plugin to pulpcore.

--- a/doc_requirements.txt
+++ b/doc_requirements.txt
@@ -1,3 +1,6 @@
+aiohttp
+aiofiles
+backoff
 coreapi
 django
 djangorestframework

--- a/pulpcore/app/models/content.py
+++ b/pulpcore/app/models/content.py
@@ -279,6 +279,31 @@ class Content(MasterModel, QueryMixin):
             to_return[key] = getattr(self, key)
         return to_return
 
+    @staticmethod
+    def init_from_artifact_and_relative_path(artifact, relative_path):
+        """
+        Return an instance of the specific content by inspecting an artifact.
+
+        Plugin writers are expected to override this method with an implementation for a specific
+        content type.
+
+        For example:
+            >>> if path.isabs(relative_path):
+            >>>     raise ValueError(_("Relative path can't start with '/'."))
+            >>> return FileContent(relative_path=relative_path, digest=artifact.sha256)
+
+        Args:
+            artifact (:class:`~pulpcore.plugin.models.Artifact`): An instance of an Artifact
+            relative_path (str): Relative path for the content
+
+        Raises:
+            ValueError: If relative_path starts with a '/'.
+
+        Returns:
+            An un-saved instance of :class:`~pulpcore.plugin.models.Content` sub-class.
+        """
+        raise NotImplementedError()
+
 
 class ContentArtifact(Model, QueryMixin):
     """

--- a/pulpcore/app/models/publication.py
+++ b/pulpcore/app/models/publication.py
@@ -218,6 +218,15 @@ class ContentGuard(MasterModel):
     """
     Defines a named content guard.
 
+    This is meant to be subclassed by plugin authors as an opportunity to provide
+    plugin-specific persistent attributes and additional validation for those attributes.
+    The permit() method must be overridden to provide the web request authorization logic.
+
+    This object is a Django model that inherits from :class: `pulpcore.app.models.ContentGuard`
+    which provides the platform persistent attributes for a content-guard. Plugin authors can
+    add additional persistent attributes by subclassing this class and adding Django fields.
+    We defer to the Django docs on extending this model definition with additional fields.
+
     Fields:
         name (models.CharField): Unique guard name.
         description (models.TextField): An optional description.
@@ -225,6 +234,18 @@ class ContentGuard(MasterModel):
     """
     name = models.CharField(max_length=255, db_index=True, unique=True)
     description = models.TextField(null=True)
+
+    def permit(self, request):
+        """
+        Authorize the specified web request.
+
+        Args:
+            request (django.http.HttpRequest): A request for a published file.
+
+        Raises:
+            PermissionError: When not authorized.
+        """
+        raise NotImplementedError()
 
 
 class BaseDistribution(MasterModel):

--- a/pulpcore/app/models/repository.py
+++ b/pulpcore/app/models/repository.py
@@ -4,6 +4,7 @@ Repository related Django models.
 from collections import defaultdict
 from contextlib import suppress
 from gettext import gettext as _
+from os import path
 import logging
 
 import django
@@ -12,10 +13,11 @@ from django.db.models import Q
 from django.urls import reverse
 
 from pulpcore.app.util import get_view_name_for_model
+from pulpcore.download.factory import DownloaderFactory
 from pulpcore.exceptions import ResourceImmutableError
 
 from .base import MasterModel, Model
-from .content import Content
+from .content import Artifact, Content
 from .task import CreatedResource
 
 
@@ -63,6 +65,17 @@ class Repository(Model):
 class Remote(MasterModel):
     """
     A remote source for content.
+
+    This is meant to be subclassed by plugin authors as an opportunity to provide plugin-specific
+    persistent data attributes for a plugin remote subclass.
+
+    This object is a Django model that inherits from :class: `pulpcore.app.models.Remote` which
+    provides the platform persistent attributes for a remote object. Plugin authors can add
+    additional persistent remote data by subclassing this object and adding Django fields. We
+    defer to the Django docs on extending this model definition with additional fields.
+
+    Validation of the remote is done at the API level by a plugin defined subclass of
+    :class: `pulpcore.plugin.serializers.repository.RemoteSerializer`.
 
     Fields:
 
@@ -118,6 +131,102 @@ class Remote(MasterModel):
     download_concurrency = models.PositiveIntegerField(default=20)
     policy = models.TextField(choices=POLICY_CHOICES, default=IMMEDIATE)
 
+    @property
+    def download_factory(self):
+        """
+        Return the DownloaderFactory which can be used to generate asyncio capable downloaders.
+
+        Upon first access, the DownloaderFactory is instantiated and saved internally.
+
+        Plugin writers are expected to override when additional configuration of the
+        DownloaderFactory is needed.
+
+        Returns:
+            DownloadFactory: The instantiated DownloaderFactory to be used by
+                get_downloader().
+        """
+        try:
+            return self._download_factory
+        except AttributeError:
+            self._download_factory = DownloaderFactory(self)
+            return self._download_factory
+
+    def get_downloader(self, remote_artifact=None, url=None, **kwargs):
+        """
+        Get a downloader from either a RemoteArtifact or URL that is configured with this Remote.
+
+        This method accepts either `remote_artifact` or `url` but not both. At least one is
+        required. If neither or both are passed a ValueError is raised.
+
+        Plugin writers are expected to override when additional configuration is needed or when
+        another class of download is required.
+
+        Args:
+            remote_artifact (:class:`~pulpcore.app.models.RemoteArtifact`): The RemoteArtifact to
+                download.
+            url (str): The URL to download.
+            kwargs (dict): This accepts the parameters of
+                :class:`~pulpcore.plugin.download.BaseDownloader`.
+
+        Raises:
+            ValueError: If neither remote_artifact and url are passed, or if both are passed.
+
+        Returns:
+            subclass of :class:`~pulpcore.plugin.download.BaseDownloader`: A downloader that
+            is configured with the remote settings.
+        """
+        if remote_artifact and url:
+            raise ValueError(_("get_downloader() cannot accept both 'remote_artifact' and 'url'."))
+        if remote_artifact is None and url is None:
+            raise ValueError(_("get_downloader() requires either 'remote_artifact' and 'url'."))
+        if remote_artifact:
+            url = remote_artifact.url
+            expected_digests = {}
+            for digest_name in Artifact.DIGEST_FIELDS:
+                digest_value = getattr(remote_artifact, digest_name)
+                if digest_value:
+                    expected_digests[digest_name] = digest_value
+            if expected_digests:
+                kwargs['expected_digests'] = expected_digests
+            if remote_artifact.size:
+                kwargs['expected_size'] = remote_artifact.size
+        return self.download_factory.build(url, **kwargs)
+
+    def get_remote_artifact_url(self, relative_path=None):
+        """
+        Get the full URL for a RemoteArtifact from a relative path.
+
+        This method returns the URL for a RemoteArtifact by concatinating the Remote's url and the
+        relative path.located in the Remote. Plugin writers are expected to override this method
+        when a more complex algorithm is needed to determine the full URL.
+
+        Args:
+            relative_path (str): The relative path of a RemoteArtifact
+
+        Raises:
+            ValueError: If relative_path starts with a '/'.
+
+        Returns:
+            str: A URL for a RemoteArtifact available at the Remote.
+        """
+        if path.isabs(relative_path):
+            raise ValueError(_("Relative path can't start with '/'. {0}").format(relative_path))
+        return path.join(self.url, relative_path)
+
+    def get_remote_artifact_content_type(self, relative_path=None):
+        """
+        Get the type of content that should be available at the relative path.
+
+        Plugin writers are expected to implement this method.
+
+        Args:
+            relative_path (str): The relative path of a RemoteArtifact
+
+        Returns:
+            Class: The Class of the content type that should be available at the relative path.
+        """
+        raise NotImplementedError()
+
     class Meta:
         default_related_name = 'remotes'
 
@@ -125,6 +234,17 @@ class Remote(MasterModel):
 class Publisher(MasterModel):
     """
     A content publisher.
+
+    This is meant to be subclassed by plugin authors as an opportunity to provide plugin-specific
+    persistant data attributes and additional validation for those attributes.
+
+    This object is a Django model that inherits from :class: `pulpcore.app.models.Publisher`
+    which provides the platform persistent attributes for a publisher object. Plugin authors can
+    add additional persistent publisher data by subclassing this object and adding Django
+    fields. We defer to the Django docs on extending this model definition with additional fields.
+
+    Validation of the publisher is done at the API level by a plugin defined subclass of
+    :class: `pulpcore.plugin.serializers.repository.PublisherSerializer`.
 
     Fields:
 

--- a/pulpcore/download/__init__.py
+++ b/pulpcore/download/__init__.py
@@ -1,0 +1,4 @@
+from .base import BaseDownloader, DownloadResult  # noqa
+from .factory import DownloaderFactory  # noqa
+from .file import FileDownloader  # noqa
+from .http import http_giveup, HttpDownloader  # noqa

--- a/pulpcore/download/base.py
+++ b/pulpcore/download/base.py
@@ -1,0 +1,256 @@
+import asyncio
+from collections import namedtuple
+import hashlib
+import logging
+import os
+import tempfile
+
+from pulpcore.app.models import Artifact
+from pulpcore.exceptions import DigestValidationError, SizeValidationError
+
+
+log = logging.getLogger(__name__)
+
+
+DownloadResult = namedtuple('DownloadResult', ['url', 'artifact_attributes', 'path', 'headers'])
+"""
+Args:
+    url (str): The url corresponding with the download.
+    path (str): The absolute path to the saved file
+    artifact_attributes (dict): Contains keys corresponding with
+        :class:`~pulpcore.plugin.models.Artifact` fields. This includes the computed digest values
+        along with size information.
+    headers (aiohttp.multidict.MultiDict): HTTP response headers. The keys are header names. The
+        values are header content. None when not using the HttpDownloader or sublclass.
+"""
+
+
+class BaseDownloader:
+    """
+    The base class of all downloaders, providing digest calculation, validation, and file handling.
+
+    This is an abstract class and is meant to be subclassed. Subclasses are required to implement
+    the :meth:`~pulpcore.plugin.download.BaseDownloader.run` method and do two things:
+
+        1. Pass all downloaded data to
+           :meth:`~pulpcore.plugin.download.BaseDownloader.handle_data` and schedule it.
+
+        2. Schedule :meth:`~pulpcore.plugin.download.BaseDownloader.finalize` after all data has
+           been delivered to :meth:`~pulpcore.plugin.download.BaseDownloader.handle_data`.
+
+    Passing all downloaded data the into
+    :meth:`~pulpcore.plugin.download.BaseDownloader.handle_data` allows the file digests to
+    be computed while data is written to disk. The digests computed are required if the download is
+    to be saved as an :class:`~pulpcore.plugin.models.Artifact` which avoids having to re-read the
+    data later.
+
+    The :meth:`~pulpcore.plugin.download.BaseDownloader.handle_data` method by default
+    writes to a random file in the current working directory or you can pass in your own file
+    object. See the ``custom_file_object`` keyword argument for more details. Allowing the download
+    instantiator to define the file to receive data allows the streamer to receive the data instead
+    of having it written to disk.
+
+    The call to :meth:`~pulpcore.plugin.download.BaseDownloader.finalize` ensures that all
+    data written to the file-like object is quiesced to disk before the file-like object has
+    `close()` called on it.
+
+    Attributes:
+        url (str): The url to download.
+        expected_digests (dict): Keyed on the algorithm name provided by hashlib and stores the
+            value of the expected digest. e.g. {'md5': '912ec803b2ce49e4a541068d495ab570'}
+        expected_size (int): The number of bytes the download is expected to have.
+        path (str): The full path to the file containing the downloaded data if no
+            ``custom_file_object`` option was specified, otherwise None.
+    """
+
+    def __init__(self, url, custom_file_object=None, expected_digests=None, expected_size=None,
+                 semaphore=None):
+        """
+        Create a BaseDownloader object. This is expected to be called by all subclasses.
+
+        Args:
+            url (str): The url to download.
+            custom_file_object (file object): An open, writable file object that downloaded data
+                can be written to by
+                :meth:`~pulpcore.plugin.download.BaseDownloader.handle_data`.
+            expected_digests (dict): Keyed on the algorithm name provided by hashlib and stores the
+                value of the expected digest. e.g. {'md5': '912ec803b2ce49e4a541068d495ab570'}
+            expected_size (int): The number of bytes the download is expected to have.
+            semaphore (asyncio.Semaphore): A semaphore the downloader must acquire before running.
+                Useful for limiting the number of outstanding downloaders in various ways.
+        """
+        self.url = url
+        self._writer = custom_file_object
+        self.path = None
+        self.expected_digests = expected_digests
+        self.expected_size = expected_size
+        if semaphore:
+            self.semaphore = semaphore
+        else:
+            self.semaphore = asyncio.Semaphore()  # This will always be acquired
+        self._digests = {n: hashlib.new(n) for n in Artifact.DIGEST_FIELDS}
+        self._size = 0
+
+    def _ensure_writer_has_open_file(self):
+        """
+        Create a temporary file on demand.
+
+        Create a temporary file when it's actually used,
+        allowing plugin writers to instantiate many downloaders in memory.
+        """
+        if not self._writer:
+            self._writer = tempfile.NamedTemporaryFile(dir=os.getcwd(), delete=False)
+            self.path = self._writer.name
+
+    async def handle_data(self, data):
+        """
+        A coroutine that writes data to the file object and compute its digests.
+
+        All subclassed downloaders are expected to pass all data downloaded to this method. Similar
+        to the hashlib docstring, repeated calls are equivalent to a single call with
+        the concatenation of all the arguments: m.handle_data(a); m.handle_data(b) is equivalent to
+        m.handle_data(a+b).
+
+        Args:
+            data (bytes): The data to be handled by the downloader.
+        """
+        self._ensure_writer_has_open_file()
+        self._writer.write(data)
+        self._record_size_and_digests_for_data(data)
+
+    async def finalize(self):
+        """
+        A coroutine to flush downloaded data, close the file writer, and validate the data.
+
+        All subclasses are required to call this method after all data has been passed to
+        :meth:`~pulpcore.plugin.download.BaseDownloader.handle_data`.
+
+        Raises:
+            :class:`~pulpcore.exceptions.DigestValidationError`: When any of the ``expected_digest``
+                values don't match the digest of the data passed to
+                :meth:`~pulpcore.plugin.download.BaseDownloader.handle_data`.
+            :class:`~pulpcore.exceptions.SizeValidationError`: When the ``expected_size`` value
+                doesn't match the size of the data passed to
+                :meth:`~pulpcore.plugin.download.BaseDownloader.handle_data`.
+        """
+        self._ensure_writer_has_open_file()
+        self._writer.flush()
+        os.fsync(self._writer.fileno())
+        self._writer.close()
+        self.validate_digests()
+        self.validate_size()
+
+    def fetch(self):
+        """
+        Run the download synchronously and return the `DownloadResult`.
+
+        Returns:
+            :class:`~pulpcore.plugin.download.DownloadResult`
+
+        Raises:
+            Exception: Any fatal exception emitted during downloading
+        """
+        done, _ = asyncio.get_event_loop().run_until_complete(asyncio.wait([self.run()]))
+        return done.pop().result()
+
+    def _record_size_and_digests_for_data(self, data):
+        """
+        Record the size and digest for an available chunk of data.
+
+        Args:
+            data (bytes): The data to have its size and digest values recorded.
+        """
+        for algorithm in self._digests.values():
+            algorithm.update(data)
+        self._size += len(data)
+
+    @property
+    def artifact_attributes(self):
+        """
+        A property that returns a dictionary with size and digest information. The keys of this
+        dictionary correspond with :class:`~pulpcore.plugin.models.Artifact` fields.
+        """
+        attributes = {'size': self._size}
+        for algorithm in Artifact.DIGEST_FIELDS:
+            attributes[algorithm] = self._digests[algorithm].hexdigest()
+        return attributes
+
+    def validate_digests(self):
+        """
+        Validate all digests validate if ``expected_digests`` is set
+
+        Raises:
+            :class:`~pulpcore.exceptions.DigestValidationError`: When any of the ``expected_digest``
+                values don't match the digest of the data passed to
+                :meth:`~pulpcore.plugin.download.BaseDownloader.handle_data`.
+        """
+        if self.expected_digests:
+            for algorithm, expected_digest in self.expected_digests.items():
+                if expected_digest != self._digests[algorithm].hexdigest():
+                    raise DigestValidationError()
+
+    def validate_size(self):
+        """
+        Validate the size if ``expected_size`` is set
+
+        Raises:
+            :class:`~pulpcore.exceptions.SizeValidationError`: When the ``expected_size`` value
+                doesn't match the size of the data passed to
+                :meth:`~pulpcore.plugin.download.BaseDownloader.handle_data`.
+        """
+        if self.expected_size:
+            if self._size != self.expected_size:
+                raise SizeValidationError()
+
+    async def run(self, extra_data=None):
+        """
+        Run the downloader with concurrency restriction.
+
+        This method acquires `self.semaphore` before calling the actual download implementation
+        contained in `_run()`. This ensures that the semaphore stays acquired even as the `backoff`
+        decorator on `_run()`, handles backoff-and-retry logic.
+
+        Args:
+            extra_data (dict): Extra data passed to the downloader.
+
+        Returns:
+            :class:`~pulpcore.plugin.download.DownloadResult` from `_run()`.
+
+        """
+        async with self.semaphore:
+            return await self._run(extra_data=extra_data)
+
+    async def _run(self, extra_data=None):
+        """
+        Run the downloader.
+
+        This is a coroutine that asyncio can schedule to complete downloading. Subclasses are
+        required to implement this method and do two things:
+
+        1. Pass all downloaded data to
+           :meth:`~pulpcore.plugin.download.BaseDownloader.handle_data`.
+
+        2. Call :meth:`~pulpcore.plugin.download.BaseDownloader.finalize` after all data has
+           been delivered to :meth:`~pulpcore.plugin.download.BaseDownloader.handle_data`.
+
+        It is also expected that the subclass implementation return a
+        :class:`~pulpcore.plugin.download.DownloadResult` object. The
+        ``artifact_attributes`` value of the
+        :class:`~pulpcore.plugin.download.DownloadResult` is usually set to the
+        :attr:`~pulpcore.plugin.download.BaseDownloader.artifact_attributes` property value.
+
+        This method is called from :meth:`~pulpcore.plugin.download.BaseDownloader.run` which
+        handles concurrency restriction. Thus, by the time this method is called, the download can
+        occur without violating the concurrency restriction.
+
+        Args:
+            extra_data (dict): Extra data passed to the downloader.
+
+        Returns:
+            :class:`~pulpcore.plugin.download.DownloadResult`
+
+        Raises:
+            Validation errors could be emitted when subclassed implementations call
+            :meth:`~pulpcore.plugin.download.BaseDownloader.finalize`.
+        """
+        raise NotImplementedError('Subclasses must define a _run() method that returns a coroutine')

--- a/pulpcore/download/factory.py
+++ b/pulpcore/download/factory.py
@@ -1,0 +1,179 @@
+import asyncio
+import atexit
+import copy
+from gettext import gettext as _
+import ssl
+from tempfile import NamedTemporaryFile
+from urllib.parse import urlparse
+
+import aiohttp
+
+from .http import HttpDownloader
+from .file import FileDownloader
+
+
+PROTOCOL_MAP = {
+    'http': HttpDownloader,
+    'https': HttpDownloader,
+    'file': FileDownloader
+}
+
+
+class DownloaderFactory:
+    """
+    A factory for creating downloader objects that are configured from with remote settings.
+
+    The DownloadFactory correctly handles SSL settings, basic auth settings, proxy settings, and
+    connection limit settings.
+
+    It supports handling urls with the `http`, `https`, and `file` protocols. The
+    ``downloader_overrides`` option allows the caller to specify the download class to be used for
+    any given protocol. This allows the user to specify custom, subclassed downloaders to be built
+    by the factory.
+
+    Usage:
+        >>> the_factory = DownloaderFactory(remote)
+        >>> downloader = the_factory.build(url_a)
+        >>> result = downloader.fetch()  # 'result' is a DownloadResult
+
+    For http and https urls, in addition to the remote settings, non-default timing values are used.
+    Specifically, the "total" timeout is set to None and the "sock_connect" and "sock_read" are both
+    5 minutes. For more info on these settings, see the aiohttp docs:
+    http://aiohttp.readthedocs.io/en/stable/client_quickstart.html#timeouts Behaviorally, it should
+    allow for an active download to be arbitrarily long, while still detecting dead or closed
+    sessions even when TCPKeepAlive is disabled.
+
+    Also for http and https urls, even though HTTP 1.1 is used, the TCP connection is setup and
+    closed with each request. This is done for compatibility reasons due to various issues related
+    to session continuation implementation in various servers.
+    """
+
+    def __init__(self, remote, downloader_overrides=None):
+        """
+        Args:
+            remote (:class:`~pulpcore.plugin.models.Remote`): The remote used to populate
+                downloader settings.
+            downloader_overrides (dict): Keyed on a scheme name, e.g. 'https' or 'ftp' and the value
+                is the downloader class to be used for that scheme, e.g.
+                {'https': MyCustomDownloader}. These override the default values.
+        """
+        self._remote = remote
+        self._download_class_map = copy.copy(PROTOCOL_MAP)
+        if downloader_overrides:
+            for protocol, download_class in downloader_overrides.items():  # overlay the overrides
+                self._download_class_map[protocol] = download_class
+        self._handler_map = {'https': self._http_or_https, 'http': self._http_or_https,
+                             'file': self._generic}
+        self._session = self._make_aiohttp_session_from_remote()
+        self._semaphore = asyncio.Semaphore(value=remote.download_concurrency)
+        atexit.register(self._session.close)
+
+    def _make_aiohttp_session_from_remote(self):
+        """
+        Build a :class:`aiohttp.ClientSession` from the remote's settings and timing settings.
+
+        This method is what provides the force_close of the TCP connection with each request.
+
+        Returns:
+            :class:`aiohttp.ClientSession`
+        """
+        tcp_conn_opts = {'force_close': True}
+
+        sslcontext = None
+        if self._remote.ssl_ca_certificate:
+            sslcontext = ssl.create_default_context(cadata=self._remote.ssl_ca_certificate)
+        if self._remote.ssl_client_key and self._remote.ssl_client_certificate:
+            if not sslcontext:
+                sslcontext = ssl.create_default_context()
+            with NamedTemporaryFile() as key_file:
+                key_file.write(bytes(self._remote.ssl_client_key, 'utf-8'))
+                key_file.flush()
+                with NamedTemporaryFile() as cert_file:
+                    cert_file.write(bytes(self._remote.ssl_client_certificate, 'utf-8'))
+                    cert_file.flush()
+                    sslcontext.load_cert_chain(
+                        cert_file.name,
+                        key_file.name
+                    )
+        if not self._remote.ssl_validation:
+            if not sslcontext:
+                sslcontext = ssl.create_default_context()
+            sslcontext.check_hostname = False
+            sslcontext.verify_mode = ssl.CERT_NONE
+        if sslcontext:
+            tcp_conn_opts['ssl_context'] = sslcontext
+
+        conn = aiohttp.TCPConnector(**tcp_conn_opts)
+
+        auth_options = {}
+        if self._remote.username and self._remote.password:
+            auth_options['auth'] = aiohttp.BasicAuth(
+                login=self._remote.username,
+                password=self._remote.password
+            )
+
+        timeout = aiohttp.ClientTimeout(total=None, sock_connect=600, sock_read=600)
+        return aiohttp.ClientSession(connector=conn, timeout=timeout, **auth_options)
+
+    def build(self, url, **kwargs):
+        """
+        Build a downloader which can optionally verify integrity using either digest or size.
+
+        The built downloader also provides concurrency restriction if specified by the remote.
+
+        Args:
+            url (str): The download URL.
+            kwargs (dict): All kwargs are passed along to the downloader. At a minimum, these
+                include the :class:`~pulpcore.plugin.download.BaseDownloader` parameters.
+
+        Returns:
+            subclass of :class:`~pulpcore.plugin.download.BaseDownloader`: A downloader that
+            is configured with the remote settings.
+        """
+        kwargs['semaphore'] = self._semaphore
+        scheme = urlparse(url).scheme.lower()
+        try:
+            builder = self._handler_map[scheme]
+            download_class = self._download_class_map[scheme]
+        except KeyError:
+            raise ValueError(_('URL: {u} not supported.'.format(u=url)))
+        else:
+            return builder(download_class, url, **kwargs)
+
+    def _http_or_https(self, download_class, url, **kwargs):
+        """
+        Build a downloader for http:// or https:// URLs.
+
+        Args:
+            download_class (:class:`~pulpcore.plugin.download.BaseDownloader`): The download
+                class to be instantiated.
+            url (str): The download URL.
+            kwargs (dict): All kwargs are passed along to the downloader. At a minimum, these
+                include the :class:`~pulpcore.plugin.download.BaseDownloader` parameters.
+
+        Returns:
+            :class:`~pulpcore.plugin.download.HttpDownloader`: A downloader that
+            is configured with the remote settings.
+        """
+        options = {'session': self._session}
+        if self._remote.proxy_url:
+            options['proxy'] = self._remote.proxy_url
+
+        return download_class(url, **options, **kwargs)
+
+    def _generic(self, download_class, url, **kwargs):
+        """
+        Build a generic downloader based on the url.
+
+        Args:
+            download_class (:class:`~pulpcore.plugin.download.BaseDownloader`): The download
+                class to be instantiated.
+            url (str): The download URL.
+            kwargs (dict): All kwargs are passed along to the downloader. At a minimum, these
+                include the :class:`~pulpcore.plugin.download.BaseDownloader` parameters.
+
+        Returns:
+            subclass of :class:`~pulpcore.plugin.download.BaseDownloader`: A downloader that
+            is configured with the remote settings.
+        """
+        return download_class(url, **kwargs)

--- a/pulpcore/download/file.py
+++ b/pulpcore/download/file.py
@@ -1,0 +1,53 @@
+import os
+
+from urllib.parse import urlparse
+
+import aiofiles
+
+from .base import BaseDownloader, DownloadResult
+
+
+class FileDownloader(BaseDownloader):
+    """
+    A downloader for downloading files from the filesystem.
+
+    It provides digest and size validation along with computation of the digests needed to save the
+    file as an Artifact. It writes a new file to the disk and the return path is included in the
+    :class:`~pulpcore.plugin.download.DownloadResult`.
+
+    This downloader has all of the attributes of
+    :class:`~pulpcore.plugin.download.BaseDownloader`
+    """
+
+    def __init__(self, url, **kwargs):
+        """
+        Download files from a url that starts with `file://`
+
+        Args:
+            url (str): The url to the file. This is expected to begin with `file://`
+            kwargs (dict): This accepts the parameters of
+                :class:`~pulpcore.plugin.download.BaseDownloader`.
+        """
+        p = urlparse(url)
+        self._path = os.path.abspath(os.path.join(p.netloc, p.path))
+        super().__init__(url, **kwargs)
+
+    async def _run(self, extra_data=None):
+        """
+        Read, validate, and compute digests on the `url`. This is a coroutine.
+
+        This method provides the same return object type and documented in
+        :meth:`~pulpcore.plugin.download.BaseDownloader._run`.
+
+        Args:
+            extra_data (dict): Extra data passed to the downloader.
+        """
+        async with aiofiles.open(self._path, 'rb') as f_handle:
+            while True:
+                chunk = await f_handle.read(1048576)  # 1 megabyte
+                if not chunk:
+                    await self.finalize()
+                    break  # the reading is done
+                await self.handle_data(chunk)
+            return DownloadResult(path=self._path, artifact_attributes=self.artifact_attributes,
+                                  url=self.url, headers=None)

--- a/pulpcore/download/http.py
+++ b/pulpcore/download/http.py
@@ -1,0 +1,188 @@
+import logging
+
+import aiohttp
+import backoff
+
+from .base import BaseDownloader, DownloadResult
+
+
+log = logging.getLogger(__name__)
+
+
+logging.getLogger('backoff').addHandler(logging.StreamHandler())
+
+
+def http_giveup(exc):
+    """
+    Inspect a raised exception and determine if we should give up.
+
+    Do not give up when the status code is one of the following:
+
+        429 - Too Many Requests
+        502 - Bad Gateway
+        503 - Service Unavailable
+        504 - Gateway Timeout
+
+    Args:
+        exc (aiohttp.ClientResponseException): The exception to inspect
+
+    Returns:
+        True if the download should give up, False otherwise
+    """
+    return exc.code not in [429, 502, 503, 504]
+
+
+class HttpDownloader(BaseDownloader):
+    """
+    An HTTP/HTTPS Downloader built on `aiohttp`.
+
+    This downloader downloads data from one `url` and is not reused.
+
+    The downloader optionally takes a session argument, which is an `aiohttp.ClientSession`. This
+    allows many downloaders to share one `aiohttp.ClientSession` which provides a connection pool,
+    connection reuse, and keep-alives across multiple downloaders. When creating many downloaders,
+    have one session shared by all of your `HttpDownloader` objects.
+
+    A session is optional; if omitted, one session will be created, used for this downloader, and
+    then closed when the download is complete. A session that is passed in will not be closed when
+    the download is complete.
+
+    If a session is not provided, the one created by HttpDownloader uses non-default timing values.
+    Specifically, the "total" timeout is set to None and the "sock_connect" and "sock_read" are both
+    5 minutes. For more info on these settings, see the aiohttp docs:
+    http://aiohttp.readthedocs.io/en/stable/client_quickstart.html#timeouts Behaviorally, it should
+    allow for an active download to be arbitrarily long, while still detecting dead or closed
+    sessions even when TCPKeepAlive is disabled.
+
+    If a session is not provided, the one created will force TCP connection closure after each
+    request. This is done for compatibility reasons due to various issues related to session
+    continuation implementation in various servers.
+
+    `aiohttp.ClientSession` objects allows you to configure options that will apply to all
+    downloaders using that session such as auth, timeouts, headers, etc. For more info on these
+    options see the `aiohttp.ClientSession` docs for more information:
+    http://aiohttp.readthedocs.io/en/stable/client_reference.html#aiohttp.ClientSession
+
+    The `aiohttp.ClientSession` can additionally be configured for SSL configuration by passing in a
+    `aiohttp.TCPConnector`. For information on configuring either server or client certificate based
+    identity verification, see the aiohttp documentation:
+    http://aiohttp.readthedocs.io/en/stable/client.html#ssl-control-for-tcp-sockets
+
+    For more information on `aiohttp.BasicAuth` objects, see their docs:
+    http://aiohttp.readthedocs.io/en/stable/client_reference.html#aiohttp.BasicAuth
+
+    Synchronous Download:
+       >>> downloader = HttpDownloader('http://example.com/')
+       >>> result = downloader.fetch()
+
+    Parallel Download:
+        >>> download_coroutines = [
+        >>>     HttpDownloader('http://example.com/').run(),
+        >>>     HttpDownloader('http://pulpproject.org/').run(),
+        >>> ]
+        >>>
+        >>> loop = asyncio.get_event_loop()
+        >>> done, not_done = loop.run_until_complete(asyncio.wait(download_coroutines))
+        >>>
+        >>> for task in done:
+        >>>     try:
+        >>>         task.result()  # This is a DownloadResult
+        >>>     except Exception as error:
+        >>>         pass  # fatal exceptions are raised by result()
+
+    The HTTPDownloaders contain automatic retry logic if the server responds with HTTP 429 response.
+    The coroutine will automatically retry 10 times with exponential backoff before allowing a
+    final exception to be raised.
+
+    Attributes:
+        session (aiohttp.ClientSession): The session to be used by the downloader.
+        auth (aiohttp.BasicAuth): An object that represents HTTP Basic Authorization or None
+        proxy (str): An optional proxy URL or None
+        proxy_auth (aiohttp.BasicAuth): An optional object that represents proxy HTTP Basic
+            Authorization or None
+        headers_ready_callback (callable): An optional callback that accepts a single dictionary
+            as its argument. The callback will be called when the response headers are
+            available. The dictionary passed has the header names as the keys and header values
+            as its values. e.g. `{'Transfer-Encoding': 'chunked'}`. This can also be None.
+
+    This downloader also has all of the attributes of
+    :class:`~pulpcore.plugin.download.BaseDownloader`
+    """
+
+    def __init__(self, url, session=None, auth=None, proxy=None, proxy_auth=None,
+                 headers_ready_callback=None, **kwargs):
+        """
+        Args:
+            url (str): The url to download.
+            session (aiohttp.ClientSession): The session to be used by the downloader. (optional) If
+                not specified it will open the session and close it
+            auth (aiohttp.BasicAuth): An object that represents HTTP Basic Authorization (optional)
+            proxy (str): An optional proxy URL.
+            proxy_auth (aiohttp.BasicAuth): An optional object that represents proxy HTTP Basic
+                Authorization.
+            headers_ready_callback (callable): An optional callback that accepts a single dictionary
+                as its argument. The callback will be called when the response headers are
+                available. The dictionary passed has the header names as the keys and header values
+                as its values. e.g. `{'Transfer-Encoding': 'chunked'}`
+            kwargs (dict): This accepts the parameters of
+                :class:`~pulpcore.plugin.download.BaseDownloader`.
+        """
+        if session:
+            self.session = session
+            self._close_session_on_finalize = False
+        else:
+            timeout = aiohttp.ClientTimeout(total=None, sock_connect=600, sock_read=600)
+            conn = aiohttp.TCPConnector({'force_close': True})
+            self.session = aiohttp.ClientSession(connector=conn, timeout=timeout)
+            self._close_session_on_finalize = True
+        self.auth = auth
+        self.proxy = proxy
+        self.proxy_auth = proxy_auth
+        self.headers_ready_callback = headers_ready_callback
+        super().__init__(url, **kwargs)
+
+    async def _handle_response(self, response):
+        """
+        Handle the aiohttp response by writing it to disk and calculating digests
+
+        Args:
+            response (aiohttp.ClientResponse): The response to handle.
+
+        Returns:
+             DownloadResult: Contains information about the result. See the DownloadResult docs for
+                 more information.
+        """
+        if self.headers_ready_callback:
+            await self.headers_ready_callback(response.headers)
+        while True:
+            chunk = await response.content.read(1048576)  # 1 megabyte
+            if not chunk:
+                await self.finalize()
+                break  # the download is done
+            await self.handle_data(chunk)
+        return DownloadResult(path=self.path, artifact_attributes=self.artifact_attributes,
+                              url=self.url, headers=response.headers)
+
+    @backoff.on_exception(backoff.expo, aiohttp.ClientResponseError,
+                          max_tries=10, giveup=http_giveup)
+    async def _run(self, extra_data=None):
+        """
+        Download, validate, and compute digests on the `url`. This is a coroutine.
+
+        This method is decorated with a backoff-and-retry behavior to retry HTTP 429 and
+        some 5XX errors. It retries with exponential backoff 10 times before allowing
+        a final exception to be raised.
+
+        This method provides the same return object type and documented in
+        :meth:`~pulpcore.plugin.download.BaseDownloader._run`.
+
+        Args:
+            extra_data (dict): Extra data passed by the downloader.
+        """
+        async with self.session.get(self.url, proxy=self.proxy) as response:
+            response.raise_for_status()
+            to_return = await self._handle_response(response)
+            await response.release()
+        if self._close_session_on_finalize:
+            await self.session.close()
+        return to_return

--- a/setup.py
+++ b/setup.py
@@ -4,6 +4,9 @@ with open('README.md') as f:
     long_description = f.read()
 
 requirements = [
+    'aiohttp',
+    'aiofiles',
+    'backoff',
     'coreapi~=2.3.3',
     'Django~=2.2.3',  # LTS version, switch only if we have a compelling reason to
     'django-filter~=2.2.0',


### PR DESCRIPTION
Moving all the methods for:
Content, ContentGuard, Remote and Publisher
from pulpcore-plugin to pulpcore

closes #5353
https://pulp.plan.io/issues/5353

Please be sure you have read our documentation on creating PRs:
https://docs.pulpproject.org/en/3.0/nightly/contributing/pull-request-walkthrough.html
