### PR TITLE
Set default `ref_name` attribute for a ModelSerializers's `Meta` class.

### DIFF
--- a/.travis/test_bindings.py
+++ b/.travis/test_bindings.py
@@ -2,9 +2,9 @@ from pulpcore.client.pulpcore import (ApiClient as CoreApiClient, ArtifactsApi, 
                                       Repository, RepositoriesApi, RepositoriesVersionsApi,
                                       TasksApi, Upload, UploadCommit, UploadsApi)
 from pulpcore.client.pulp_file import (ApiClient as FileApiClient, ContentFilesApi,
-                                       DistributionsFileApi, FileDistribution,
-                                       PublicationsFileApi, RemotesFileApi, FileRemote,
-                                       RepositorySyncURL, FilePublication)
+                                       DistributionsFileApi, FileFileDistribution,
+                                       PublicationsFileApi, RemotesFileApi, FileFileRemote,
+                                       RepositorySyncURL, FileFilePublication)
 from pprint import pprint
 from time import sleep
 import hashlib
@@ -116,7 +116,7 @@ with NamedTemporaryFile() as downloaded_file:
 
 # Create a File Remote
 remote_url = 'https://repos.fedorapeople.org/pulp/pulp/demo_repos/test_file_repo/PULP_MANIFEST'
-remote_data = FileRemote(name='bar25', url=remote_url)
+remote_data = FileFileRemote(name='bar25', url=remote_url)
 file_remote = fileremotes.create(remote_data)
 pprint(file_remote)
 
@@ -157,13 +157,15 @@ repository_version_2 = repoversions.read(created_resources[0])
 pprint(repository_version_2)
 
 # Create a publication from the latest version of the repository
-publish_data = FilePublication(repository=repository.pulp_href)
+publish_data = FileFilePublication(repository=repository.pulp_href)
 publish_response = filepublications.create(publish_data)
 
 # Monitor the publish task
 created_resources = monitor_task(publish_response.task)
 publication_href = created_resources[0]
 
-distribution_data = FileDistribution(name='baz25', base_path='foo25', publication=publication_href)
+distribution_data = FileFileDistribution(
+    name='baz25', base_path='foo25', publication=publication_href
+)
 distribution = filedistributions.create(distribution_data)
 pprint(distribution)

--- a/.travis/test_bindings.rb
+++ b/.travis/test_bindings.rb
@@ -104,7 +104,7 @@ artifact = upload_file_in_chunks(File.join(ENV['TRAVIS_BUILD_DIR'], '.travis.yml
 
 # Create a File Remote
 remote_url = 'https://repos.fedorapeople.org/pulp/pulp/demo_repos/test_file_repo/PULP_MANIFEST'
-remote_data = PulpFileClient::FileRemote.new({name: 'bar38', url: remote_url})
+remote_data = PulpFileClient::FileFileRemote.new({name: 'bar38', url: remote_url})
 file_remote = @fileremotes_api.create(remote_data)
 
 # Create a Repository
@@ -139,12 +139,12 @@ created_resources = monitor_task(repo_version_response.task)
 repository_version_2 = @repoversions_api.read(created_resources[0])
 
 # Create a publication from the latest version of the repository
-publish_data = PulpFileClient::FilePublication.new({repository: repository.pulp_href})
+publish_data = PulpFileClient::FileFilePublication.new({repository: repository.pulp_href})
 publish_response = @filepublications_api.create(publish_data)
 
 # Monitor the publish task
 created_resources = monitor_task(publish_response.task)
 publication_href = created_resources[0]
 
-distribution_data = PulpFileClient::FileDistribution.new({name: 'baz38', base_path: 'foo38', publication: publication_href})
+distribution_data = PulpFileClient::FileFileDistribution.new({name: 'baz38', base_path: 'foo38', publication: publication_href})
 distribution = @filedistributions_api.create(distribution_data)

--- a/CHANGES/5574.misc
+++ b/CHANGES/5574.misc
@@ -1,0 +1,1 @@
+Set default `ref_name` attribute for a ModelSerializers's `Meta` class.

--- a/CHANGES/plugin_api/5574.doc
+++ b/CHANGES/plugin_api/5574.doc
@@ -1,0 +1,1 @@
+Be more explicit about namespacing `ref_name` in plugin serializers.

--- a/docs/plugins/reference/how-to-doc-api.rst
+++ b/docs/plugins/reference/how-to-doc-api.rst
@@ -29,11 +29,27 @@ Response status codes can be generated through the `Meta` class on the serialize
 
 
 .. note::
-    ref_name - a string that is used as the model definition name for this serializer class.
-    If this option is not specified, all serializers have an implicit name derived from their
-    class name. In order to avoid possible collisions, it is better to explicitly define ref_name
-    on the Meta class.
-    Suggested format: ref_name = f'{model._meta.app_label}_{model._meta.model_name}'
+    ``Meta.ref_name`` is a string that is used as the model definition name for
+    the serializer class. If this attribute is not specified, all serializers
+    have an implicit name derived from their class name. In order to avoid
+    possible name collisions between plugins, plugins must define ``ref_name``
+    on the Meta class using ``<app_label>.`` as a prefix.
+
+    For the model based serializers offered by pulpcore (i.e.
+    :class:`~pulpcore.plugin.serializers.ModelSerializer` and derived
+    serializers), ``Meta.ref_name`` will be set correctly automatically. There is no
+    need to set ``Meta.ref_name`` in this case.
+
+    If a serializer has no associated model, you need to set ``Meta.ref_name``
+    explicitly. For example, if the ``SnippetSerializerV1`` from above is for
+    the plugin providing the ``snippets`` app, ``ref_name`` could be set like
+    this::
+
+        class SnippetSerializerV1(serializers.Serializer):
+            title = serializers.CharField(required=False, allow_blank=True, max_length=100)
+
+            class Meta:
+                ref_name = "snippets.Snippet"
 
 .. note::
 


### PR DESCRIPTION
Use the `__init_subclass__` method added in Python 3.6 to customize
subclasses of pulpcore's ModelSerializer class.

If it is not yet defined, set the `Meta.ref_name` attribute according to
the best practice established within Pulp (`'<app label>_<model name>'`).

closes #5574
https://pulp.plan.io/issues/5574
