### PR TITLE
Provide storage information in the status API

### DIFF
--- a/CHANGES/5631.feature
+++ b/CHANGES/5631.feature
@@ -1,0 +1,1 @@
+Add storage information to the status API. Currently limited to disk space information.

--- a/pulpcore/app/serializers/status.py
+++ b/pulpcore/app/serializers/status.py
@@ -39,6 +39,27 @@ class RedisConnectionSerializer(serializers.Serializer):
     )
 
 
+class StorageSerializer(serializers.Serializer):
+    """
+    Serializer for information about the storage system
+    """
+
+    total = serializers.IntegerField(
+        min_value=0,
+        help_text=_('Total number of bytes')
+    )
+
+    used = serializers.IntegerField(
+        min_value=0,
+        help_text=_('Number of bytes in use')
+    )
+
+    free = serializers.IntegerField(
+        min_value=0,
+        help_text=_('Number of free bytes')
+    )
+
+
 class StatusSerializer(serializers.Serializer):
     """
     Serializer for the status information of the app
@@ -74,4 +95,9 @@ class StatusSerializer(serializers.Serializer):
 
     redis_connection = RedisConnectionSerializer(
         help_text=_("Redis connection information")
+    )
+
+    storage = StorageSerializer(
+        required=False,
+        help_text=_("Storage information")
     )

--- a/pulpcore/tests/functional/api/test_status.py
+++ b/pulpcore/tests/functional/api/test_status.py
@@ -43,6 +43,14 @@ STATUS = {
                 }
             },
         },
+        'storage': {
+            'type': 'object',
+            'properties': {
+                'total': {'type': 'integer'},
+                'used': {'type': 'integer'},
+                'free': {'type': 'integer'},
+            },
+        },
     }
 }
 
@@ -96,3 +104,4 @@ class StatusTestCase(unittest.TestCase):
         self.assertEqual(status['missing_workers'], [])
         self.assertNotEqual(status['online_workers'], [])
         self.assertNotEqual(status['versions'], [])
+        self.assertIsNotNone(status['storage'])


### PR DESCRIPTION
Currently Katello has the ability to query the Pulp storage usage. This is implemented via the smart_proxy_pulp project. This requires the Smart Proxy to be colocated with Pulp. The colocation also makes deployment in Kubernetes harder. It won't work with S3 unless a lot of duplication with Pulp itself is done. By providing it in the Pulp API, this can be
avoided.

Currently it's only implemented for local filesystem storage.

This is currently more of a draft to see what the ideas about implementing this are. If this is not desired at all or if this should be a plugin, I'd rather not waste my time writing a fully working implementation. If there is, I'll look into writing the correct tests and making sure this works properly.

https://pulp.plan.io/issues/5631