### PR TITLE
Rename CONTENT_HOST to CONTENT_ORIGIN

### DIFF
--- a/.travis/install.sh
+++ b/.travis/install.sh
@@ -91,7 +91,7 @@ spec:
     username: pulp
     password: pulp
     admin_password: pulp
-  content_host: $(hostname):24816
+  content_origin: $(hostname):24816
 CRYAML
 
 # Install k3s, lightweight Kubernetes

--- a/CHANGES/5629.removal
+++ b/CHANGES/5629.removal
@@ -1,0 +1,1 @@
+The ``CONTENT_HOST`` setting is renamed to ``CONTENT_ORIGIN``.

--- a/CHANGES/plugin_api/5629.removal
+++ b/CHANGES/plugin_api/5629.removal
@@ -1,0 +1,1 @@
+The ``CONTENT_HOST`` setting is renamed to ``CONTENT_ORIGIN``.

--- a/docs/installation/configuration.rst
+++ b/docs/installation/configuration.rst
@@ -199,8 +199,8 @@ WORKING_DIRECTORY
     validated before being moved to their permanent home in ``MEDIA_ROOT``.
 
 
-CONTENT_HOST
-^^^^^^^^^^^^
+CONTENT_ORIGIN
+^^^^^^^^^^^^^^
 
    A string containing the protocol, fqdn, and port where the content app is deployed. This is used
    when Pulp needs to refer the client to the content serving app from within the REST API, such as

--- a/pulpcore/app/serializers/fields.py
+++ b/pulpcore/app/serializers/fields.py
@@ -241,7 +241,7 @@ class BaseURLField(serializers.CharField):
 
     def to_representation(self, value):
         base_path = value
-        host = settings.CONTENT_HOST
+        host = settings.CONTENT_ORIGIN
         prefix = settings.CONTENT_PATH_PREFIX
         return '/'.join(
             (

--- a/pulpcore/app/settings.py
+++ b/pulpcore/app/settings.py
@@ -201,7 +201,7 @@ LOGGING = {
     }
 }
 
-CONTENT_HOST = ''
+CONTENT_ORIGIN = ''
 CONTENT_PATH_PREFIX = '/pulp/content/'
 CONTENT_APP_TTL = 30
 


### PR DESCRIPTION
The name CONTENT_HOST was inaccurate because we recommend keeping the
protocol in the variable.

Required PR: https://github.com/pulp/pulp_file/pull/300

https://pulp.plan.io/issues/5629
re #5629

