### PR TITLE
Fix bug where ordering filter raised 400

### DIFF
--- a/CHANGES/5621.bugfix
+++ b/CHANGES/5621.bugfix
@@ -1,0 +1,1 @@
+Fix bug where 'ordering' parameter returned 400 error.

--- a/pulpcore/app/viewsets/base.py
+++ b/pulpcore/app/viewsets/base.py
@@ -463,7 +463,7 @@ class BaseFilterSet(filterset.FilterSet):
     def is_valid(self, *args, **kwargs):
         is_valid = super().is_valid(*args, **kwargs)
         DEFAULT_FILTERS = [
-            "exclude_fields", "fields", "limit", "minimal", "offset", "page_size"
+            "exclude_fields", "fields", "limit", "minimal", "offset", "page_size", "ordering"
         ]
         for field in self.data.keys():
             if field in DEFAULT_FILTERS:


### PR DESCRIPTION
The ordering parameter is used by DRF to order results and should not be
considered an invalid parameter on GET requests.

refs #5621

Please be sure you have read our documentation on creating PRs:
https://docs.pulpproject.org/en/3.0/nightly/contributing/pull-request-walkthrough.html
