### PR TITLE
Introduce CONTENT_ORIGIN setting

### DIFF
--- a/.travis/install.sh
+++ b/.travis/install.sh
@@ -92,7 +92,8 @@ spec:
     password: pulp
     admin_password: pulp
   pulp_settings:
-     content_host: $(hostname):24816
+     content_origin: http://$(hostname):24816
+    
 CRYAML
 
 # Install k3s, lightweight Kubernetes

--- a/.travis/script.sh
+++ b/.travis/script.sh
@@ -20,6 +20,10 @@ export FUNC_TEST_SCRIPT=$TRAVIS_BUILD_DIR/.travis/func_test_script.sh
 export DJANGO_SETTINGS_MODULE=pulpcore.app.settings
 
 if [ "$TEST" = 'docs' ]; then
+  
+    export PULP_CONTENT_ORIGIN=http://$(hostname):24816
+  
+
   cd docs
   make html
   cd ..

--- a/CHANGES/5629.feature
+++ b/CHANGES/5629.feature
@@ -1,0 +1,1 @@
+Added ``CONTENT_ORIGIN`` setting, which is now required.

--- a/CHANGES/plugin_api/5629.feature
+++ b/CHANGES/plugin_api/5629.feature
@@ -1,0 +1,2 @@
+Added the ``CONTENT_ORIGIN`` setting which can be used to reliably know the scheme+host+port to the
+pulp content app.

--- a/docs/installation/configuration.rst
+++ b/docs/installation/configuration.rst
@@ -209,6 +209,15 @@ CONTENT_HOST
    This defaults to ``None`` which returns relative urls.
 
 
+CONTENT_ORIGIN
+^^^^^^^^^^^^^^
+
+   A required string containing the protocol, fqdn, and port where the content app is reachable by
+   users. This is used by ``pulpcore`` and various plugins when referring users to the content app.
+   For example if the API should refer users to content at using http to pulp.example.com on port
+   24816, (the content default port), you would set: ``https://pulp.example.com:24816``.
+
+
 .. _content-path-prefix:
 
 CONTENT_PATH_PREFIX

--- a/pulpcore/app/serializers/fields.py
+++ b/pulpcore/app/serializers/fields.py
@@ -241,11 +241,11 @@ class BaseURLField(serializers.CharField):
 
     def to_representation(self, value):
         base_path = value
-        host = settings.CONTENT_HOST
+        origin = settings.CONTENT_ORIGIN
         prefix = settings.CONTENT_PATH_PREFIX
         return '/'.join(
             (
-                host.strip('/'),
+                origin.strip('/'),
                 prefix.strip('/'),
                 base_path.lstrip('/')
             ))

--- a/pulpcore/app/settings.py
+++ b/pulpcore/app/settings.py
@@ -10,8 +10,12 @@ https://docs.djangoproject.com/en/1.11/ref/settings/
 
 import os
 from contextlib import suppress
+from gettext import gettext as _
 from importlib import import_module
 from pkg_resources import iter_entry_points
+
+from django.core.exceptions import ImproperlyConfigured
+
 
 # Build paths inside the project like this: os.path.join(BASE_DIR, ...)
 BASE_DIR = os.path.dirname(os.path.abspath(__file__))
@@ -234,3 +238,9 @@ settings = dynaconf.DjangoDynaconf(
     ENVVAR_FOR_DYNACONF='PULP_SETTINGS',
 )
 # HERE ENDS DYNACONF EXTENSION LOAD (No more code below this line)
+
+
+try:
+    CONTENT_ORIGIN
+except NameError:
+    raise ImproperlyConfigured(_('You must specify the CONTENT_ORIGIN setting.'))

--- a/pulpcore/tests/functional/api/using_plugin/test_content_promotion.py
+++ b/pulpcore/tests/functional/api/using_plugin/test_content_promotion.py
@@ -79,8 +79,7 @@ class ContentPromotionTestCase(unittest.TestCase):
         unit_urls = []
         unit_path = get_added_content(repo)[FILE_CONTENT_NAME][0]['relative_path']
         for distribution in distributions:
-            unit_url = cfg.get_hosts('api')[0].roles['api']['scheme']
-            unit_url += '://' + distribution['base_url'] + '/'
+            unit_url = distribution['base_url'] + '/'
             unit_urls.append(urljoin(unit_url, unit_path))
 
         client.response_handler = api.safe_handler

--- a/pulpcore/tests/functional/api/using_plugin/test_distributions.py
+++ b/pulpcore/tests/functional/api/using_plugin/test_distributions.py
@@ -305,12 +305,11 @@ class ContentServePublicationDistributionTestCase(unittest.TestCase):
 
         added_content = get_added_content(repo)
         unit_path = added_content[FILE_CONTENT_NAME][0]['relative_path']
-        unit_url = self.cfg.get_hosts('api')[0].roles['api']['scheme']
-        unit_url += '://' + distribution['base_url'] + '/'
+        unit_url = distribution['base_url'] + '/'
         unit_url = urljoin(unit_url, unit_path)
 
         pulp_hash = hashlib.sha256(
-            self.client.using_handler(api.safe_handler).get(unit_url).content
+            self.client.get(unit_url).content
         ).hexdigest()
         fixtures_hash = hashlib.sha256(
             utils.http_get(urljoin(FILE_URL, unit_path))
@@ -323,12 +322,10 @@ class ContentServePublicationDistributionTestCase(unittest.TestCase):
         unit_url = reduce(
             urljoin,
             (
-                self.cfg.get_content_host_base_url(),
-                '//' + distribution['base_url'] + '/',
-                'PULP_MANIFEST'
+                distribution['base_url'] + '/', 'PULP_MANIFEST'
             ),
         )
-        return self.client.using_handler(api.safe_handler).get(unit_url)
+        return self.client.get(unit_url)
 
 
 def parse_pulp_manifest(pulp_manifest):

--- a/template_config.yml
+++ b/template_config.yml
@@ -21,7 +21,7 @@ plugin_dash_short: pulpcore
 plugin_name: pulpcore
 plugin_snake: pulpcore
 pulp_settings:
-  content_host: $(hostname):24816
+  content_origin: http://$(hostname):24816
 pydocstyle: true
 pypi_username: pulp
 test_bindings: true


### PR DESCRIPTION
This also adds a check that the user specified CONTENT_ORIGIN at
startup. Pulp refuses to start if it is not set with an error message
for the user.

Required PR: https://github.com/PulpQE/pulp-smash/pull/1227
Required PR: https://github.com/pulp/ansible-pulp/pull/185
Required PR: https://github.com/pulp/pulp_file/pull/303

https://pulp.plan.io/issues/5629
re #5629