### PR TITLE
Make file required on ArtifactSerializer

### DIFF
--- a/.travis/test_bindings.rb
+++ b/.travis/test_bindings.rb
@@ -122,7 +122,7 @@ repository_version_1 = @repoversions_api.read(created_resources[0])
 
 # Create an artifact from a local file
 file_path = File.join(ENV['TRAVIS_BUILD_DIR'], '.travis/test_bindings.rb')
-artifact = @artifacts_api.create({file: File.new(file_path)})
+artifact = @artifacts_api.create(File.new(file_path))
 
 # Create a FileContent from the artifact
 filecontent_response = @filecontent_api.create('foo.tar.gz', {artifact: artifact.pulp_href})

--- a/pulpcore/app/serializers/content.py
+++ b/pulpcore/app/serializers/content.py
@@ -157,12 +157,11 @@ class ArtifactSerializer(base.ModelSerializer):
     file = serializers.FileField(
         help_text=_("The stored file."),
         allow_empty_file=True,
-        required=False
     )
 
     size = serializers.IntegerField(
         help_text=_("The size of the file in bytes."),
-        required=False
+        required=False,
     )
 
     md5 = serializers.CharField(

--- a/pulpcore/tests/unit/serializers/test_content.py
+++ b/pulpcore/tests/unit/serializers/test_content.py
@@ -1,0 +1,31 @@
+from unittest import TestCase
+
+import mock
+from pulpcore.app.serializers import ArtifactSerializer
+
+
+class TestArtifactSerializer(TestCase):
+
+    def test_validate_file_checksum(self):
+        mock_file = mock.MagicMock(size=42)
+        mock_file.hashers.__getitem__.return_value.hexdigest.return_value = 'asdf'
+
+        data = {'file': mock_file}
+        serializer = ArtifactSerializer(data=data)
+        self.assertTrue(serializer.is_valid())
+        new_data = serializer.validated_data
+        self.assertEqual(new_data, {
+            'file': mock_file,
+            'size': 42,
+            'md5': 'asdf',
+            'sha1': 'asdf',
+            'sha224': 'asdf',
+            'sha256': 'asdf',
+            'sha384': 'asdf',
+            'sha512': 'asdf',
+        })
+
+    def test_emtpy_data(self):
+        data = {}
+        serializer = ArtifactSerializer(data=data)
+        self.assertFalse(serializer.is_valid())


### PR DESCRIPTION
When refactoring the upload mechanics away from the artifacts endpoint, this
has been missed.

[noissue]

Please be sure you have read our documentation on creating PRs:
https://docs.pulpproject.org/en/3.0/nightly/contributing/pull-request-walkthrough.html
