### PR TITLE
Return HTML listing of directories served by content app

### DIFF
--- a/CHANGES/5378.feature
+++ b/CHANGES/5378.feature
@@ -1,0 +1,2 @@
+Adds ability to view content served by pulpcore-content in a browser.
+


### PR DESCRIPTION
This patch enables users to browse each distribution. However, the /pulp/content/ endpoint
continues to return a 404.

When a user requests the 'base_url' of a Distribution or any path that ends in '/' inside the
Distribution's 'base_url' path, the pulpcore-content app looks for either a PublishedArtifact
or ContentArtifact with a relative path equal to <requested path>'index.html'. If no such
relative path is found for the RepositoryVersion or Publication, an HTML page is dynamically
generated and returned.

closes #5378
https://pulp.plan.io/issues/5378