### PR TITLE
pulpcore-content return  HTML list of avaiable distributions

### DIFF
--- a/CHANGES/5397.feature
+++ b/CHANGES/5397.feature
@@ -1,0 +1,2 @@
+Adds ability to view distributions served by pulpcore-content in a browser.
+

--- a/pulpcore/content/__init__.py
+++ b/pulpcore/content/__init__.py
@@ -47,5 +47,6 @@ async def server(*args, **kwargs):
                                                            module=CONTENT_MODULE_NAME)
             with suppress(ModuleNotFoundError):
                 import_module(content_module_name)
+    app.add_routes([web.get(settings.CONTENT_PATH_PREFIX, Handler().list_distributions)])
     app.add_routes([web.get(settings.CONTENT_PATH_PREFIX + '{path:.+}', Handler().stream_content)])
     return app


### PR DESCRIPTION
This patch enables the user to browse :24816/pulp/content/ to see the list of available
distributions.

closes: #5397
https://pulp.plan.io/issues/5397
