### PR TITLE
Fix __str__ method pulp_type for master models

### DIFF
--- a/CHANGES/5733.bugfix
+++ b/CHANGES/5733.bugfix
@@ -1,0 +1,1 @@
+Fix the pulp_type field output in __str__ for MasterModels.

--- a/CHANGES/plugin_api/5733.bugfix
+++ b/CHANGES/plugin_api/5733.bugfix
@@ -1,0 +1,1 @@
+Fix the pulp_type field output in __str__ for MasterModels.

--- a/pulpcore/app/models/base.py
+++ b/pulpcore/app/models/base.py
@@ -147,9 +147,13 @@ class MasterModel(Model, metaclass=MasterModelMeta):
             return super().__str__()
 
         try:
-            return '<{} (pulp_type={}): {}>'.format(self._meta.object_name, cast.TYPE, cast.name)
+            return '<{} (pulp_type={}): {}>'.format(self._meta.object_name,
+                                                    cast.pulp_type,
+                                                    cast.name)
         except AttributeError:
-            return '<{} (pulp_type={}): pk={}>'.format(self._meta.object_name, cast.TYPE, cast.pk)
+            return '<{} (pulp_type={}): pk={}>'.format(self._meta.object_name,
+                                                       cast.pulp_type,
+                                                       cast.pk)
 
 
 # Add properties to model _meta info to support master/detail models


### PR DESCRIPTION
The pulp_type field is different than TYPE (eg file.file vs file).

fixes #5733
https://pulp.plan.io/issues/5733

Please be sure you have read our documentation on creating PRs:
https://docs.pulpproject.org/en/3.0/nightly/contributing/pull-request-walkthrough.html
