### PR TITLE
Fix repository parameter name in OpenAPI schema

### DIFF
--- a/.travis/install.sh
+++ b/.travis/install.sh
@@ -70,7 +70,7 @@ images:
         - ./$PLUGIN
         - $PULP_CERTGUARD
 VARSYAML
-ansible-playbook build.yaml
+ansible-playbook -v build.yaml
 
 cd $TRAVIS_BUILD_DIR/../pulp-operator
 # Tell pulp-perator to deploy our image

--- a/.travis/test_bindings.py
+++ b/.travis/test_bindings.py
@@ -161,6 +161,9 @@ created_resources = monitor_task(repo_version_response.task)
 repository_version_2 = filerepoversions.read(created_resources[0])
 pprint(repository_version_2)
 
+# List all the repository versions
+filerepoversions.list(repository.pulp_href)
+
 # Create a publication from the latest version of the repository
 publish_data = FileFilePublication(repository=repository.pulp_href)
 publish_response = filepublications.create(publish_data)

--- a/.travis/test_bindings.rb
+++ b/.travis/test_bindings.rb
@@ -138,6 +138,9 @@ created_resources = monitor_task(repo_version_response.task)
 
 repository_version_2 = @repoversions_api.read(created_resources[0])
 
+# List all the repository versions
+@repoversions_api.list(file_repository.pulp_href)
+
 # Create a publication from the latest version of the repository
 publish_data = PulpFileClient::FileFilePublication.new({repository: file_repository.pulp_href})
 publish_response = @filepublications_api.create(publish_data)

--- a/CHANGES/5760.bugfix
+++ b/CHANGES/5760.bugfix
@@ -1,0 +1,1 @@
+Fix path parameter in OpenAPI schema for Repoistory Version endpoints.

--- a/pulpcore/app/openapigenerator.py
+++ b/pulpcore/app/openapigenerator.py
@@ -9,7 +9,7 @@ from drf_yasg.inspectors import SwaggerAutoSchema
 from drf_yasg.openapi import Parameter
 from drf_yasg.utils import filter_none, force_real_str
 
-from pulpcore.app.viewsets import RepositoryVersionViewSet
+from pulpcore.app.models import RepositoryVersion
 
 
 class Paths(openapi.SwaggerDict):
@@ -106,7 +106,7 @@ class PulpOpenAPISchemaGenerator(OpenAPISchemaGenerator):
                             resource_model = view.queryset.model
                         resource_name = self.get_parameter_name(resource_model)
                         prefix_ = None
-                        if issubclass(view_cls, RepositoryVersionViewSet):
+                        if issubclass(resource_model, RepositoryVersion):
                             prefix_ = view_cls.parent_viewset.endpoint_name
                         param_name = self.get_parameter_slug_from_model(resource_model, prefix_)
                         if resource_path in resources:


### PR DESCRIPTION
The prefix for the *_repository_version_href was getting applied to *_repository_href slug
names. This patch limits it to only *_repository_version_href.

re: #5760
https://pulp.plan.io/issues/5760