### PR TITLE
containers: Adapt for pulp_container rename

### DIFF
--- a/containers/vars/defaults.yaml
+++ b/containers/vars/defaults.yaml
@@ -47,7 +47,7 @@ images:
         - pulp-file
         - pulp-ansible
         - pulp-cookbook
-        - pulp-docker
+        - pulp-container
         - pulp-maven
         - pulp-python
         - pulp-rpm
@@ -60,7 +60,7 @@ images:
         - "git+https://github.com/pulp/pulp_file.git"
         - "git+https://github.com/pulp/pulp_ansible.git"
         - "git+https://github.com/gmbnomis/pulp_cookbook.git"
-        - "git+https://github.com/pulp/pulp_docker.git"
+        - "git+https://github.com/pulp/pulp_container.git"
         - "git+https://github.com/pulp/pulp_maven.git"
         - "git+https://github.com/pulp/pulp_python.git"
         - "git+https://github.com/pulp/pulp_rpm.git"


### PR DESCRIPTION
(noissue because it only affects the container vars that are currently only a
reference for manually building the all-in-one image.)
[noissue]

Please be sure you have read our documentation on creating PRs:
https://docs.pulpproject.org/en/3.0/nightly/contributing/pull-request-walkthrough.html
