### PR TITLE
Move Rest API to its own section.

### DIFF
--- a/CHANGES/5722.doc
+++ b/CHANGES/5722.doc
@@ -1,0 +1,1 @@
+Adding dedicated `Rest API` left-navigation section.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -98,8 +98,9 @@ Table of Contents
    from-pulp-2
    components
    installation/index
-   plugins/index
    workflows/index
+   plugins/index
+   rest_api
    integration-guide/index
    contributing/index
    bugs-features

--- a/docs/integration-guide/index.rst
+++ b/docs/integration-guide/index.rst
@@ -1,13 +1,3 @@
-REST API Documentation
-======================
-
-The REST API documentation for pulpcore can be `found here <../restapi.html>`_.
-
-The documentation is auto generated based on the OpenAPI schema for the REST API. The hosted
-documentation is broken up between ``pulpcore`` and each of the plugin's documentation sites.
-Users can view the REST API documentation for their instance of Pulp by pointing their browser at
-``http://<pulp-hostname>:24817/pulp/api/v3/docs/``.
-
 Python Client for pulpcore's REST API
 =====================================
 

--- a/docs/rest_api.rst
+++ b/docs/rest_api.rst
@@ -1,0 +1,12 @@
+REST API
+========
+
+.. note::
+
+    The REST API documentation is `here <../restapi.html>`_.
+
+
+The documentation is auto generated based on the OpenAPI schema for the REST API. The hosted
+documentation is broken up between ``pulpcore`` and each of the plugin's documentation sites.
+Users can view the REST API documentation for their instance of Pulp by pointing their browser at
+``http://<pulp-hostname>:24817/pulp/api/v3/docs/``.


### PR DESCRIPTION
We originally wanted the left-side navigation link to directly link to
the ../restapi.html page, but sphinx doesn't allow for that. The
left-navigation comes from the toctree, which requires each entry to be
a page.

https://pulp.plan.io/issues/5722
closes #5722

