### PR TITLE
Release resources when worker is cleaned up

### DIFF
--- a/CHANGES/5673.bugfix
+++ b/CHANGES/5673.bugfix
@@ -1,0 +1,1 @@
+Release reservations for tasks when cleaned up by another worker.

--- a/pulpcore/tasking/util.py
+++ b/pulpcore/tasking/util.py
@@ -54,6 +54,7 @@ def cancel(task_id):
         task_status.state = TASK_STATES.CANCELED
         task_status.save()
         _delete_incomplete_resources(task_status)
+        task_status.release_resources()
 
     _logger.info(_('Task canceled: {id}.').format(id=task_id))
     return task_status


### PR DESCRIPTION
https://pulp.plan.io/issues/5673
closes #5673
