### PR TITLE
Remove "missing_workers" from Status API

### DIFF
--- a/CHANGES/5786.bugfix
+++ b/CHANGES/5786.bugfix
@@ -1,0 +1,2 @@
+Only online workers are shown in the ``/pulp/api/v3/status/`` causing environments where worker
+names change to not accumulate workers endlessly.

--- a/CHANGES/5786.removal
+++ b/CHANGES/5786.removal
@@ -1,0 +1,2 @@
+The ``/pulp/api/v3/status/`` had the ``missing_workers`` section removed. Also the
+``online_workers`` key had the ``online`` and ``missing`` keys removed.

--- a/pulpcore/app/serializers/status.py
+++ b/pulpcore/app/serializers/status.py
@@ -76,16 +76,9 @@ class StatusSerializer(serializers.Serializer):
         many=True
     )
 
-    missing_workers = WorkerSerializer(
-        help_text=_("List of missing workers known to the application. A missing worker is a "
-                    "worker that was online, but has now stopped heartbeating and has potentially "
-                    "died"),
-        many=True
-    )
-
     online_content_apps = ContentAppStatusSerializer(
-        help_text=_("List of online content apps known to the application. An online worker is "
-                    "actively heartbeating"),
+        help_text=_("List of online content apps known to the application. An online content app "
+                    "is actively heartbeating and can serve data to clients"),
         many=True
     )
 

--- a/pulpcore/app/serializers/task.py
+++ b/pulpcore/app/serializers/task.py
@@ -154,18 +154,10 @@ class WorkerSerializer(ModelSerializer):
         help_text=_('Timestamp of the last time the worker talked to the service.'),
         read_only=True
     )
-    online = serializers.BooleanField(
-        help_text=_('True if the worker is considered online, otherwise False'),
-        read_only=True
-    )
-    missing = serializers.BooleanField(
-        help_text=_('True if the worker is considerd missing, otherwise False'),
-        read_only=True
-    )
     # disable "created" because we don't care about it
     created = None
 
     class Meta:
         model = models.Worker
         _base_fields = tuple(set(ModelSerializer.Meta.fields) - set(['created']))
-        fields = _base_fields + ('name', 'last_heartbeat', 'online', 'missing')
+        fields = _base_fields + ('name', 'last_heartbeat')

--- a/pulpcore/app/views/status.py
+++ b/pulpcore/app/views/status.py
@@ -59,11 +59,6 @@ class StatusView(APIView):
             online_workers = None
 
         try:
-            missing_workers = Worker.objects.missing_workers()
-        except Exception:
-            missing_workers = None
-
-        try:
             online_content_apps = ContentAppStatus.objects.online()
         except Exception:
             online_content_apps = None
@@ -71,7 +66,6 @@ class StatusView(APIView):
         data = {
             'versions': versions,
             'online_workers': online_workers,
-            'missing_workers': missing_workers,
             'online_content_apps': online_content_apps,
             'database_connection': db_status,
             'redis_connection': redis_status,

--- a/pulpcore/tests/functional/api/test_status.py
+++ b/pulpcore/tests/functional/api/test_status.py
@@ -101,7 +101,6 @@ class StatusTestCase(unittest.TestCase):
         validate(status, STATUS)
         self.assertTrue(status['database_connection']['connected'])
         self.assertTrue(status['redis_connection']['connected'])
-        self.assertEqual(status['missing_workers'], [])
         self.assertNotEqual(status['online_workers'], [])
         self.assertNotEqual(status['versions'], [])
         self.assertIsNotNone(status['storage'])


### PR DESCRIPTION
Having "missing_workers" did not work well when worker names are unique
each time. It accumulated an endless number of worker names.

https://pulp.plan.io/issues/5786
closes #5786

