### PR TITLE
Problem: plugin-template & pulpcore should use additional_plugins

### DIFF
--- a/.travis/install.sh
+++ b/.travis/install.sh
@@ -10,9 +10,7 @@
 set -euv
 
 if [ "$TEST" = 'docs' ]; then
-
   pip install psycopg2-binary
-
   pip install -r doc_requirements.txt
 fi
 
@@ -48,10 +46,11 @@ else
 fi
 
 
-PLUGIN=pulp_file
-
-
-# For pulpcore, and any other repo that might check out some plugin PR
+if [ -e $TRAVIS_BUILD_DIR/../pulp_file ]; then
+  PULP_FILE=./pulp_file
+else
+  PULP_FILE=git+https://github.com/pulp/pulp_file.git@master
+fi
 
 if [ -e $TRAVIS_BUILD_DIR/../pulp-certguard ]; then
   PULP_CERTGUARD=./pulp-certguard
@@ -59,15 +58,15 @@ else
   PULP_CERTGUARD=git+https://github.com/pulp/pulp-certguard.git@master
 fi
 
-  cat > vars/vars.yaml << VARSYAML
+cat > vars/vars.yaml << VARSYAML
 ---
 images:
-  - ${PLUGIN}-${TAG}:
-      image_name: $PLUGIN
+  - pulp_file-${TAG}:
+      image_name: pulp_file
       tag: $TAG
       pulpcore: ./pulpcore
       plugins:
-        - ./$PLUGIN
+        - $PULP_FILE
         - $PULP_CERTGUARD
 VARSYAML
 ansible-playbook -v build.yaml
@@ -85,7 +84,7 @@ spec:
     access_mode: "ReadWriteOnce"
     # We have a little over 40GB free on Travis VMs/instances
     size: "40Gi"
-  image: $PLUGIN
+  image: pulp_file
   tag: $TAG
   database_connection:
     username: pulp

--- a/.travis/pre_before_install.sh
+++ b/.travis/pre_before_install.sh
@@ -5,7 +5,7 @@ export PULP_FILE_PR_NUMBER=$(echo $COMMIT_MSG | grep -oP 'Required\ PR:\ https\:
 export PULP_CERTGUARD_PR_NUMBER=$(echo $COMMIT_MSG | grep -oP 'Required\ PR:\ https\:\/\/github\.com\/pulp\/pulp-certguard\/pull\/(\d+)' | awk -F'/' '{print $7}')
 
 pip install yq
-PULP_FILE_BRANCH=$(yq -r .pulpcore_branch ./template_config.yml)
+PULP_FILE_BRANCH=$(yq -r ".additional_plugins | .[] | select(.name == \"pulp_file\") | .branch" template_config.yml)
 echo PULP_FILE_BRANCH="$PULP_FILE_BRANCH"
 
 cd ..

--- a/template_config.yml
+++ b/template_config.yml
@@ -1,7 +1,13 @@
 # This config represents the latest values used when running the plugin-template. Any settings that
 # were not present before running plugin-template have been added with their default values.
 
+# pulp_file is hardcoded in plugin_template when generating for pulpcore in some
+# places. In other places, plugin_template uses generic logic for it, so we
+# specify it here.
+# Also, .travis/pre_before_install.sh reads the pulp_file branch. At runtime,
+# not template generation time.
 additional_plugins:
+- { name: pulp_file, branch: master }
 - { name: pulp-certguard, branch: master }
 black: false
 check_commit_message: true
@@ -22,7 +28,7 @@ plugin_dash_short: pulpcore
 plugin_name: pulpcore
 plugin_snake: pulpcore
 pulp_settings: null
-pulpcore_branch: master
+pulpcore_branch: null
 pydocstyle: true
 pypi_username: pulp
 test_bindings: true


### PR DESCRIPTION
to specify pulp_file's branch instead of pulpcore_branch.

Solution: re-generate with latest template, and update
pre_before_install.sh to read additional_plugins.

re: https://github.com/pulp/pulpcore/pull/409

re: #5810
plugin-template and pulpcore should use additional_plugins var to specify the pulp_file branch
https://pulp.plan.io/issues/5810

[noissue]

Please be sure you have read our documentation on creating PRs:
https://docs.pulpproject.org/en/3.0/nightly/contributing/pull-request-walkthrough.html
