### PR TITLE
Move the section Static Content to Architecture and Deploying

### DIFF
--- a/CHANGES/5716.doc
+++ b/CHANGES/5716.doc
@@ -1,0 +1,1 @@
+Move the section "Static Content" to "Architecture and Deploying"

--- a/docs/components.rst
+++ b/docs/components.rst
@@ -75,26 +75,24 @@ Resource Manager
    the same repo should not run in parallel. Generally tasks are serialized at the "repo" level, so
    if you have N workers you can process N repo sync's concurrently.
 
-.. _static-content:
 
 Static Content
-==============
+--------------
 
 When browsing the REST API or the browsable documentation with a web browser, for a good experience,
 you'll need static content to be served.
 
 In Development
---------------
+^^^^^^^^^^^^^^
 
 If using the built-in Django webserver and your settings.yaml has ``DEBUG: True`` then static
 content is automatically served for you.
 
 In Production
--------------
-
-For production environments, configure static content as follows:
+^^^^^^^^^^^^^
 
 Collect all of the static content into place using the ``collectstatic`` command
 as follows::
 
     $ django-admin collectstatic
+


### PR DESCRIPTION
In this commit, there is also removed a redundant note about configuring static content.
This paragraph started to rot after the following commit https://github.com/pulp/pulpcore/commit/aa79d05c669802e58d75f6bd3340a948ecb9cf93

closes #5716
https://pulp.plan.io/issues/5716
