### PR TITLE
Properly reflect GPLv2+ in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Using Pulp you can:
 - Promote content through different repos in an organized way
 
 Pulp is completely free and open-source!
-- License: GNUv2
+- License: GNUv2+
 - Documentation: http://docs.pulpproject.org/en/3.0/nightly/
 - Source: https://github.com/pulp/pulpcore/
 - Bugs: https://pulp.plan.io/projects/pulp


### PR DESCRIPTION
The license that pulpcore uses includes the clause to apply future versions of the GPL to it, which implies a GPLv2+ (meaning it can be used with GPLv3 projects)

setup.py also indicates this