### PR TITLE
Allow multiple resource-managers to be started

### DIFF
--- a/CHANGES/3707.doc
+++ b/CHANGES/3707.doc
@@ -1,0 +1,1 @@
+Added info about ``resource-manager`` High Availability to the docs.

--- a/CHANGES/3707.feature
+++ b/CHANGES/3707.feature
@@ -1,0 +1,1 @@
+Multiple resource-managers can be started and only one will be active.

--- a/CHANGES/3707.removal
+++ b/CHANGES/3707.removal
@@ -1,0 +1,3 @@
+Resource managers must now have the name ``resource-manager``. For example::
+
+     /path/to/python/bin/rq worker -n 'resource-manager' -w 'pulpcore.tasking.worker.PulpWorker' -c 'pulpcore.rqconfig'

--- a/containers/images/pulp/container-assets/pulp-resource-manager
+++ b/containers/images/pulp/container-assets/pulp-resource-manager
@@ -3,4 +3,4 @@
 /usr/bin/wait_on_postgres.py
 /usr/bin/wait_on_database_migrations.sh
 
-exec rq worker --url "redis://${REDIS_SERVICE_HOST}:${REDIS_SERVICE_PORT}" -n "resource-manager@${HOSTNAME}" -w "pulpcore.tasking.worker.PulpWorker" -c "pulpcore.rqconfig"
+exec rq worker --url "redis://${REDIS_SERVICE_HOST}:${REDIS_SERVICE_PORT}" -n "resource-manager" -w "pulpcore.tasking.worker.PulpWorker" -c "pulpcore.rqconfig"

--- a/docs/components.rst
+++ b/docs/components.rst
@@ -69,13 +69,17 @@ Worker
 Resource Manager
   A different type of Pulp worker that plays a coordinating role for the tasking system. You must
   run exactly one of these for Pulp to operate correctly. The ``resource-manager`` is identified by
-  configuring its name with the ``-n 'resource_manager'``.
+  configuring using exactly the name ``resource-manager`` with the ``-n 'resource_manager'`` option.
+
+  *N* ``resource-manager`` rq processes can be started with 1 being active and *N-1* being passive.
+  The *N-1* will exit and should be configured to auto-relaunch with either systemd, supervisord, or
+  k8s.
 
 .. note::
 
    Pulp serializes tasks that are unsafe to run in parallel, e.g. a sync and publish operation on
    the same repo should not run in parallel. Generally tasks are serialized at the "repo" level, so
-   if you have N workers you can process N repo sync's concurrently.
+   if you start *N* workers you can process *N* repo sync/modify/publish operations concurrently.
 
 
 Static Content

--- a/docs/installation/instructions.rst
+++ b/docs/installation/instructions.rst
@@ -76,8 +76,7 @@ PyPI Installation
     In place of using the systemd unit files provided in the `systemd-setup` section, you can run
     the commands yourself inside of a shell. This is fine for development but not recommended in production::
 
-    $ /path/to/python/bin/rq worker -n 'resource-manager@%h' -w 'pulpcore.tasking.worker.PulpWorker' -c 'pulpcore.rqconfig'
-    $ /path/to/python/bin/rq worker -w 'pulpcore.tasking.worker.PulpWorker' -c 'pulpcore.rqconfig'
+    $ /path/to/python/bin/rq worker -n 'resource-manager' -w 'pulpcore.tasking.worker.PulpWorker' -c 'pulpcore.rqconfig'
     $ /path/to/python/bin/rq worker -w 'pulpcore.tasking.worker.PulpWorker' -c 'pulpcore.rqconfig'
 
 8. Run Django Migrations::

--- a/pulpcore/app/models/task.py
+++ b/pulpcore/app/models/task.py
@@ -121,7 +121,7 @@ class WorkerManager(models.Manager):
             Worker.DoesNotExist: If all Workers have at least one ReservedResource entry.
         """
         workers_qs = self.online_workers().exclude(
-            name__startswith=TASKING_CONSTANTS.RESOURCE_MANAGER_WORKER_NAME
+            name=TASKING_CONSTANTS.RESOURCE_MANAGER_WORKER_NAME
         )
         workers_qs_with_counts = workers_qs.annotate(models.Count('reservations'))
         try:
@@ -215,7 +215,7 @@ class WorkerManager(models.Manager):
             :class:`django.db.models.query.QuerySet`:  A query set of the Worker objects which
                 which match the resource manager name.
         """
-        return self.filter(name__startswith=TASKING_CONSTANTS.RESOURCE_MANAGER_WORKER_NAME)
+        return self.filter(name=TASKING_CONSTANTS.RESOURCE_MANAGER_WORKER_NAME)
 
 
 class Worker(Model):

--- a/pulpcore/tasking/services/worker_watcher.py
+++ b/pulpcore/tasking/services/worker_watcher.py
@@ -75,10 +75,10 @@ def check_worker_processes():
         mark_worker_offline(worker.name)
 
     worker_count = Worker.objects.online_workers().exclude(
-        name__startswith=TASKING_CONSTANTS.RESOURCE_MANAGER_WORKER_NAME).count()
+        name=TASKING_CONSTANTS.RESOURCE_MANAGER_WORKER_NAME).count()
 
     resource_manager_count = Worker.objects.online_workers().filter(
-        name__startswith=TASKING_CONSTANTS.RESOURCE_MANAGER_WORKER_NAME).count()
+        name=TASKING_CONSTANTS.RESOURCE_MANAGER_WORKER_NAME).count()
 
     if resource_manager_count == 0:
         msg = _("There are 0 pulpcore-resource-manager processes running. Pulp will not operate "

--- a/pulpcore/tasking/worker.py
+++ b/pulpcore/tasking/worker.py
@@ -54,7 +54,7 @@ class PulpWorker(Worker):
         else:
             kwargs['name'] = "{pid}@{hostname}".format(pid=os.getpid(), hostname=socket.getfqdn())
 
-        if kwargs['name'].startswith(TASKING_CONSTANTS.RESOURCE_MANAGER_WORKER_NAME):
+        if kwargs['name'] == TASKING_CONSTANTS.RESOURCE_MANAGER_WORKER_NAME:
             queues = [Queue('resource-manager', connection=kwargs['connection'])]
         else:
             queues = [Queue(kwargs['name'], connection=kwargs['connection'])]


### PR DESCRIPTION
The resource manager name must exctly equal `resource-manager` and
multiple of them can be started at once safely.

https://pulp.plan.io/issues/3707
closes #3707