### PR TITLE
containers: Use Fedora 30's test Errata for libcomps

### DIFF
--- a/containers/images/pulp/Dockerfile.j2
+++ b/containers/images/pulp/Dockerfile.j2
@@ -31,11 +31,13 @@ RUN		dnf -y update && \
 		dnf -y install python3-psycopg2 && \
 		dnf -y install glibc-langpack-en && \
 		dnf -y install python3-createrepo_c && \
-		dnf -y install libmodulemd-devel && \
 		dnf -y install python3-libmodulemd && \
-		dnf -y install libcomps-devel && \
 		dnf -y install python3-libcomps && \
 		dnf clean all
+
+# Until the update is re-submitted & released
+# https://bodhi.fedoraproject.org/updates/FEDORA-2019-0d122cc67a
+RUN rpm -q python3-libcomps --queryformat=%{VERSION}-%{RELEASE} | grep -v 0.1.11-1 || dnf upgrade -y --enablerepo=updates-testing python3-libcomps
 
 # Docs suggest RHEL8 uses the alternatives system for /usr/bin/python ,
 # but Fedora does not.


### PR DESCRIPTION
until they release the Errata.

So that python3-libcomps can have .egg-info metadata available
for pip to see that libcomps is already satisfied for pulp_rpm.

They already released the corresponding Errata for Fedora 31,
so this should be very safe.

Also, cleanup currently unneeded -devel packages.

[noissue]

re: #5840
as a user of pulp_rpm_prerequisites I have libcomps installed from pypi
https://pulp.plan.io/issues/5840