### PR TITLE
Fix incorrect licensing claim

### DIFF
--- a/CHANGES/4592.doc
+++ b/CHANGES/4592.doc
@@ -1,0 +1,1 @@
+Fix an incorrect license claim in the docs. Pulp is GPLv2+.

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Using Pulp you can:
 - Promote content through different repos in an organized way
 
 Pulp is completely free and open-source!
-- License: GNUv2
+- License: GPLv2+
 - Documentation: http://docs.pulpproject.org/en/3.0/nightly/
 - Source: https://github.com/pulp/pulpcore/
 - Bugs: https://pulp.plan.io/projects/pulp


### PR DESCRIPTION
Pulp is GPLv2+ licensed not GNUv2. GNUv2 isn't technicall a license
either.

https://pulp.plan.io/issues/4592
closes #4592
