### PR TITLE
Adds changelog

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -13,6 +13,64 @@ Changelog
 
 .. towncrier release notes start
 
+3.0.0 (2019-12-11)
+==================
+
+.. note::
+
+    Task names, e.g. ``pulpcore.app.tasks.orphan.orphan_cleanup``, are subject to change in future
+    releases 3.y releases. These are represented in the Task API as the "name" attribute. Please
+    check future release notes to see when these names will be considered stable. Otherwise, the
+    REST API pulpcore provides is considered semantically versioned.
+
+
+REST API
+--------
+
+Features
+~~~~~~~~
+
+- Pulp will do validation that a new repository version contains only content which is supported by
+  the Repository type. Using the same a-priori knowledge of content types, increase performance of
+  duplicate removal.
+  `#5701 <https://pulp.plan.io/issues/5701>`_
+
+
+Bugfixes
+~~~~~~~~
+
+- Improve speed and memory performance.
+  `#5688 <https://pulp.plan.io/issues/5688>`_
+
+
+Improved Documentation
+~~~~~~~~~~~~~~~~~~~~~~
+
+- Fix an incorrect license claim in the docs. Pulp is GPLv2+.
+  `#4592 <https://pulp.plan.io/issues/4592>`_
+- Labeling 3.0 features as tech preview.
+  `#5563 <https://pulp.plan.io/issues/5563>`_
+- Simplified docs index page.
+  `#5714 <https://pulp.plan.io/issues/5714>`_
+- Add text to Promotion page.
+  `#5721 <https://pulp.plan.io/issues/5721>`_
+- Fixes and updates to the glossry page.
+  `#5726 <https://pulp.plan.io/issues/5726>`_
+
+
+Plugin API
+----------
+
+Features
+~~~~~~~~
+
+- Added a new required field called CONTENT_TYPES to the Repository model.
+  `#5701 <https://pulp.plan.io/issues/5701>`_
+
+
+----
+
+
 3.0.0rc9 (2019-12-03)
 =====================
 REST API

--- a/CHANGES/4592.doc
+++ b/CHANGES/4592.doc
@@ -1,1 +1,0 @@
-Fix an incorrect license claim in the docs. Pulp is GPLv2+.

--- a/CHANGES/5563.doc
+++ b/CHANGES/5563.doc
@@ -1,1 +1,0 @@
-Labeling 3.0 features as tech preview.

--- a/CHANGES/5688.bugfix
+++ b/CHANGES/5688.bugfix
@@ -1,1 +1,0 @@
-Improve speed and memory performance.

--- a/CHANGES/5701.feature
+++ b/CHANGES/5701.feature
@@ -1,3 +1,0 @@
-Pulp will do validation that a new repository version contains only content which is supported by
-the Repository type. Using the same a-priori knowledge of content types, increase performance of
-duplicate removal.

--- a/CHANGES/5714.doc
+++ b/CHANGES/5714.doc
@@ -1,1 +1,0 @@
-Simplified docs index page.

--- a/CHANGES/5721.doc
+++ b/CHANGES/5721.doc
@@ -1,1 +1,0 @@
-Add text to Promotion page.

--- a/CHANGES/5726.doc
+++ b/CHANGES/5726.doc
@@ -1,1 +1,0 @@
-Fixes and updates to the glossry page.

--- a/CHANGES/plugin_api/5701.feature
+++ b/CHANGES/plugin_api/5701.feature
@@ -1,1 +1,0 @@
-Added a new required field called CONTENT_TYPES to the Repository model.


### PR DESCRIPTION
In addition to the `towncrier` auto-generated changelog, this adds a
note about the values of the "name" field in the Task API possibly
changing in future versions.

[noissue]

(cherry picked from commit 10f58a2534f24b597b4c4db315b912b3dcc41918)

