### PR TITLE
Adds a note on where django-admin is found.

### DIFF
--- a/CHANGES/5859.doc
+++ b/CHANGES/5859.doc
@@ -1,0 +1,1 @@
+Clarifies where ``django-admin`` is found. Also notes the alternate name Katello environments use.

--- a/docs/installation/instructions.rst
+++ b/docs/installation/instructions.rst
@@ -81,8 +81,18 @@ PyPI Installation
 
 9. Run Django Migrations::
 
-   $ django-admin migrate --noinput
-   $ django-admin reset-admin-password --password admin
+    $ django-admin migrate --noinput
+    $ django-admin reset-admin-password --password admin
+
+.. note::
+
+    ``django-admin`` is provided by Django and is available wherever Django is installed. For
+    virtualenv based installs, that is from the activated virtualenv. For system-wide Django
+    installations, ``django-admin`` should be on your system path.
+
+    Katello users use an alternate binary, ``python3-django-admin`` which is available on the system
+    path. In Katello environments, the ``django-admin`` command is for the Django environment of
+    Pulp 2.
 
 10. Collect Static Media for live docs and browsable API::
 


### PR DESCRIPTION
The note identifies django-admin's location for virtualenv, system-wide,
and Katello environments.

https://pulp.plan.io/issues/5859
closes #5859

