### PR TITLE
Allow storages.backends.azure_storage.AzureStorage as value DEFAULT_F…

### DIFF
--- a/pulpcore/content/handler.py
+++ b/pulpcore/content/handler.py
@@ -539,7 +539,7 @@ class Handler:
         """
         if settings.DEFAULT_FILE_STORAGE == 'pulpcore.app.models.storage.FileSystem':
             return FileResponse(os.path.join(settings.MEDIA_ROOT, file.name), headers=headers)
-        elif settings.DEFAULT_FILE_STORAGE == 'storages.backends.s3boto3.S3Boto3Storage':
+        elif settings.DEFAULT_FILE_STORAGE == 'storages.backends.s3boto3.S3Boto3Storage' or settings.DEFAULT_FILE_STORAGE == 'storages.backends.azure_storage.AzureStorage':
             raise HTTPFound(file.url, headers=headers)
         else:
             raise NotImplementedError()


### PR DESCRIPTION
In order to use Azure Blob storage as location for the artifacts stored by Pulp 'storages.backends.azure_storage.AzureStorage' needs to be added as a valid value for this setting. I will add the required instructions on how to configure Azure storage next to the already available S3 documentation
