### PR TITLE
Publishes GA docs to docs.pulpproject.org/

### DIFF
--- a/CHANGES/5833.misc
+++ b/CHANGES/5833.misc
@@ -1,0 +1,1 @@
+Improvement of doc-builder.py used to publish docs.


### PR DESCRIPTION
This patch improves the .travis/docs-builder.py script. The script will always publish GA docs to
the root of docs.pulpproject.org. The same docs are also published into the docs.pulpproject.org/en/3.y/
directory. The same docs are also published to docs.pulpproject.org/en/3.y.z/ for long term storage.

Pre-release builds are always published into docs.pulpproject.org/en/<tag>/.

Nightly docs are pubished to docs.pulpproject.org/<branch_name>/nightly/.

closes: #5833
https://pulp.plan.io/issues/5833