### PR TITLE
REMOTE_USER auth shouldn't trigger csrf rejects

### DIFF
--- a/CHANGES/5955.bugfix
+++ b/CHANGES/5955.bugfix
@@ -1,0 +1,1 @@
+Webserver auth no longer prompts for csrf incorrectly.

--- a/CHANGES/5955.removal
+++ b/CHANGES/5955.removal
@@ -1,0 +1,4 @@
+Removed ``pulpcore.app.middleware.PulpRemoteUserMiddleware`` from the default middleware section.
+Also replaced ``rest_framework.authentication.RemoteUserAuthentication`` with
+``pulpcore.app.authentication.PulpRemoteUserAuthentication`` in the Django Rest Framework portion
+of the config.

--- a/pulpcore/app/authentication.py
+++ b/pulpcore/app/authentication.py
@@ -1,0 +1,8 @@
+from rest_framework.authentication import RemoteUserAuthentication
+
+from pulpcore.app import settings
+
+
+class PulpRemoteUserAuthentication(RemoteUserAuthentication):
+
+    header = settings.REMOTE_USER_ENVIRON_NAME

--- a/pulpcore/app/middleware.py
+++ b/pulpcore/app/middleware.py
@@ -1,7 +1,0 @@
-from django.contrib.auth.middleware import RemoteUserMiddleware
-
-from pulpcore.app import settings
-
-
-class PulpRemoteUserMiddleware(RemoteUserMiddleware):
-    header = settings.REMOTE_USER_ENVIRON_NAME

--- a/pulpcore/app/settings.py
+++ b/pulpcore/app/settings.py
@@ -87,7 +87,6 @@ MIDDLEWARE = [
     'django.middleware.common.CommonMiddleware',
     'django.middleware.csrf.CsrfViewMiddleware',
     'django.contrib.auth.middleware.AuthenticationMiddleware',
-    'pulpcore.app.middleware.PulpRemoteUserMiddleware',
     'django.contrib.messages.middleware.MessageMiddleware',
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
 ]
@@ -125,7 +124,7 @@ REST_FRAMEWORK = {
     'DEFAULT_PERMISSION_CLASSES': ('rest_framework.permissions.IsAuthenticated',),
     'DEFAULT_AUTHENTICATION_CLASSES': (
         'rest_framework.authentication.SessionAuthentication',
-        'rest_framework.authentication.RemoteUserAuthentication',
+        'pulpcore.app.authentication.PulpRemoteUserAuthentication',
         'rest_framework.authentication.BasicAuthentication',
     ),
     'UPLOADED_FILES_USE_URL': False,


### PR DESCRIPTION
Move all authentication fully to DRF. We were incorrectly configuring
webserver auth support in django and not DRF. This ports the setting
`REMOTE_USER_ENVIRON_NAME` to work with DRF instead of Django.

It adjusts the settings.py so there are removal claims even though this
will likely go into a z-release. It's an important FYI for the user.

https://pulp.plan.io/issues/5955
closes #5955

