### PR TITLE
Problem: pulpcore 3.0 CI is failing.

### DIFF
--- a/.travis/install.sh
+++ b/.travis/install.sh
@@ -73,6 +73,7 @@ ansible-playbook -v build.yaml
 
 cd $TRAVIS_BUILD_DIR/../pulp-operator
 # Tell pulp-perator to deploy our image
+# NOTE: With k3s 1.17, $TAG must be quoted. So that 3.0 does not become 3.
 cat > deploy/crds/pulpproject_v1alpha1_pulp_cr.yaml << CRYAML
 apiVersion: pulpproject.org/v1alpha1
 kind: Pulp
@@ -85,7 +86,7 @@ spec:
     # We have a little over 40GB free on Travis VMs/instances
     size: "40Gi"
   image: pulp_file
-  tag: $TAG
+  tag: "${TAG}"
   database_connection:
     username: pulp
     password: pulp


### PR DESCRIPTION
Is due to k3s interpreting the 3.0 image tag as 3 due to lack of
quotes.
And therefore thinking the image does not exist (ImagePullBackoff)

Solution: regenerate with latest plugin-template, but merge in changes
made to pulpcore master but not plugin-template master.

[noissue]

Please be sure you have read our documentation on creating PRs:
https://docs.pulpproject.org/en/3.0/nightly/contributing/pull-request-walkthrough.html
