### PR TITLE
Adds 'Modify Repository Content' operation summary

### DIFF
--- a/CHANGES/6002.bugfix
+++ b/CHANGES/6002.bugfix
@@ -1,0 +1,1 @@
+Adds operation_summary to the OpenAPI schema definition of repository modify operation

--- a/pulpcore/plugin/actions.py
+++ b/pulpcore/plugin/actions.py
@@ -18,6 +18,7 @@ class ModifyRepositoryActionMixin:
 
     @swagger_auto_schema(
         operation_description="Trigger an asynchronous task to create a new repository version.",
+        operation_summary="Modify Repository Content",
         responses={202: AsyncOperationResponseSerializer}
     )
     @action(detail=True, methods=["post"], serializer_class=RepositoryAddRemoveContentSerializer)


### PR DESCRIPTION
The OpenAPI schema definition of repository modify operation was missing a human readable
operation summary. This patch adds it.

fixes: #6002
https://pulp.plan.io/issues/6002
