### PR TITLE
Add a batching content iterator `content_batch_qs()` to `RepositoryVersion`

### DIFF
--- a/CHANGES/plugin_api/6024.feature
+++ b/CHANGES/plugin_api/6024.feature
@@ -1,0 +1,1 @@
+Add a batching content iterator ``content_batch_qs()`` to ``RepositoryVersion``.


### PR DESCRIPTION
Plugins need to iterate over the content in a repository version to create a publication.

`RepositoryVersion.content_batch_qs()` generates content batches to
efficiently iterate over all content.

fixes: #6024
https://pulp.plan.io/issues/6024
