### PR TITLE
Remove Remote Auth by Default

### DIFF
--- a/CHANGES/5949.doc
+++ b/CHANGES/5949.doc
@@ -1,0 +1,1 @@
+Rewrote the Authentication page for more clarity on how to configure Pulp's authentication.

--- a/CHANGES/5949.feature
+++ b/CHANGES/5949.feature
@@ -1,0 +1,3 @@
+Adds ``pulpcore.app.authentication.PulpDoNotCreateUsersRemoteUserBackend`` which can be used to
+verify authentication in the webserver, but will not automatically create users like
+``django.contrib.auth.backends.RemoteUserBackend`` does.

--- a/CHANGES/5949.removal
+++ b/CHANGES/5949.removal
@@ -1,0 +1,4 @@
+Removed the ``django.contrib.auth.backends.RemoteUserBackend`` as a default configured backend in
+``settings.AUTHENTICATION_BACKENDS``. Also removed
+``pulpcore.app.authentication.PulpRemoteUserAuthentication`` from the DRF configuration of
+``DEFAULT_AUTHENTICATION_CLASSES``.

--- a/docs/installation/authentication.rst
+++ b/docs/installation/authentication.rst
@@ -3,11 +3,8 @@
 API Authentication
 ==================
 
-By default, Pulp has two types of authentication enabled, and both are tried before rejecting a
-request as unauthenticated.
-
-   1. Basic Authentication, which is checked against an internal users database
-   2. Webserver authentication that relies on the webserver to perform the authentication.
+By default, Pulp supports Basic and Session authentication. The Basic Authentication checks the
+username and password against the internal users database.
 
 .. note::
     This authentication is only for the REST API. Client's fetching binary data have their identity
@@ -22,12 +19,34 @@ which is served to unauthenticated users too. This is true regardless of the typ
 you configure.
 
 
-Basic Auth
-----------
+Concepts
+--------
 
-Pulp by default uses `Basic Auth <https://tools.ietf.org/html/rfc7617>`_ authentication which checks
-the user submitted header against an internal database of users. If the username and password match,
-the request is considered authenticated as that username.
+Authentication in Pulp is provided by Django Rest Framework and Django together.
+
+Django provides the
+`AUTHENTICATION_BACKENDS <https://docs.djangoproject.com/en/2.2/ref/settings/#std:setting-AUTHENTICATION_BACKENDS>`_
+which defines a set of behaviors to check usernames and passwords against.
+
+Django Rest Framework defines the source usernames and passwords come from with the
+`DEFAULT_AUTHENTICATION_CLASSES <https://www.django-rest-framework.org/api-guide/authentication/#setting-the-authentication-scheme>`_
+setting.
+
+
+Basic Authentication
+--------------------
+
+Pulp by default uses `Basic Authentication <https://tools.ietf.org/html/rfc7617>`_ which checks the
+user submitted header against an internal database of users. If the username and password match, the
+request is considered authenticated as that username.
+
+Below is an example of a Basic Authentication header::
+
+    Authorization: Basic YWRtaW46cGFzc3dvcmQ=
+
+You can set this header on an `httpie <https://httpie.org/>`_ command as follows::
+
+    http :80/pulp/api/v3/tasks/ Authorization:"Basic YWRtaW46cGFzc3dvcmQ="
 
 .. warning::
 
@@ -39,28 +58,86 @@ the request is considered authenticated as that username.
     `pulp-list@redhat.com <https://www.redhat.com/mailman/listinfo/pulp-list>`_.
 
 
-Disabling Basic Auth
-********************
+Disabling Basic Authentication
+******************************
 
-To disable Basic Auth, remove the ``'django.contrib.auth.backends.ModelBackend'`` from the
-``AUTHENTICATION_BACKENDS`` setting in Pulp.
+Basic Authentication is defined by receiving the username and password encoded in the
+``Authorization`` header. To disable receiving the username and password using Basic Authentication,
+remove the ``rest_framework.authentication.BasicAuthentication`` from the
+``REST_FRAMEWORK['DEFAULT_AUTHENTICATION_CLASSES']`` list.
 
-You can configure Django Rest Framework to not trust users authenticated with Basic Auth by removing
-``'rest_framework.authentication.BasicAuthentication'`` from the
-``REST_FRAMEWORK['DEFAULT_AUTHENTICATION_CLASSES']`` .
+
+Disabling Checks against Internal User DB
+-----------------------------------------
+
+The internal users database is checked using the ``django.contrib.auth.backends.ModelBackend`` from
+Django. To disable checking a username and password against the internal users database, remote the
+``django.contrib.auth.backends.ModelBackend`` from the ``AUTHENTICATION_BACKENDS`` setting in Pulp.
+
+You can do this effectively, for example using a Python settings file::
+
+    AUTHENTICATION_BACKENDS = []
+
+
+Or as an by defining an environment variable for Dynaconf to use::
+
+    export PULP_AUTHENTICATION_BACKEND="[]"
 
 
 .. _webserver-auth:
 
-Webserver Auth
---------------
+Webserver Authentication
+------------------------
 
-Pulp by default can use authentication configured in the webserver, e.g. Apache 2.4 configured with
-`mod_ldap <https://httpd.apache.org/docs/2.4/mod/mod_ldap.html>`_. By default Pulp trusts a WSGI
-environment variable named ``REMOTE_USER``, and will create a Django user in the user list to
-represent that user. These are the typical behaviors provided by Django's `REMOTE_USER middleware
-<https://docs.djangoproject.com/en/2.2/howto/auth-remote-user/>`_ which is enabled by default with
-Pulp.
+Pulp can be configured to use authentication provided in the webserver outside of Pulp. This allows
+for integration with ldap for examples, through
+`mod_ldap <https://httpd.apache.org/docs/2.4/mod/mod_ldap.html>`_, or certificate based API access,
+etc.
+
+Enable external authentication in two steps:
+
+1. Accept external auth instead of checking the internal users database by enabling::
+
+    ``AUTHENTICATION_BACKENDS = ['pulpcore.app.authentication.PulpNoCreateRemoteUserBackend']``.
+
+This will cause Pulp to accept any username for each request and not create a user in the database
+backend for them. To have any name accepted but create the username in the database backend, use the
+``django.contrib.auth.backends.RemoteUserBackend`` instead, which creates users by default.
+
+
+2. Specify how to receive the username from the webserver. Do this by specifying to DRF an
+   AUTHENTICATION_CLASS. For example, use the ``PulpRemoteUserAuthentication`` as follows::
+
+    REST_FRAMEWORK['DEFAULT_AUTHENTICATION_CLASSES'] = (
+        'rest_framework.authentication.SessionAuthentication',
+        'pulpcore.app.authentication.PulpRemoteUserAuthentication'
+    )
+
+This removes ``rest_framework.authentication.BasicAuthentication``, and adds
+``PulpRemoteUserAuthentication`` which accepts the username as WSGI environment variable
+``REMOTE_USER`` by default, but can be configured via the
+`REMOTE_USER_ENVIRON_NAME <remote-user-environ-name>`_ Pulp setting.
+
+
+.. _webserver-auth-same-webserver:
+
+Webserver Auth in Same Webserver
+********************************
+
+If your webserver authentication is occurring in the same webserver that is serving the
+``pulpcore.app.wsgi`` application, you can pass the authenticated username to Pulp via the WSGI
+environment variable ``REMOTE_USER``.
+
+Reading the ``REMOTE_USER`` WSGI environment is the default behavior of the
+``pulpcore.app.authentication.PulpRemoteUserAuthentication`` and the Django Rest Framework provided
+``rest_framework.authentication.RemoteUserAuthentication``. The only difference in the Pulp provided
+one is that the WSGI environment variable name can be configured from a Pulp provided WSGI
+environment variable name.
+
+See the `REMOTE_USER_ENVIRON_NAME <remote-user-environ-name>`_ for configuring the WSGI provided
+name, but if you are using the ``REMOTE_USER`` WSGI environment name with "same webserver"
+authentication, you likely want to leave `REMOTE_USER_ENVIRON_NAME <remote-user-environ-name>`_
+unset and configure the webserver to set the ``REMOTE_USER`` WSGI environment variable.
 
 
 .. _webserver-auth-with-reverse-proxy:
@@ -72,12 +149,12 @@ For example purposes, assume you're using Nginx with LDAP authentication require
 authenticating it reverse proxies your request to the gunicorn process running the pulpcore.app.wsgi
 application. That would look like this::
 
-    nginx <----> gunicorn <----> pulpcore.app.wsgi application
+    nginx <---http---> gunicorn <----WSGI----> pulpcore.app.wsgi application
 
 
-With nginx knowing ``REMOTE_USER`` and acting as a proxy it can't set the environment variable
-for the wsgi request because that happens in gunicorn. To give the REMOTE_USER information to Pulp
-a header should be used, and the nginx config should include a line like::
+With nginx providing authentication, all it can do is pass ``REMOTE_USER`` (or similar name) to the
+application webserver, i.e. gunicorn. You can pass the header as part of the proxy request in nginx
+with a config line like::
 
     proxy_set_header REMOTE_USER $remote_user;
 
@@ -85,7 +162,9 @@ Per the `WSGI standard <https://www.python.org/dev/peps/pep-0333/#environ-variab
 headers will be prepended with a ``HTTP_``. The above line would send the header named
 ``REMOTE_USER`` to gunicorn, and the WSGI application would receive it as ``HTTP_REMOTE_USER``. The
 default configuration of Pulp is expecting ``REMOTE_USER`` in the WSGI environment not
-``HTTP_REMOTE_USER``, so this won't work.
+``HTTP_REMOTE_USER``, so this won't work with
+``pulpcore.app.authentication.PulpRemoteUserAuthentication`` or the Django Rest Framework provided
+``rest_framework.authentication.RemoteUserAuthentication`` as is.
 
 Pulp provides a setting named `REMOTE_USER_ENVIRON_NAME <remote-user-environ-name>`_ which allows
 you to specify another WSGI environment variable to read the authenticated username from.
@@ -97,23 +176,11 @@ you to specify another WSGI environment variable to read the authenticated usern
     #configuration>`_ for more details.
 
 
-Disabling Webserver Auth
-************************
-
-To disable Pulp from using webserver authentication remove the
-``'django.contrib.auth.backends.RemoteUserBackend'`` from the ``AUTHENTICATION_BACKENDS`` setting in
-Pulp.
-
-You can configure Django Rest Framework to not trust webserver authenticated users by removing
-``'rest_framework.authentication.RemoteUserAuthentication'`` from the
-``REST_FRAMEWORK['DEFAULT_AUTHENTICATION_CLASSES']`` .
-
-
 Custom Authentication
 ---------------------
 
-Pulp is a Django app, so additional Django authentication can be added as long as it's correctly
-configured for both Django and Django Rest Frameowork.
+Pulp is a Django app and Django Rest Framework (DRF) application, so additional authentication can
+be added as long as it's correctly configured for both Django and Django Rest Frameowork.
 
 See the `Django docs on configuring custom authentication <https://docs.djangoproject.com/en/2.2/
 topics/auth/customizing/#customizing-authentication-in-django>`_ and the `Django Rest Framework docs

--- a/pulpcore/app/authentication.py
+++ b/pulpcore/app/authentication.py
@@ -1,3 +1,4 @@
+from django.contrib.auth.backends import RemoteUserBackend
 from rest_framework.authentication import RemoteUserAuthentication
 
 from pulpcore.app import settings
@@ -6,3 +7,8 @@ from pulpcore.app import settings
 class PulpRemoteUserAuthentication(RemoteUserAuthentication):
 
     header = settings.REMOTE_USER_ENVIRON_NAME
+
+
+class PulpNoCreateRemoteUserBackend(RemoteUserBackend):
+
+    create_unknown_user = False  # Configure RemoteUserBackend to not create users

--- a/pulpcore/app/settings.py
+++ b/pulpcore/app/settings.py
@@ -93,7 +93,6 @@ MIDDLEWARE = [
 
 AUTHENTICATION_BACKENDS = [
     'django.contrib.auth.backends.ModelBackend',
-    'django.contrib.auth.backends.RemoteUserBackend',
 ]
 
 ROOT_URLCONF = 'pulpcore.app.urls'
@@ -124,7 +123,6 @@ REST_FRAMEWORK = {
     'DEFAULT_PERMISSION_CLASSES': ('rest_framework.permissions.IsAuthenticated',),
     'DEFAULT_AUTHENTICATION_CLASSES': (
         'rest_framework.authentication.SessionAuthentication',
-        'pulpcore.app.authentication.PulpRemoteUserAuthentication',
         'rest_framework.authentication.BasicAuthentication',
     ),
     'UPLOADED_FILES_USE_URL': False,


### PR DESCRIPTION
This PR comes with a few changes:

- Significantly revamp the authenticaiton docs
- Adds a Pulp Backend that will not create users by default
- Removes the RemoteUserBackend disabling external auth by default

https://pulp.plan.io/issues/5949
closes #5949
