### PR TITLE
[WIP/experiment] Add prometheus metrics support

### DIFF
--- a/CHANGES/6462.feature
+++ b/CHANGES/6462.feature
@@ -1,0 +1,9 @@
+Add optional prometheus metrics support
+
+This enables pulpcore to export pulp metrics to
+be scraped by prometheus if the django module 'django_prometheus'
+(https://github.com/korfuri/django-prometheus) is installed.
+
+If 'django_prometheus' is available, the '/metrics'
+url will contain metrics that can be collected
+by https://prometheus.io/

--- a/pulpcore/app/settings.py
+++ b/pulpcore/app/settings.py
@@ -101,10 +101,10 @@ MIDDLEWARE = [
 
 # Prepend and append optional middleware like django_prometheus
 with suppress(ImportError):
-    import_module('django_prometheus')
-    INSTALLED_APPS.append('django_prometheus')
-    MIDDLEWARE.insert(0, 'django_prometheus.middleware.PrometheusBeforeMiddleware')
-    MIDDLEWARE.append('django_prometheus.middleware.PrometheusAfterMiddleware')
+    import_module("django_prometheus")
+    INSTALLED_APPS.append("django_prometheus")
+    MIDDLEWARE.insert(0, "django_prometheus.middleware.PrometheusBeforeMiddleware")
+    MIDDLEWARE.append("django_prometheus.middleware.PrometheusAfterMiddleware")
 
 
 AUTHENTICATION_BACKENDS = [

--- a/pulpcore/app/settings.py
+++ b/pulpcore/app/settings.py
@@ -74,6 +74,7 @@ for entry_point in iter_entry_points("pulpcore.plugin"):
     INSTALLED_PULP_PLUGINS.append(entry_point.module_name)
     INSTALLED_APPS.append(plugin_app_config)
 
+
 # Optional apps that help with development, or augment Pulp in some non-critical way
 OPTIONAL_APPS = [
     "crispy_forms",
@@ -97,6 +98,14 @@ MIDDLEWARE = [
     "django.contrib.messages.middleware.MessageMiddleware",
     "django.middleware.clickjacking.XFrameOptionsMiddleware",
 ]
+
+# Prepend and append optional middleware like django_prometheus
+with suppress(ImportError):
+    import_module('django_prometheus')
+    INSTALLED_APPS.append('django_prometheus')
+    MIDDLEWARE.insert(0, 'django_prometheus.middleware.PrometheusBeforeMiddleware')
+    MIDDLEWARE.append('django_prometheus.middleware.PrometheusAfterMiddleware')
+
 
 AUTHENTICATION_BACKENDS = [
     "django.contrib.auth.backends.ModelBackend",

--- a/pulpcore/app/urls.py
+++ b/pulpcore/app/urls.py
@@ -120,7 +120,7 @@ urlpatterns = [
 ]
 
 with suppress(ImportError):
-    urlpatterns.append(url('', include('django_prometheus.urls')))
+    urlpatterns.append(url("", include("django_prometheus.urls")))
 
 api_info = openapi.Info(
     title="Pulp 3 API",

--- a/pulpcore/app/urls.py
+++ b/pulpcore/app/urls.py
@@ -1,4 +1,5 @@
 """pulp URL Configuration"""
+from contextlib import suppress
 import logging
 
 from django.conf.urls import include, url
@@ -117,6 +118,9 @@ urlpatterns = [
     url(r"^{api_root}orphans/".format(api_root=API_ROOT), OrphansView.as_view()),
     url(r"^auth/", include("rest_framework.urls")),
 ]
+
+with suppress(ImportError):
+    urlpatterns.append(url('', include('django_prometheus.urls')))
 
 api_info = openapi.Info(
     title="Pulp 3 API",


### PR DESCRIPTION
**Note:** This is mostly just an example of how prometheus metrics support could be added to pulpcore (and presumably, all the pulp plugins).

I'm looking for a more general way to set up this configuration, if that is possible.
For example, I'm not sure this is something that could be done with dynaconf 
(it seems like dynaconf's django support doesn't allow changing INSTALLED_APPS or MIDDLEWARE.)

So looking for suggestions on the best way to approach this.

> This enables pulpcore to export pulp metrics to
> be scraped by prometheus.
> 
> It uses the django module 'django_prometheus'
> django app/middleware to do this.
> (https://github.com/korfuri/django-prometheus)
> The result is a set of metrics exposed at /metrics

