### PR TITLE
Have S3 and Azure redirect specify filename

### DIFF
--- a/CHANGES/4733.bugfix
+++ b/CHANGES/4733.bugfix
@@ -1,0 +1,1 @@
+Files stored on S3 and Azure now download with the correct filename.

--- a/CHANGES/plugin_api/4733.removal
+++ b/CHANGES/plugin_api/4733.removal
@@ -1,0 +1,5 @@
+The ```Handler._handle_file_response` has been removed. It was renamed to
+``_serve_content_artifact`` and has the following signature::
+
+    def _serve_content_artifact(self, content_artifact, headers):
+


### PR DESCRIPTION
The filename is specified as part of the redirect url.

This also changes the Handler's interface for the plugin writer, and
there is a changelog entry with more details.

closes #4733
https://pulp.plan.io/issues/4733

