### PR TITLE
Renames /var/lib/pulp/static/ to /var/lib/pulp/assets/.

### DIFF
--- a/CHANGES/5995.bugfix
+++ b/CHANGES/5995.bugfix
@@ -1,0 +1,1 @@
+Renames /var/lib/pulp/static/ to /var/lib/pulp/static/.

--- a/pulpcore/app/settings.py
+++ b/pulpcore/app/settings.py
@@ -29,7 +29,7 @@ DEBUG = False
 ALLOWED_HOSTS = ['*']
 
 MEDIA_ROOT = '/var/lib/pulp/'
-STATIC_ROOT = os.path.join(MEDIA_ROOT, 'static/')
+STATIC_ROOT = os.path.join(MEDIA_ROOT, 'assets/')
 
 DEFAULT_FILE_STORAGE = 'pulpcore.app.models.storage.FileSystem'
 


### PR DESCRIPTION
This directory name is already being used by Pulp 2. As a result the SELinux policies for Pulp 2 and
Pulp 3 are conflicting. After this change, the two SELinux policies can explicitly name the directories
inside /var/lib/pulp/ that they manage.

re: #5995
https://pulp.plan.io/issues/5995