### PR TITLE
Pin `idna==2.9` to resolve conflicting packages

### DIFF
--- a/CHANGES/6169.bugfix
+++ b/CHANGES/6169.bugfix
@@ -1,0 +1,1 @@
+Pin `idna==2.8`` to avoid a version conflict caused by the idna 2.9 release.

--- a/setup.py
+++ b/setup.py
@@ -16,6 +16,7 @@ requirements = [
     'drf-yasg~=1.17.0',
     'dynaconf>=2.2,<2.3',
     'gunicorn>=19.9,<20.1',
+    'idna==2.8',  # temporary pin until https://pulp.plan.io/issues/6169#note-2 is resolved
     'pygtrie~=2.3.2',
     'psycopg2>=2.7,<2.9',
     'PyYAML>=5.1.1,<5.4.0',


### PR DESCRIPTION
The `yarl` and `requests` packages are sub-dependencies of pulpcore, and
have conflicting version needs for idna. With idna==2.9 released, this
prevents Pulp from installing. This temporary pin will ensure idna==2.8
is released which all versions are satisfied with.

https://pulp.plan.io/issues/6169
closes #6169

