### PR TITLE
Do not trim leading and trailing whitespace characters

### DIFF
--- a/CHANGES/6025.bugfix
+++ b/CHANGES/6025.bugfix
@@ -1,0 +1,2 @@
+Disabled the trimming of leading and trailing whitespace characters which led to a situation where
+a hash of a certificate computed in Pulp was not equal to a hash generated locally

--- a/pulpcore/app/serializers/fields.py
+++ b/pulpcore/app/serializers/fields.py
@@ -284,6 +284,12 @@ class SecretCharField(serializers.CharField):
 
     This field accepts text as input and it returns a sha256 digest of the text stored.
     """
+    def __init__(self, **kwargs):
+        """
+        Initialize a class and do not trim leading and trailing whitespace characters by default.
+        """
+        kwargs['trim_whitespace'] = False
+        super().__init__(**kwargs)
 
     def to_representation(self, value):
         return hashlib.sha256(bytes(value, 'utf-8')).hexdigest()

--- a/pulpcore/app/serializers/repository.py
+++ b/pulpcore/app/serializers/repository.py
@@ -54,20 +54,22 @@ class RemoteSerializer(ModelSerializer):
     ca_cert = SecretCharField(
         help_text='A string containing the PEM encoded CA certificate used to validate the server '
                   'certificate presented by the remote server. All new line characters must be '
-                  'escaped. Returns SHA256 sum on GET.',
+                  'escaped. Returns SHA256 checksum of the certificate file on GET.',
         write_only=False,
         required=False,
         allow_null=True,
     )
     client_cert = SecretCharField(
         help_text='A string containing the PEM encoded client certificate used for authentication. '
-                  'All new line characters must be escaped. Returns SHA256 sum on GET.',
+                  'All new line characters must be escaped. Returns SHA256 checksum of the '
+                  'certificate file on GET.',
         write_only=False,
         required=False,
         allow_null=True,
     )
     client_key = SecretCharField(
-        help_text='A PEM encoded private key used for authentication. Returns SHA256 sum on GET.',
+        help_text='A PEM encoded private key used for authentication. Returns SHA256 checksum of '
+                  'the certificate file on GET.',
         write_only=False,
         required=False,
         allow_null=True,


### PR DESCRIPTION
In this commit, there was also fixed the documentation. The field itself returns a hash of a file content, not a hash of a certificate stored within a file.

closes #6025
https://pulp.plan.io/issues/6025
