### PR TITLE
Stop sending basic auth credentials to redirect location

### DIFF
--- a/CHANGES/6227.bugfix
+++ b/CHANGES/6227.bugfix
@@ -1,0 +1,1 @@
+Stopped HttpDownloader sending basic auth credentials to redirect location if domains don't match.

--- a/pulpcore/download/factory.py
+++ b/pulpcore/download/factory.py
@@ -106,15 +106,8 @@ class DownloaderFactory:
 
         conn = aiohttp.TCPConnector(**tcp_conn_opts)
 
-        auth_options = {}
-        if self._remote.username and self._remote.password:
-            auth_options['auth'] = aiohttp.BasicAuth(
-                login=self._remote.username,
-                password=self._remote.password
-            )
-
         timeout = aiohttp.ClientTimeout(total=None, sock_connect=600, sock_read=600)
-        return aiohttp.ClientSession(connector=conn, timeout=timeout, **auth_options)
+        return aiohttp.ClientSession(connector=conn, timeout=timeout)
 
     def build(self, url, **kwargs):
         """
@@ -159,6 +152,12 @@ class DownloaderFactory:
         options = {'session': self._session}
         if self._remote.proxy_url:
             options['proxy'] = self._remote.proxy_url
+
+        if self._remote.username and self._remote.password:
+            options['auth'] = aiohttp.BasicAuth(
+                login=self._remote.username,
+                password=self._remote.password
+            )
 
         return download_class(url, **options, **kwargs)
 

--- a/pulpcore/download/http.py
+++ b/pulpcore/download/http.py
@@ -181,7 +181,7 @@ class HttpDownloader(BaseDownloader):
         Args:
             extra_data (dict): Extra data passed by the downloader.
         """
-        async with self.session.get(self.url, proxy=self.proxy) as response:
+        async with self.session.get(self.url, proxy=self.proxy, auth=self.auth) as response:
             response.raise_for_status()
             to_return = await self._handle_response(response)
             await response.release()


### PR DESCRIPTION
Pulp is getting redirected and sending the Remote's credentials to the
redirected location. Looks like if we set the credentials on the request
instead of the session, aiohttp will only send the credentials to
redirected locations when the domains match which is the behavior we
want.

Please be sure you have read our documentation on creating PRs:
https://docs.pulpproject.org/contributing/pull-request-walkthrough.html
