### PR TITLE
Adds pulpcore-manager console command

### DIFF
--- a/CHANGES/5859.doc
+++ b/CHANGES/5859.doc
@@ -1,0 +1,1 @@
+Updated docs to suggest to use ``pulpcore-manager`` command instead of ``django-admin`` directly.

--- a/CHANGES/5859.feature
+++ b/CHANGES/5859.feature
@@ -1,0 +1,3 @@
+Added a ``pulpcore-manager`` script that is ``django-admin`` only configured with
+``DJANGO_SETTINGS_MODULE="pulpcore.app.settings"``. This can be used for things like applying
+database migrations or collecting static media.

--- a/docs/components.rst
+++ b/docs/components.rst
@@ -24,9 +24,10 @@ things:
 .. note::
 
    A simple, but limited way to run the REST API as a standalone service using the built-in Django
-   runserver.::
+   runserver. The ``pulpcore-manager`` command is ``manage.py`` configured with the
+   ``DJANGO_SETTINGS_MODULE="pulpcore.app.settings"``. Run the simple webserver with::
 
-      $ python django-admin runserver 24817
+      $ pulpcore-manager runserver 24817
 
 
 The REST API can be deployed with any any WSGI webserver like a normal Django application. See the
@@ -97,8 +98,9 @@ content is automatically served for you.
 In Production
 ^^^^^^^^^^^^^
 
-Collect all of the static content into place using the ``collectstatic`` command
-as follows::
+Collect all of the static content into place using the ``collectstatic`` command. The
+``pulpcore-manager`` command is ``manage.py`` configured with the
+``DJANGO_SETTINGS_MODULE="pulpcore.app.settings"``. Run ``collectstatic`` as follows::
 
-    $ django-admin collectstatic
+    $ pulpcore-manager collectstatic
 

--- a/docs/contributing/tests.rst
+++ b/docs/contributing/tests.rst
@@ -52,7 +52,9 @@ Prerequisites for running tests
 If you want to run the functional tests, you need a running Pulp instance that is allowed to be
 mixed up by the tests (in other words, running the tests on a production instance is not
 recommended). For example, using the development vm (see :ref:`DevSetup`),
-this can be accomplished by `workon pulp; django-admin runserver 24817`.
+this can be accomplished by `workon pulp; pulpcore-manager runserver 24817`. The
+``pulpcore-manager`` command is ``manage.py`` configured with the
+``DJANGO_SETTINGS_MODULE="pulpcore.app.settings"``.
 
 Functional tests require a valid *pulp-smash*
 `config <https://pulp-smash.readthedocs.io/en/latest/configuration.html>`_ file.
@@ -63,12 +65,12 @@ Running tests
 
 In case pulp is installed in a virtual environment, activate it first (`workon pulp`).
 
-All tests of a plugin (or pulpcore itself) are run with `django-admin test <plugin_name>`.
+All tests of a plugin (or pulpcore itself) are run with `pulpcore-manager test <plugin_name>`.
 This involves setting up (and tearing down) the test database, however the functional tests are
 still performed against the configured pulp instance with its *production* database.
 
 To only perform the unittests, you can skip the prerequisites and call
-`django-admin test <plugin_name>.tests.unit`.
+`pulpcore-manager test <plugin_name>.tests.unit`.
 
 If you are only interested in functional tests, you can skip the creation of the test database by
 using `pytest <path_to_plugin>/<plugin_name>/tests/functional`.
@@ -81,7 +83,7 @@ using `pytest <path_to_plugin>/<plugin_name>/tests/functional`.
 .. note::
 
     You can be more specific on which tests to run by calling something like
-    `django-admin test pulp_file.tests.unit.test_models` or
+    `pulpcore-manager test pulp_file.tests.unit.test_models` or
     `py.test <path_to_plugin>/<plugin_name>/tests/functional/api/test_sync.py`.
 
 

--- a/docs/installation/authentication.rst
+++ b/docs/installation/authentication.rst
@@ -52,8 +52,8 @@ You can set this header on an `httpie <https://httpie.org/>`_ command as follows
 
     For the 3.0 release, Pulp expects the user table to have exactly 1 user in it named 'admin',
     which is created automatically when the initial migration is applied. The password for this user
-    can be set with the ``django-admin reset-admin-password`` command, but defaults to 'password'.
-    To articulate what you'd like to see future versions of Pulp file a feature request
+    can be set with the ``pulpcore-manager reset-admin-password`` command, but defaults to
+    'password'. To articulate what you'd like to see future versions of Pulp file a feature request
     `here <https://pulp.plan.io/projects/pulp/issues/new>`_ or reach out via
     `pulp-list@redhat.com <https://www.redhat.com/mailman/listinfo/pulp-list>`_.
 

--- a/docs/installation/instructions.rst
+++ b/docs/installation/instructions.rst
@@ -81,17 +81,24 @@ PyPI Installation
 
 9. Run Django Migrations::
 
-   $ django-admin migrate --noinput
-   $ django-admin reset-admin-password --password admin
+   $ pulpcore-manager migrate --noinput
+   $ pulpcore-manager reset-admin-password --password admin
+
+
+.. note::
+
+    The ``pulpcore-manager`` command is ``manage.py`` configured with the
+    ``DJANGO_SETTINGS_MODULE="pulpcore.app.settings"``. You can use it anywhere you would normally
+    use ``manage.py``.
 
 10. Collect Static Media for live docs and browsable API::
 
-    $ django-admin collectstatic --noinput
+    $ pulpcore-manager collectstatic --noinput
 
 11. Run Pulp::
 
     $ pulp-content  # The Pulp Content service (listening on port 24816)
-    $ django-admin runserver 24817  # The Pulp API service
+    $ pulpcore-manager runserver 24817  # The Pulp API service
 
 .. _database-install:
 

--- a/docs/plugins/api-reference/profiling.rst
+++ b/docs/plugins/api-reference/profiling.rst
@@ -13,10 +13,10 @@ enabled it will write a sqlite3 with the uuid of the task name it runs in to the
 Summarizing Performance Data
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-`django-admin` includes command that displays the pipeline along with summary statistics. After
+`pulpcore-manager` includes command that displays the pipeline along with summary statistics. After
 generating a sqlite3 performance database, use the `stage-profile-summary` command like this::
 
-    $ django-admin stage-profile-summary /var/lib/pulp/debug/2dcaf53a-4b0f-4b42-82ea-d2d68f1786b0
+   $ pulpcore-manager stage-profile-summary /var/lib/pulp/debug/2dcaf53a-4b0f-4b42-82ea-d2d68f1786b0
 
 
 Profiling API Machinery

--- a/docs/plugins/plugin-writer/concepts/index.rst
+++ b/docs/plugins/plugin-writer/concepts/index.rst
@@ -4,8 +4,8 @@ Plugin Concepts
 ===============
 
 Like the Pulp Core itself, all Pulp Plugins are Django Applications, and could be created like any
-other Django app with ``django-admin startapp <your_plugin>``. However, instead of writing all of
-the boilerplate yourself, it is recommmended that you start your plugin by utilizing the `Plugin
+other Django app with ``pulpcore-manager startapp <your_plugin>``. However, instead of writing all
+of the boilerplate yourself, it is recommmended that you start your plugin by utilizing the `Plugin
 Template <https://github.com/pulp/plugin_template>`_.  This guide will assume that you have used
 the plugin_template, but if you are interested in the details of what it provides you, please see
 :ref:`plugin-django-application` for more information for how plugins are "discovered" and connected to

--- a/docs/plugins/plugin-writer/concepts/subclassing/models.rst
+++ b/docs/plugins/plugin-writer/concepts/subclassing/models.rst
@@ -55,11 +55,12 @@ can make and run database migrations with:
 
 .. code-block:: bash
 
-      django-admin makemigrations <plugin_app_label>
-      django-admin migrate
+      pulpcore-manager makemigrations <plugin_app_label>
+      pulpcore-manager migrate
 
-If you recognize this syntax, it is because django-admin is used with the same interace as ``django
-admin``, but has additional commands.
+If you recognize this syntax, it is because pulpcore-manager is ``manage.py`` configured with
+`` DJANGO_SETTINGS_MODULE="pulpcore.app.settings"``. You can use it anywhere you normally would use
+``manage.py`` or ``django-admin``.
 
 
 Uniqueness

--- a/docs/plugins/reference/how-plugins-work.rst
+++ b/docs/plugins/reference/how-plugins-work.rst
@@ -7,7 +7,7 @@ Plugin Django Application
 -------------------------
 
 Like the Pulp Core itself, all Pulp Plugins begin as Django Applications, started like any other
-with `django-admin startapp <your_plugin>`. However, instead of subclassing Django's
+with `pulpcore-manager startapp <your_plugin>`. However, instead of subclassing Django's
 `django.apps.AppConfig` as seen `in the Django documentation
 <https://docs.djangoproject.com/en/1.8/ref/applications/#for-application-authors>`_, Pulp Plugins
 identify themselves as plugins to the Pulp Core by subclassing

--- a/docs/workflows/signed-metadata.rst
+++ b/docs/workflows/signed-metadata.rst
@@ -58,7 +58,8 @@ The example below demonstrates how a signing service can be created using ``gpg`
 
 2. Create a signing service consisting of an absolute path to the script and a meaningful
    name describing the script's purpose. It is possible to insert the signing service in
-   to a database by leveraging the utility ``django-admin shell_plus``:
+   to a database by using the ``pulpcore-manager shell_plus`` interactive Python shell. Here is an
+   example showing how to create one instance pointing to a script:
 
    .. code-block:: python
 

--- a/pulpcore/app/manage.py
+++ b/pulpcore/app/manage.py
@@ -2,9 +2,14 @@
 import os
 import sys
 
-if __name__ == "__main__":
+
+def manage():
     os.environ.setdefault("DJANGO_SETTINGS_MODULE", "pulpcore.app.settings")
 
     from django.core.management import execute_from_command_line
 
     execute_from_command_line(sys.argv)
+
+
+if __name__ == "__main__":
+    manage()

--- a/setup.py
+++ b/setup.py
@@ -52,4 +52,7 @@ setup(
         'Programming Language :: Python :: 3.7',
     ),
     scripts=['bin/pulp-content'],
+    entry_points={'console_scripts': [
+        'pulpcore-manager = pulpcore.app.manage:manage',
+    ]},
 )


### PR DESCRIPTION
This add the `pulpcore-manager` script which is an alias for `manage.py`
only correctly configured to know where the Pulp settings app is
already.

This change includes docs which recommend users apply migrations with
`pulpcore-manager` instead of `manage.py`.

Originally inspired by this PR from @evgeni:

https://github.com/pulp/pulpcore/pull/445/files

https://pulp.plan.io/issues/5859
closes #5859
