### PR TITLE
Refactor the existing SigningService classes

### DIFF
--- a/CHANGES/plugin_api/6342.doc
+++ b/CHANGES/plugin_api/6342.doc
@@ -1,0 +1,1 @@
+Updated the metadata signing plugin writers documentation.

--- a/CHANGES/plugin_api/6342.misc
+++ b/CHANGES/plugin_api/6342.misc
@@ -1,0 +1,1 @@
+Moved resuable methods to the SigningService base class.


### PR DESCRIPTION
fixes #6342
https://pulp.plan.io/issues/6342

This is based on my experience of implementing the `AptReleaseSigingService` class here: https://github.com/pulp/pulp_deb/pull/160

I found that I replicated some of the exact same functions as for the `AsciiArmoredDetachedSigningService` since the only thing that is really different for different signing services is the validation. I therefore moved the reusable functions into the parent class, and split out a dedicated `validate` function from the existing `save` function. The Idea is that this is the one and only function that needs to be provided by each subclass of `SigningService`.