### PR TITLE
Dramatically increase re-sync performance

### DIFF
--- a/CHANGES/6373.bugfix
+++ b/CHANGES/6373.bugfix
@@ -1,0 +1,1 @@
+Improved resync performance by up to 2x with a change to the content stages.

--- a/pulpcore/plugin/stages/api.py
+++ b/pulpcore/plugin/stages/api.py
@@ -78,7 +78,7 @@ class Stage:
             content = await self._in_q.get()
             if content is None:
                 break
-            log.debug(_('%(name)s - next: %(content)s.'), {'name': self, 'content': content})
+            log.debug('%(name)s - next: %(content)s.', {'name': self, 'content': content})
             yield content
 
     async def batches(self, minsize=500):

--- a/pulpcore/plugin/stages/artifact_stages.py
+++ b/pulpcore/plugin/stages/artifact_stages.py
@@ -42,7 +42,7 @@ class QueryExistingArtifacts(Stage):
             The coroutine for this stage.
         """
         async for batch in self.batches():
-            all_artifacts_q = Q(pulp_created=None)
+            all_artifacts_q = Q(pk__in=[])
             for d_content in batch:
                 for d_artifact in d_content.d_artifacts:
                     one_artifact_q = d_artifact.artifact.q()

--- a/pulpcore/plugin/stages/content_stages.py
+++ b/pulpcore/plugin/stages/content_stages.py
@@ -37,7 +37,7 @@ class QueryExistingContents(Stage):
             The coroutine for this stage.
         """
         async for batch in self.batches():
-            content_q_by_type = defaultdict(lambda: Q(pulp_created=None))
+            content_q_by_type = defaultdict(lambda: Q(pk__in=[]))
             for d_content in batch:
                 if d_content.content._state.adding:
                     model_type = type(d_content.content)


### PR DESCRIPTION
Increase the performance of the QueryExisting* stages. pulp_created=None
was originally picked because it wouldn't match with anything, and an empty
Q() object matches with everything. But it's a lookup on an unindexed field
that requires looking at an entirely different table, so it ends up
being incredibly inefficient. It turns out that there is a way to
accomplish the same thing that gets compiled out of the query entirely.

[noissue]
