### PR TITLE
Checking for dupe content in finalize

### DIFF
--- a/CHANGES/plugin_api/6362.feature
+++ b/CHANGES/plugin_api/6362.feature
@@ -1,0 +1,1 @@
+Added two new repo validation methods (validate_repo_version and validate_duplicate_content).

--- a/CHANGES/plugin_api/6362.removal
+++ b/CHANGES/plugin_api/6362.removal
@@ -1,0 +1,1 @@
+RepositoryVersion add_content no longer checks for duplicate content.

--- a/pulpcore/app/models/repository.py
+++ b/pulpcore/app/models/repository.py
@@ -553,33 +553,6 @@ class RepositoryVersion(BaseModel):
         if self.complete:
             raise ResourceImmutableError(self)
 
-        error_messages = []
-        for type_obj in self.repository.CONTENT_TYPES:
-            if type_obj.repo_key_fields == ():
-                continue
-
-            pulp_type = type_obj.get_pulp_type()
-            repo_key_fields = type_obj.repo_key_fields
-            new_content_total = type_obj.objects.filter(
-                pk__in=content.filter(pulp_type=pulp_type)
-            ).count()
-            unique_new_content_total = type_obj.objects.filter(
-                pk__in=content.filter(pulp_type=pulp_type)
-            ).distinct(*repo_key_fields).count()
-
-            if unique_new_content_total < new_content_total:
-                error_messages.append(_(
-                    "More than one {pulp_type} content with the duplicate values for {fields}."
-                    ).format(
-                        pulp_type=pulp_type,
-                        fields=", ".join(repo_key_fields),
-                    )
-                )
-        if error_messages:
-            raise ValueError(
-                _("Cannot create repository version. {msg}").format(msg=", ".join(error_messages))
-            )
-
         repo_content = []
         to_add = set(content.exclude(pk__in=self.content).values_list('pk', flat=True))
 


### PR DESCRIPTION
fixes #6362
https://pulp.plan.io/issues/6362

Plugin example: https://github.com/pulp/pulp_file/pull/368

I decided not to update remove_duplicates to handle checking for duplicate content because (a) it would violate the single responsibility principle as remove_duplicates removes existing content from the repo version if it collides with content being added. 

Also (b) [remove_duplicates is called at the beginning of finalize before processing happens](https://github.com/pulp/pulp_rpm/blob/417541e71655f10045f5e6f5f8cb156dff7972ff/pulp_rpm/app/models/repository.py#L127) while validation ought to happen at the end.