### PR TITLE
Normalize PK path parameter names used in openapi schema generation

### DIFF
--- a/CHANGES/6372.bugfix
+++ b/CHANGES/6372.bugfix
@@ -1,0 +1,1 @@
+Properly sort endpoints during generation of the OpenAPI schema. 


### PR DESCRIPTION
This ensures that when the endpoints are sorted, the parent endpoint appears before the
endpoints nested under it.

fixes: #6372
https://pulp.plan.io/issues/6372