### PR TITLE
Port pulpcore-content to use Application Runners

### DIFF
--- a/CHANGES/6397.misc
+++ b/CHANGES/6397.misc
@@ -1,0 +1,2 @@
+Port the ``/bin/pulp-content`` script to use `Application runners` to allow for more future
+customization of the aiohttp server components.

--- a/bin/pulp-content
+++ b/bin/pulp-content
@@ -1,8 +1,24 @@
 #!/usr/bin/env python
 
+import asyncio
+
 import aiohttp
+
+import django  # noqa otherwise E402: module level not at top of file
+django.setup()  # noqa otherwise E402: module level not at top of file
+
+from django.conf import settings
 
 from pulpcore.content import server
 
 
-aiohttp.web.run_app(server(), port=24816)
+async def work():
+    pulp_content_app = await server()
+    runner = aiohttp.web.AppRunner(pulp_content_app, max_line_size=16380, max_field_size=16380)
+    await runner.setup()
+    site = aiohttp.web.TCPSite(runner, 'localhost', 24816)
+    await site.start()
+
+loop = asyncio.get_event_loop()
+asyncio.ensure_future(work())
+loop.run_forever()

--- a/pulpcore/content/worker.py
+++ b/pulpcore/content/worker.py
@@ -1,0 +1,11 @@
+from aiohttp.worker import GunicornWebWorker
+
+
+class PulpGunicornWebWorker(GunicornWebWorker):
+
+    def _get_application_runner_instance(self, app, **kwargs):
+        return super()._get_application_runner_instance(
+            app,
+            max_line_size=16380,
+            max_field_size=16380
+        )


### PR DESCRIPTION
Application Runners in aiohttp Server are the recommended way to
configure additional aspects of aiohttp such configuring the header
length. Plugins like `pulp-certguard` require this additional
configuration.

This PR ports the `pulp-content` app to use Application Runners. Also
port the `pulpcore.content.app` entry point that gunicorn uses to it
also.

https://pulp.plan.io/issues/6397
closes #6397

