### PR TITLE
Problem: Trailing underscores in branch names breaks CI

### DIFF
--- a/.travis/install.sh
+++ b/.travis/install.sh
@@ -37,7 +37,7 @@ elif [ -n "$TRAVIS_PULL_REQUEST_BRANCH" ]; then
 # For push builds and hopefully cron builds
 elif [ -n "$TRAVIS_BRANCH" ]; then
   TAG=$(echo $TRAVIS_BRANCH | tr / _)
-  if [ "$TAG" = "master" ]; then
+  if [ "${TAG}" = "master" ]; then
     TAG=latest
   fi
 else
@@ -63,7 +63,7 @@ cat > vars/vars.yaml << VARSYAML
 images:
   - pulp_file-${TAG}:
       image_name: pulp_file
-      tag: $TAG
+      tag: "${TAG}"
       pulpcore: ./pulpcore
       plugins:
         - $PULP_FILE
@@ -78,7 +78,7 @@ ansible-playbook -v build.yaml
 
 cd $TRAVIS_BUILD_DIR/../pulp-operator
 # Tell pulp-perator to deploy our image
-# NOTE: With k3s 1.17, $TAG must be quoted. So that 3.0 does not become 3.
+# NOTE: With k3s 1.17, ${TAG} must be quoted. So that 3.0 does not become 3.
 cat > deploy/crds/pulpproject_v1alpha1_pulp_cr.yaml << CRYAML
 apiVersion: pulpproject.org/v1alpha1
 kind: Pulp


### PR DESCRIPTION
Solution: Regenerate with latest plugin-template

re: #6405
https://pulp.plan.io/issues/6405
Trailing underscores in branch names breaks CI

[noissue]

Please be sure you have read our documentation on creating PRs:
https://docs.pulpproject.org/contributing/pull-request-walkthrough.html
