### PR TITLE
Problem: Pulp containers do not allow commands like "/bin/bash"

### DIFF
--- a/CHANGES/6420.bugfix
+++ b/CHANGES/6420.bugfix
@@ -1,0 +1,1 @@
+Fixed pulp containers not allowing commands to be run via absolute path.

--- a/containers/images/pulp/container-assets/pulp-common-entrypoint.sh
+++ b/containers/images/pulp/container-assets/pulp-common-entrypoint.sh
@@ -3,7 +3,12 @@
 # Prevent pip-installed /usr/local/bin/pulp-content from getting run instead of
 # our /usr/bin/pulp script.
 #
-# We still want conatiner users to call command names, not paths, so we can
-# change our scripts' locations in the future, and call special logic in this
-# script based solely on the command name.
-exec "/usr/bin/$@"
+# We still want conatiner users to call pulp-* command names, not paths, so we
+# can change our scripts' locations in the future, and call special logic in this
+# script based solely on theo command name.
+
+if [[ "$@" = "pulp-content" || "$@" = "pulp-api" || "$@" = "pulp-worker" || "$@" = "pulp-resource-manager" ]]; then
+        exec "/usr/bin/$@"
+else
+        exec "$@"
+fi


### PR DESCRIPTION
to be run, only "bash"

Solution: Only apply the /bin/ logic for the 4 pulp-* commands.

fixes: #6420
Pulp containers do not allow commands like "/bin/bash" to be run, only "bash"
https://pulp.plan.io/issues/6420

Please be sure you have read our documentation on creating PRs:
https://docs.pulpproject.org/contributing/pull-request-walkthrough.html
