### PR TITLE
Rename ansible-pulp to pulp_installer in pulpcore

### DIFF
--- a/CHANGES/6461.doc
+++ b/CHANGES/6461.doc
@@ -1,0 +1,1 @@
+Renamed ansible-pulp to pulp_installer (to avoid confusion with pulp-ansible)

--- a/containers/images/pulp/Dockerfile.j2
+++ b/containers/images/pulp/Dockerfile.j2
@@ -19,7 +19,7 @@ ENV PULP_SETTINGS=/etc/pulp/settings.py
 #
 # libxcrypt-compat is needed by psycopg2-binary from PyPI
 #
-# python3-psycopg2 is installed by ansible-pulp
+# python3-psycopg2 is installed by pulp_installer
 #
 # glibc-langpack-en is needed to provide the en_US.UTF-8 locale, which Pulp
 # seems to need.

--- a/docs/client_bindings.rst
+++ b/docs/client_bindings.rst
@@ -50,9 +50,9 @@ started with openapi-generator-cli is available on
 Generating a client for a dev environment
 -----------------------------------------
 
-The pulp dev environment provided by `ansible-pulp <https://github.com/pulp/ansible-pulp>`_
+The pulp dev environment provided by `pulp_installer <https://github.com/pulp/pulp_installer>`_
 introduces a set of useful
-`aliases <https://github.com/pulp/ansible-pulp/tree/master/roles/pulp-devel#aliases>`_,
+`aliases <https://github.com/pulp/pulp_installer/tree/master/roles/pulp-devel#aliases>`_,
 such as `pbindings`.
 
 Examples:

--- a/docs/contributing/dev-setup.rst
+++ b/docs/contributing/dev-setup.rst
@@ -42,5 +42,5 @@ We recommened using ``pulplift`` for developer installations. Follow the instruc
 `README.md <https://github.com/pulp/pulplift/#pulplift>`_.
 
 It is also possible to use the `Ansible roles
-<https://github.com/pulp/ansible-pulp#pulp-3-ansible-installer>`_ directly, if you prefer not to
+<https://github.com/pulp/pulp_installer#pulp-3-ansible-installer>`_ directly, if you prefer not to
 use Vagrant.

--- a/docs/installation/instructions.rst
+++ b/docs/installation/instructions.rst
@@ -24,7 +24,7 @@ Ansible Installation (Recommended)
 ----------------------------------
 
 To use ansible roles to install Pulp 3 instead of manual setup refer to
-`Pulp 3 Ansible installer <https://github.com/pulp/ansible-pulp/>`_.
+`Pulp 3 Ansible Installer <https://github.com/pulp/pulp_installer/>`_.
 
 PyPI Installation
 -----------------
@@ -154,34 +154,34 @@ Systemd
 -------
 
 To run the four Pulp services, systemd files needs to be created in /usr/lib/systemd/system/. The
-`Pulp 3 Ansible Installer <https://github.com/pulp/ansible-pulp/>`_ makes these for you, but you
+`Pulp 3 Ansible Installer <https://github.com/pulp/pulp_installer/>`_ makes these for you, but you
 can also configure them by hand from the templates below. Custom configuration can be applied using
 the ``Environment`` option with various :ref:`Pulp settings <settings>`.
 
 
 1. Make a ``pulpcore-content.service`` file for the pulpcore-content service which serves Pulp
    content to clients. We recommend starting with the `pulpcore-content template <https://github.com
-   /pulp/ansible-pulp/blob/master/roles/pulp-content/templates/pulpcore-content.service.j2>`_ and
+   /pulp/pulp_installer/blob/master/roles/pulp-content/templates/pulpcore-content.service.j2>`_ and
    setting the variables according to the `pulpcore-content config variables documentation <https://
-   github.com/pulp/ ansible-pulp/tree/master/roles/pulp-content#variables>`_
+   github.com/pulp/ pulp_installer/tree/master/roles/pulp-content#variables>`_
 
 2. Make a ``pulpcore-api.service`` file for the pulpcore-api service which serves the Pulp REST API. We
-   recommend starting with the `pulpcore-api template <https://github.com/pulp/ansible-pulp/blob/master/
+   recommend starting with the `pulpcore-api template <https://github.com/pulp/pulp_installer/blob/master/
    roles/pulp/templates/pulpcore-api.service.j2>`_ and setting the variables according to the `pulpcore-api
-   config variables documentation <https://github.com/pulp/ ansible-pulp/tree/master/roles/
+   config variables documentation <https://github.com/pulp/ pulp_installer/tree/master/roles/
    pulp-content#variables>`_
 
 3. Make a ``pulpcore-worker@.service`` file for the pulpcore-worker processes which allows you to manage
    one or more workers. We recommend starting with the `pulpcore-worker template <https://github.com/pulp/
-   ansible-pulp/blob/master/roles/pulp-workers/templates/pulpcore-worker%40.service.j2>`_ and setting
+   pulp_installer/blob/master/roles/pulp-workers/templates/pulpcore-worker%40.service.j2>`_ and setting
    the variables according to the `pulp-worker config variables documentation <https://github.com/
-   pulp/ansible-pulp/tree/master/roles/pulp-workers#configurable-variables>`_
+   pulp/pulp_installer/tree/master/roles/pulp-workers#configurable-variables>`_
 
 4. Make a ``pulpcore-resource-manager.service`` file which can manage one pulpcore-resource-manager
    process. We recommend starting with the `pulpcore-resource-manager template <https://github.com/pulp/
-   ansible-pulp/blob/master/roles/pulp-resource-manager/templates/pulpcore-resource-manager.service.
+   pulp_installer/blob/master/roles/pulp-resource-manager/templates/pulpcore-resource-manager.service.
    j2>`_ and setting the variables according to the `pulpcore-resource-manager config variables
-   documentation <https://github.com/pulp/ansible-pulp/tree/master/roles/pulp-resource-manager#
+   documentation <https://github.com/pulp/pulp_installer/tree/master/roles/pulp-resource-manager#
    configurable-variables>`_
 
 These services can then be started by running::

--- a/docs/plugins/plugin-writer/concepts/index.rst
+++ b/docs/plugins/plugin-writer/concepts/index.rst
@@ -200,7 +200,7 @@ For the MANIFEST.in entry, you'll likely want one like the example below which w
 Installation
 ------------
 
-It's recommended to use the `Pulp 3 Ansible Installer <https://github.com/pulp/ansible-pulp
+It's recommended to use the `Pulp 3 Ansible Installer <https://github.com/pulp/pulp_installer
 #pulp-3-ansible-installer>`_ to install your plugin. Generally you can do this by configuring
 ``pulp_install_plugins`` variable with your Python package's name. For example for ``pulp-file``::
 
@@ -222,4 +222,4 @@ to create a new role with tasks that needs to be done and publish it on Ansible 
 
 Documentation will need to be added to the plugin installation instructions. See the
 `RPM Plugin Documentation <https://pulp-rpm.readthedocs.io/en/latest/installation.html#
-install-with-ansible-pulp>`_ as an example.
+install-with-pulp-installer-recommended>`_ as an example.


### PR DESCRIPTION
The pulpcore docs are an especially important thing to update, and they deserve a proper changelog entry.

(Especially because ansible-pulp releases correspond to pulpcore releases.)

fixes: #6461
Rename ansible-pulp to pulp_installer in pulpcore
https://pulp.plan.io/issues/6461

Please be sure you have read our documentation on creating PRs:
https://docs.pulpproject.org/contributing/pull-request-walkthrough.html
