### PR TITLE
Fixing sphinx error about undefined terms

### DIFF
--- a/CHANGES/6485.docs
+++ b/CHANGES/6485.docs
@@ -1,0 +1,1 @@
+Fixed missing terms in documentation.

--- a/docs/concepts.rst
+++ b/docs/concepts.rst
@@ -10,26 +10,25 @@ From a user’s perspective Pulp is a tool to manage their content. In this cont
 can be described as a framework for plugin development.
 
 :term:`pulpcore` is a generalized backend with a REST API and a plugin API. Users will need at
-least one :term:`plugin` to manage :term:`content`.  Each :term:`type` of content unit (like rpm or
+least one :term:`plugin` to manage :term:`Content`.  Each :term:`type` of content unit (like rpm or
 deb) is defined by a plugin.  Files that belong to a content unit are called
-:term:`artifacts<artifact>`. Each content unit can have 0 or many artifacts and artifacts can be
+:term:`Artifacts<Artifact>`. Each content unit can have 0 or many artifacts and artifacts can be
 shared by multiple content units.
 
 .. image:: ./_diagrams/concept-content.png
     :align: center
 
-Content units in Pulp are organized by their membership in :term:`repositories<repository>` over
+Content units in Pulp are organized by their membership in :term:`Repositories<Repository>` over
 time. Plugin users can add or remove content units to a repository. Each time the content set of a
-repository is changed, a new :term:`repository version<RepositoryVersion>` is created. Any
-operation such as sync that doesn't result in a change of the content set will not produce a new
-repository version.
+repository is changed, a new :term:`RepositoryVersion` is created. Any operation such as sync that
+doesn't result in a change of the content set will not produce a new repository version.
 
 .. image:: ./_diagrams/concept-repository.png
     :align: center
 .. image:: ./_diagrams/concept-add-repo.png
     :align: center
 
-Users can inform Pulp about external sources of content units, called :term:`remotes<remote>`.
+Users can inform Pulp about external sources of content units, called :term:`Remotes<Remote>`.
 Plugins can define actions to interact with those sources. For example, most or all plugins define
 :term:`sync` to fetch content units from a remote and add them to a repository.
 
@@ -37,9 +36,9 @@ Plugins can define actions to interact with those sources. For example, most or 
     :align: center
 
 All content that is managed by Pulp can be hosted by the :term:`content app`. Users create
-a :term:`publication` for a content set in a repository version. A publication consists of the
+a :term:`Publication` for a content set in a repository version. A publication consists of the
 metadata of the content set and the artifacts of each content unit in the content set. To host a
-publication, it must be assigned to a :term:`distribution`, which determines how and where a
+publication, it must be assigned to a :term:`Distribution`, which determines how and where a
 publication is served.
 
 .. image:: ./_diagrams/concept-publish.png

--- a/docs/from-pulp-2.rst
+++ b/docs/from-pulp-2.rst
@@ -8,7 +8,7 @@ Importers -> Remotes
 ********************
 
 CLI users may not have been aware of Importer objects because they were embedded into CLI commands
-with repositories. In Pulp 3, this object is now called a :term:`remote`. The scope of this object
+with repositories. In Pulp 3, this object is now called a :term:`Remote`. The scope of this object
 has been reduced to interactions with a single external source. They are no longer associated with a
 repository.
 
@@ -21,15 +21,15 @@ published content, e.g. ``YumDistributor``. In other cases, Distributor objects 
 remote services, such as the ``RsyncDistributor``.
 
 For Pulp 2 Distributors that produce metadata, e.g. ``YumDistributor``, Pulp 3 introduces a
-:term:`publication` that stores content and metadata created describing that content. The
-responsibilities of serving a :term:`publication` are moved to a new object, the
-:term:`distribution`. Only plugins that need metadata produced at publish time will have use
-:term:`publications<publication>`.
+:term:`Publication` that stores content and metadata created describing that content. The
+responsibilities of serving a :term:`Publication` are moved to a new object, the
+:term:`Distribution`. Only plugins that need metadata produced at publish time will have use
+:term:`Publications<Publication>`.
 
 For Pulp 2 Distributors that push content to remote systems, e.g. ``RsyncDistributor``, Pulp 3
-introduces an :term:`exporter` that is used to push an existing :term:`publication` to a remote
-location. For content types that don't use :term:`publications<publication>`, exporters can export
-:term:`repository version<repositoryversion>` content directly.
+introduces an :term:`Exporter` that is used to push an existing :term:`Publication` to a remote
+location. For content types that don't use :term:`Publications<Publication>`, exporters can export
+:term:`RepositoryVersion` content directly.
 
 New Concepts
 ------------
@@ -38,9 +38,8 @@ Repository Version
 ******************
 
 A new feature of Pulp 3 is that the content set of a repository is versioned. Each time the content
-set of a repository is changed, a new immutable :term:`repository version<repositoryversion>` is
-created. An empty :term:`repository version<repositoryversion>` is created upon creation of a
-repository.
+set of a repository is changed, a new immutable :term:`RepositoryVersion` is created. An empty
+:term:`RepositoryVersion` is created upon creation of a repository.
 
 Rollback
 ********
@@ -52,6 +51,6 @@ publication.
 Going Live is Atomic
 ********************
 
-Content is served by a :term:`distribution` and goes live from Pulp's :term:`content app` as soon as
+Content is served by a :term:`Distribution` and goes live from Pulp's :term:`content app` as soon as
 the database is configured to serve it. This guarantees a users view of a repository is consistent
 and as the entire repository is made available atomically.

--- a/docs/glossary.rst
+++ b/docs/glossary.rst
@@ -4,8 +4,9 @@ Glossary
 .. glossary::
 
     :class:`~pulpcore.app.models.Artifact`
-        A file. They usually belong to a :term:`content unit<content>` but may be used elsewhere
-        (e.g. for PublishedArtifacts).
+    artifact
+        A file. They usually belong to a :term:`content unit<Content>` but may be used
+        elsewhere (e.g. for PublishedArtifacts).
 
     :class:`~pulpcore.plugin.models.ContentGuard`
         A pluggable content protection mechanism that can be added to a :term:`Distribution`, and
@@ -15,26 +16,26 @@ Glossary
     :class:`~pulpcore.app.models.Content`
     content unit
         Content are the smallest units of data that can be added and removed from
-        :term:`repositories<repository>`. When singular, "content unit" should be used. Each
+        :term:`repositories<Repository>`. When singular, "content unit" should be used. Each
         content unit can have multiple :term:`artifacts<artifact>`. Each content unit has a
         :term:`type` (like .rpm or .deb) which that is defined by a :term:`plugin`.
 
     content app
         An `aiohttp.server <https://aiohttp.readthedocs.io/en/stable/web.html>`_ app provided by
-        :term:`pulpcore` that serves :term:`content` through :term:`Distributions <distribution>`.
+        :term:`pulpcore` that serves :term:`content <Content>` through :term:`Distributions
+        <Distribution>`.
 
     :class:`~pulpcore.plugin.models.Distribution`
         User facing object that configures the :term:`content app` to serve either a
-        :term:`Repository Version <RepositoryVersion>`, a :term:`Repository`, or a
-        :term:`Publication<publication>`.
+        :term:`RepositoryVersion`, a :term:`Repository`, or a :term:`Publication`.
 
-    Exporter
+    :class:`~pulpcore.plugin.models.Exporter`
         Exporters can push a :term:`Repository Version <RepositoryVersion>`, a :term:`Repository`,
-        or a :term:`Publication<publication>` content to a location outside of Pulp. Some example
+        or a :term:`Publication` content to a location outside of Pulp. Some example
         locations include a remote server or a file system location.
 
     on-demand content
-        :term:`Content<content>` that was synchronized into Pulp but not yet saved to the
+        :term:`Content<Content>` that was synchronized into Pulp but not yet saved to the
         filesystem. The Content's :term:`Artifacts<artifact>` are fetched at the time they are
         requested.  On-demand content is associated with a :term:`Remote` that knows how to download
         those :term:`Artifacts<artifact>`.
@@ -42,37 +43,37 @@ Glossary
     plugin
         A `Django <https://docs.djangoproject.com>`_ app that exends :term:`pulpcore` to add more
         features to Pulp. Plugins are most commonly used to add support for one or more
-        :term:`types<type>` of :term:`content`.
+        :term:`types<type>` of :term:`Content`.
 
     :class:`~pulpcore.app.models.Publication`
-        The metadata and :term:`artifacts<Artifact>` of the :term:`content units<content>` in a
-        :term:`repository version<RepositoryVersion>`. Publications are served by the
-        :term:`content app` when they are assigned to a :term:`distribution`.
+        The metadata and :term:`artifacts<Artifact>` of the :term:`content units<Content>` in a
+        :term:`RepositoryVersion`. Publications are served by the :term:`content app` when they are
+        assigned to a :term:`Distribution`.
 
     pulpcore
         A python package offering users a :doc:`rest_api` and plugin writers a
-        :ref:`Plugin API`. It is :term:`plugin`-based and manages :term:`content`.
+        :ref:`Plugin API`. It is :term:`plugin`-based and manages :term:`Content`.
 
     PUP
         Stands for "Pulp Update Proposal", and are the documents that specify process changes for
         the Pulp project and community.
 
     :class:`~pulpcore.plugin.models.Remote`
-        User facing settings that specify how Pulp should interact with an external :term:`content`
+        User facing settings that specify how Pulp should interact with an external :term:`Content`
         source.
 
     :class:`~pulpcore.app.models.Repository`
-        A versioned set of :term:`content units<content>`.
+        A versioned set of :term:`content units<Content>`.
 
     :class:`~pulpcore.app.models.RepositoryVersion`
-        An immutable snapshot of the set of :term:`content units<content>` that are in a
-        :term:`repository`.
+        An immutable snapshot of the set of :term:`content units<Content>` that are in a
+        :term:`Repository`.
 
     sync
-        A :term:`plugin` defined task that fetches :term:`content` from an external source using a
-        :term:`remote`. The task adds and/or removes the :term:`content units<content>` to a
-        :term:`repository`, creating a new :term:`repository version<RepositoryVersion>`.
+        A :term:`plugin` defined task that fetches :term:`Content` from an external source using a
+        :term:`Remote`. The task adds and/or removes the :term:`content units<Content>` to a
+        :term:`Repository`, creating a new :term:`RepositoryVersion`.
 
     type
-        Each :term:`content unit<content>` has a type (ex. rpm package or container tag) which is
+        Each :term:`content unit<Content>` has a type (ex. rpm package or container tag) which is
         defined by a :term:`Plugin<plugin>`.

--- a/docs/workflows/promotion.rst
+++ b/docs/workflows/promotion.rst
@@ -8,7 +8,7 @@ environment to another. There are some features Pulp provides which can help fac
 Distributions
 -------------
 
-:term:`Distributions<distribution>` are a resource in Pulp that are useful for supporting different
+:term:`Distributions<Distribution>` are a resource in Pulp that are useful for supporting different
 environments. In most cases, you'll want to create one Distribution for each :term:`Repository` and
 environment. If for example, you have a CentOS Repository that you want to serve to your Dev
 servers, you can create a distribution called "Dev CentOS" that points to your CentOS Publication.


### PR DESCRIPTION
With the release of sphinx 3.0.1 came a new error during docs builds:

/home/travis/build/pulp/pulpcore/docs/components.rst:40:term not in glossary: artifact

fixes #6485

Please be sure you have read our documentation on creating PRs:
https://docs.pulpproject.org/contributing/pull-request-walkthrough.html
