### PR TITLE
Problem: pulp_rpm 3.3.0 cannot install (& F32 upgrade)

### DIFF
--- a/CHANGES/6522.feature
+++ b/CHANGES/6522.feature
@@ -1,0 +1,1 @@
+containers: Upgrade from Fedora 30 to Fedora 32

--- a/CHANGES/6523.bugfix
+++ b/CHANGES/6523.bugfix
@@ -1,0 +1,1 @@
+containers: Fix pulp_rpm 3.3.0 install by replacing the createrep_c RPM with its build-dependencies, so createrep_c gets installed & built from PyPI

--- a/containers/images/pulp/Dockerfile.j2
+++ b/containers/images/pulp/Dockerfile.j2
@@ -1,4 +1,4 @@
-FROM fedora:30
+FROM fedora:32
 
 # https://superuser.com/questions/959380/how-do-i-install-generate-all-locales-on-fedora
 # This may not be necessary anymore because Fedora 30, unlike CentOS 7, has
@@ -38,17 +38,6 @@ RUN		dnf -y update && \
 		dnf -y install python3-devel && \
 		dnf -y install gcc && \
 		dnf clean all
-
-# Docs suggest RHEL8 uses the alternatives system for /usr/bin/python ,
-# but Fedora does not.
-RUN ln -s /usr/bin/python3 /usr/bin/python
-# If pip2 is installed, it will replace /usr/bin/pip .
-# /usr/local/bin will be before it in the PATH .
-RUN ln -s /usr/bin/pip3 /usr/local/bin/pip
-
-# Need to update pip inside of the container so that manylinux2014
-# packages are supported. This can be dropped with Fedora 32.
-RUN pip install --upgrade pip
 
 # Need to install optional dep, rhsm, for pulp-certguard
 RUN pip install rhsm

--- a/containers/images/pulp/Dockerfile.j2
+++ b/containers/images/pulp/Dockerfile.j2
@@ -24,19 +24,24 @@ ENV PULP_SETTINGS=/etc/pulp/settings.py
 # glibc-langpack-en is needed to provide the en_US.UTF-8 locale, which Pulp
 # seems to need.
 #
-# python3-createrepo_c is needed for pulp_rpm
-#
 # openssl-devel, python3-devel, and gcc are for testing pulp-certguard
+#
+# The last 5 lines (before clean) are needed until python3-createrepo_c gets an
+# RPM upgrade to 0.15.10. Until then, we install & build it from PyPI.
 RUN		dnf -y update && \
 		dnf -y install wget git && \
 		dnf -y install libxcrypt-compat && \
 		dnf -y install python3-psycopg2 && \
 		dnf -y install glibc-langpack-en && \
-		dnf -y install python3-createrepo_c && \
 		dnf -y install python3-libmodulemd && \
 		dnf -y install openssl-devel && \
 		dnf -y install python3-devel && \
 		dnf -y install gcc && \
+		dnf -y install libmodulemd-devel && \
+		dnf -y install libcomps-devel && \
+		dnf -y install ninja-build && \
+		dnf -y install 'dnf-command(builddep)' && \
+		dnf -y builddep createrepo_c && \
 		dnf clean all
 
 # Need to install optional dep, rhsm, for pulp-certguard


### PR DESCRIPTION
on the pulp-operator pulp container because Fedora's createrepo_c
 is too old
    
 Solution: Temporarily replace the createrepo_c RPM with its
 build-dependencies, and let createrepo_c get installed &
 built from PyPI.

fixes: #6523

Developed on top of this change:

containers: Upgrade to Fedora 32
    
fixes: #6522
