### PR TITLE
Problem: pulp_rpm 3.3.0 cannot install

### DIFF
--- a/CHANGES/6523.bugfix
+++ b/CHANGES/6523.bugfix
@@ -1,0 +1,1 @@
+containers: Fix pulp_rpm 3.3.0 install by replacing the python3-createrepo_c RPM with its build-dependencies, so createrep_c gets installed & built from PyPI

--- a/containers/images/pulp/Dockerfile.j2
+++ b/containers/images/pulp/Dockerfile.j2
@@ -24,19 +24,24 @@ ENV PULP_SETTINGS=/etc/pulp/settings.py
 # glibc-langpack-en is needed to provide the en_US.UTF-8 locale, which Pulp
 # seems to need.
 #
-# python3-createrepo_c is needed for pulp_rpm
-#
 # openssl-devel, python3-devel, and gcc are for testing pulp-certguard
+#
+# The last 5 lines (before clean) are needed until python3-createrepo_c gets an
+# RPM upgrade to 0.15.10. Until then, we install & build it from PyPI.
 RUN		dnf -y update && \
 		dnf -y install wget git && \
 		dnf -y install libxcrypt-compat && \
 		dnf -y install python3-psycopg2 && \
 		dnf -y install glibc-langpack-en && \
-		dnf -y install python3-createrepo_c && \
 		dnf -y install python3-libmodulemd && \
 		dnf -y install openssl-devel && \
 		dnf -y install python3-devel && \
 		dnf -y install gcc && \
+		dnf -y install libmodulemd-devel && \
+		dnf -y install libcomps-devel && \
+		dnf -y install ninja-build && \
+		dnf -y install 'dnf-command(builddep)' && \
+		dnf -y builddep createrepo_c && \
 		dnf clean all
 
 # Docs suggest RHEL8 uses the alternatives system for /usr/bin/python ,


### PR DESCRIPTION
on the pulp-operator pulp container because Fedora's createrepo_c
is too old

Solution: Temporarily replace the createrepo_c RPM with its
build-dependencies, and let createrepo_c get installed &
built from PyPI.

fixes: #6523

Please be sure you have read our documentation on creating PRs:
https://docs.pulpproject.org/contributing/pull-request-walkthrough.html
