### PR TITLE
Fixed missing RemoteFilter object

### DIFF
--- a/CHANGES/plugin_api/6563.bugfix
+++ b/CHANGES/plugin_api/6563.bugfix
@@ -1,0 +1,1 @@
+Added ``RemoteFilter`` to the plugin API as it was missing but used by plugin_template.

--- a/pulpcore/plugin/viewsets/__init__.py
+++ b/pulpcore/plugin/viewsets/__init__.py
@@ -17,6 +17,7 @@ from pulpcore.app.viewsets import (  # noqa
     PublicationFilter,
     PublicationViewSet,
     ReadOnlyContentViewSet,
+    RemoteFilter,
     RemoteViewSet,
     RepositoryViewSet,
     RepositoryVersionViewSet,


### PR DESCRIPTION
Used in plugins: https://github.com/pulp/plugin_template/blob/24dc0c7cb725620ae92b6771dc902edf08386077/templates/bootstrap/plugin_name/app/viewsets.py.j2#L14

fixes #6563

Please be sure you have read our documentation on creating PRs:
https://docs.pulpproject.org/contributing/pull-request-walkthrough.html
