### PR TITLE
Fixed bug where TaskGroup was showing up as null

### DIFF
--- a/CHANGES/6573.bugfix
+++ b/CHANGES/6573.bugfix
@@ -1,0 +1,1 @@
+Fixed bug where ``TaskGroup`` was showing up as null for ``created_resources`` in tasks.

--- a/pulpcore/app/serializers/task.py
+++ b/pulpcore/app/serializers/task.py
@@ -125,6 +125,7 @@ class MinimalTaskSerializer(TaskSerializer):
 
 
 class TaskGroupSerializer(ModelSerializer):
+    pulp_href = IdentityField(view_name='task-groups-detail')
     description = serializers.CharField(
         help_text=_("A description of the task group.")
     )
@@ -157,7 +158,7 @@ class TaskGroupSerializer(ModelSerializer):
     class Meta:
         model = models.TaskGroup
         fields = (
-            'description',
+            'pulp_href', 'description',
             'waiting', 'skipped', 'running',
             'completed', 'canceled', 'failed'
         )


### PR DESCRIPTION
fixes #6573

Please be sure you have read our documentation on creating PRs:
https://docs.pulpproject.org/contributing/pull-request-walkthrough.html
