### PR TITLE
Add task groups to the Plugin API

### DIFF
--- a/CHANGES/plugin_api/6603.feature
+++ b/CHANGES/plugin_api/6603.feature
@@ -1,0 +1,1 @@
+Add TaskGroup to the plugin API.

--- a/pulpcore/plugin/models/__init__.py
+++ b/pulpcore/plugin/models/__init__.py
@@ -29,4 +29,5 @@ from pulpcore.app.models import (  # noqa
     RepositoryVersionDistribution,
     SigningService,
     Task,
+    TaskGroup,
 )


### PR DESCRIPTION
Somehow this never got added to the plugin API even though I remember making the change, it must have gotten accidentally stashed or something.  There's already a changelog entry... we can send this out in a Y release.

re: #6414
https://pulp.plan.io/issues/6414
