### PR TITLE
Add content handler to distribution

### DIFF
--- a/CHANGES/plugin_api/6570.feature
+++ b/CHANGES/plugin_api/6570.feature
@@ -1,0 +1,1 @@
+Added support for Distributions to provide non-Artifact content via a content_handler.

--- a/CHANGES/plugin_api/6570.removal
+++ b/CHANGES/plugin_api/6570.removal
@@ -1,0 +1,1 @@
+The :meth:`pulpcore.content.handler.Handler.list_directory` function now returns a set of strings where it returned a string of HTML before.

--- a/docs/plugins/api-reference/content-app.rst
+++ b/docs/plugins/api-reference/content-app.rst
@@ -14,6 +14,10 @@ Making a custom Handler is a two-step process:
 2. Add the Handler to a route using aiohttp.server's `add_route() <https://aiohttp.readthedocs.io/en
    /stable/web_reference.html#aiohttp.web.UrlDispatcher.add_route>`_ interface.
 
+If content needs to be served from within the :term:`Distribution`'s base_path,
+overriding the :meth:`~pulpcore.plugin.models.BaseDistribution.content_handler` and
+:meth:`~pulpcore.plugin.models.BaseDistribution.content_handler_directory_listing`
+methods in your Distribution is an easier way to serve this content.
 
 Creating your Handler
 ---------------------

--- a/pulpcore/app/models/publication.py
+++ b/pulpcore/app/models/publication.py
@@ -286,6 +286,18 @@ class BaseDistribution(MasterModel):
     content_guard = models.ForeignKey(ContentGuard, null=True, on_delete=models.SET_NULL)
     remote = models.ForeignKey(Remote, null=True, on_delete=models.SET_NULL)
 
+    def content_handler(self, path):
+        """
+        Handler to serve extra, non-Artifact content for this Distribution
+
+        Args:
+            path (str): The path being requested
+        Returns:
+            None if there is no content to be served at path. Otherwise a
+            aiohttp.web_response.Response with the content.
+        """
+        return None
+
 
 class PublicationDistribution(BaseDistribution):
     """

--- a/pulpcore/app/models/publication.py
+++ b/pulpcore/app/models/publication.py
@@ -298,6 +298,18 @@ class BaseDistribution(MasterModel):
         """
         return None
 
+    def content_handler_list_directory(self, rel_path):
+        """
+        Generate the directory listing entries for content_handler
+
+        Args:
+            rel_path (str): relative path inside the distribution's base_path. For example,
+            the root of the base_path is '', a subdir within the base_path is 'subdir/'.
+        Returns:
+            Set of strings for the extra entries in rel_path
+        """
+        return set()
+
 
 class PublicationDistribution(BaseDistribution):
     """

--- a/pulpcore/content/handler.py
+++ b/pulpcore/content/handler.py
@@ -254,11 +254,11 @@ class Handler:
 
     async def list_directory(self, repo_version, publication, path):
         """
-        Generate HTML with directory listing of the path.
+        Generate a set with directory listing of the path.
 
         This method expects either a repo_version or a publication in addition to a path. This
-        method generates HTML directory list of a path inside the repository version or
-        publication.
+        method generates a set of strings representing the list of a path inside the repository
+        version or publication.
 
         Args:
             repo_version (:class:`~pulpcore.app.models.RepositoryVersion`): The repository version
@@ -266,7 +266,7 @@ class Handler:
             path (str): relative path inside the repo version of publication.
 
         Returns:
-            String representing HTML of the directory listing.
+            Set of strings representing the files and directories in the directory listing.
         """
         if not publication and not repo_version:
             raise Exception("Either a repo_version or publication is required.")
@@ -300,13 +300,30 @@ class Handler:
                 directory_list.add(file_or_directory_name(path, ca.relative_path))
 
         if directory_list:
-            return self.render_html(directory_list)
+            return directory_list
         else:
             raise PathNotResolved(path)
 
     async def _match_and_stream(self, path, request):
         """
         Match the path and stream results either from the filesystem or by downloading new data.
+
+        After deciding the client can access the distribution at ``path``, this function calls
+        :meth:`BaseDistribution.content_handler`. If that function returns a not-None result,
+        it is returned to the client.
+
+        Then the publication linked to the Distribution is used to determine what content should
+        be served. If ``path`` is a directory entry (i.e. not a file), the directory contents
+        are served to the client. This method calls
+        :meth:`BaseDistribution.content_handler_list_directory` to acquire any additional entries
+        the Distribution's content_handler might serve in that directory. If there is an actifact
+        to be served, it is served to the client.
+
+        If there's no publication, the above paragraph is applied to the lastest repository linked
+        to the matched Distribution.
+
+        Finally, when nothing is served to client yet, we check if there is a remote for the
+        Distribution. If so, the artifact is pulled from the remote and streamed to the client.
 
         Args:
             path (str): The path component of the URL.
@@ -343,7 +360,10 @@ class Handler:
                     rel_path = index_path
                 except ObjectDoesNotExist:
                     dir_list = await self.list_directory(None, publication, rel_path)
-                    return HTTPOk(headers={"Content-Type": "text/html"}, body=dir_list)
+                    dir_list.update(distro.content_handler_list_directory(rel_path))
+                    return HTTPOk(
+                        headers={"Content-Type": "text/html"}, body=self.render_html(dir_list)
+                    )
 
             # published artifact
             try:
@@ -397,7 +417,10 @@ class Handler:
                     rel_path = index_path
                 except ObjectDoesNotExist:
                     dir_list = await self.list_directory(repo_version, None, rel_path)
-                    return HTTPOk(headers={"Content-Type": "text/html"}, body=dir_list)
+                    dir_list.update(distro.content_handler_list_directory(rel_path))
+                    return HTTPOk(
+                        headers={"Content-Type": "text/html"}, body=self.render_html(dir_list)
+                    )
 
             try:
                 ca = ContentArtifact.objects.get(

--- a/pulpcore/content/handler.py
+++ b/pulpcore/content/handler.py
@@ -327,6 +327,10 @@ class Handler:
         rel_path = rel_path[len(distro.base_path) :]
         rel_path = rel_path.lstrip("/")
 
+        content_handler_result = distro.content_handler(rel_path)
+        if content_handler_result is not None:
+            return content_handler_result
+
         headers = self.response_headers(rel_path)
 
         publication = getattr(distro, "publication", None)


### PR DESCRIPTION
See https://pulp.plan.io/issues/6570

This implements a `content_handler` function in `BaseDistribution` to allow plugin writers to serve non-Artifact content from their plugin. It also adds a `content_handler_directory_listing` function in `BaseDistribution` that allows plugin writers to add these 'files' to the directory listings.

On how this can be used, see https://github.com/pulp/pulp_rpm/pull/1687

Please comment on the code (and where perhaps an `await` or `async` could be added). Once the code is "good enough", I'll add tests.