### PR TITLE
Better debugging for task group monitoring in tests

### DIFF
--- a/pulpcore/tests/functional/utils.py
+++ b/pulpcore/tests/functional/utils.py
@@ -50,8 +50,8 @@ def monitor_task_group(tg_href):
         sleep(2)
         tg = task_groups.read(tg_href)
     if (tg.failed + tg.skipped + tg.canceled) > 0:
-        print("The task gorup failed.")
+        print(f"The task group failed: {tg}")
         exit()
     else:
-        print("The task group was succesful.")
+        print("The task group was successful.")
         return tg


### PR DESCRIPTION
Adding more info to print statement when a task group fails to complete
in order to better debug some task group failures in Travis.

[noissue]

Please be sure you have read our documentation on creating PRs:
https://docs.pulpproject.org/contributing/pull-request-walkthrough.html
