### PR TITLE
Adds proper headers for index.html pages served by content app

### DIFF
--- a/CHANGES/6802.bugfix
+++ b/CHANGES/6802.bugfix
@@ -1,0 +1,1 @@
+Added proper headers for index.html pages served by content app.

--- a/pulpcore/content/handler.py
+++ b/pulpcore/content/handler.py
@@ -366,6 +366,7 @@ class Handler:
                     index_path = "{}index.html".format(rel_path)
                     publication.published_artifact.get(relative_path=index_path)
                     rel_path = index_path
+                    headers = self.response_headers(rel_path)
                 except ObjectDoesNotExist:
                     dir_list = await self.list_directory(None, publication, rel_path)
                     dir_list.update(distro.content_handler_list_directory(rel_path))


### PR DESCRIPTION
fixes: #6802
https://pulp.plan.io/issues/6802