### PR TITLE
Stabilize content list ordering

### DIFF
--- a/pulpcore/app/viewsets/content.py
+++ b/pulpcore/app/viewsets/content.py
@@ -1,7 +1,9 @@
 from gettext import gettext as _
 
 from django.db import models
+from django_filters.rest_framework import DjangoFilterBackend
 from rest_framework import mixins, status
+from rest_framework.filters import OrderingFilter
 from rest_framework.response import Response
 
 from pulpcore.app.models import Artifact, Content, SigningService
@@ -112,6 +114,8 @@ class BaseContentViewSet(NamedModelViewSet):
 
     endpoint_name = "content"
     filterset_class = ContentFilter
+    filter_backends = (OrderingFilter, DjangoFilterBackend)
+    ordering = "-pulp_created"
     # These are just placeholders, the plugin writer would replace them with the actual
     queryset = Content.objects.all()
     serializer_class = MultipleArtifactContentSerializer


### PR DESCRIPTION
Without a stable ordering, pagination can use different orders when selecting different subsets of content resulting in duplicated and missing entries.

Since the pagination is based on the index of the content, the order must be consistent.

I discovered this issue when listing RPM packages within a repository version. I was expecting 501 packages back, but after de-duplicating the list based on the `pulp_href` of each package, I was seeing less than 400 unique entries. If I compared the packages I was getting with a list that was fetched in a single page, only the first page had a different ordering.

Django is completely foreign to me, so if this isn't the right spot to make this fix, then please point me in the right direction. The fix stabilized the pagination for me and resolved the issues I'm seeing when fetching content lists, but I very well may have missed something obvious.

Environment:
- pulpcore 3.2.1 and pulp_rpm 3.2.0 on CentOS 7
- pulp-rpm-client 3.3.2 on Fedora 32