### PR TITLE
Removes Content-Encoding header from pulpcore-content responses.

### DIFF
--- a/CHANGES/6831.bugfix
+++ b/CHANGES/6831.bugfix
@@ -1,0 +1,1 @@
+Removed Content-Encoding header from pulpcore-content responses.

--- a/pulpcore/content/handler.py
+++ b/pulpcore/content/handler.py
@@ -229,8 +229,6 @@ class Handler:
         headers = {}
         if content_type:
             headers["Content-Type"] = content_type
-        if encoding:
-            headers["Content-Encoding"] = encoding
         return headers
 
     @staticmethod


### PR DESCRIPTION
This header is not needed because the server is not actually encoding the response.

fixes: #6831
https://pulp.plan.io/issues/6831