### PR TITLE
Rewrite QueryExistingContent stage for performance

### DIFF
--- a/CHANGES/7143.misc
+++ b/CHANGES/7143.misc
@@ -1,0 +1,1 @@
+Sync performance improvements from rewriting the QueryExistingContent stage.


### PR DESCRIPTION
Making the following assumptions:

* Even though total uniqueness is only guaranteed by the full natural key, most content types
  have a single attribute which gets you 99.9% of the way there, e.g. "digest" for file content and
  "pkgId" for RPM content and "filename" for Python content.  It is far, far cheaper to query by a
  single attribute than to query for sets of many attributes, both in terms of query construction
  (ORM has a high overhead here) and the ability of the database to optimize it.
* If we were to query by a single attribute to find existing content, we may get back "false positives"
  which have a duplicate value of this attribute but with a different overall natural key. If discriminating
  and ignoring these is sufficiently cheap and if there are sufficiently few of them, then the overall
  performance can be increased.

The idea is that instead of sending PostgreSQL queries that look like this:

```
SELECT ... FROM rpm_package WHERE
   (name='tmux' AND epoch='0' AND version='2' AND release='1' AND arch='x86_64' AND ...) OR
   (name='ssh' AND  epoch='0' AND version='3' AND release='2' AND arch='x86_64' AND ...) OR
   ...
   x100
```

We send it vastly more efficient (to execute, and to construct) queries that look like this:

```
SELECT ... FROM rpm_package WHERE name IN {'tmux', 'ssh', ..., x100}
```

And, by making it sufficiently inexpensive to compare natural keys between the
units from the database query (filled with potential false positives) and the
incoming content (the batch), we can gain a large overall net win in terms of
performance.

[noissue]
