### PR TITLE
Remove deprecated warning for does_batch

### DIFF
--- a/docs/plugins/plugin-writer/concepts/sync_pipeline/sync_pipeline.rst
+++ b/docs/plugins/plugin-writer/concepts/sync_pipeline/sync_pipeline.rst
@@ -59,10 +59,11 @@ To support this pattern, the declarative content allows to be associated with a
 :class:`pulpcore.plugin.stages.ResolveContentFutures` stage.
 By awaiting this Future, one can implement an informational back loop into earlier stages.
 
-.. warning::
+.. hint::
 
-   In order to prevent deadlocks, be sure that you mark the declarative content with
-   `does_batch=False`, and that you do not drop it without resolving the future.
+   To improve performance when you expect to create a lot of those futures, consider to
+   create a larger batch before starting to await them. This way the batching in the subsequent
+   stages will still be exploited.
 
 .. hint::
 


### PR DESCRIPTION
Add a hint to batch futures.

[noissue]

Please be sure you have read our documentation on creating PRs:
https://docs.pulpproject.org/contributing/pull-request-walkthrough.html
