### PR TITLE
Fix broken link from website update

### DIFF
--- a/CHANGES/7017.doc
+++ b/CHANGES/7017.doc
@@ -1,0 +1,1 @@
+Fixed broken link to content plugins web page

--- a/docs/bugs-features.rst
+++ b/docs/bugs-features.rst
@@ -3,7 +3,7 @@ Bugs and Feature Requests
 
 Bugs and feature requests for :term:`pulpcore` are tracked with `Redmine
 <https://pulp.plan.io/projects/pulp/issues/>`_. Please see the `plugin table
-<https://pulpproject.org/pulp-3-plugins/>`_ for trackers for each plugin.
+<https://pulpproject.org/content-plugins/>`_ for trackers for each plugin.
 
 .. _issue-writing:
 
@@ -153,5 +153,3 @@ Redmine Fields
 +-------------+-----------------------------------------------------------------------------------+
 | Tags        | Used for filtering.                                                               |
 +-------------+-----------------------------------------------------------------------------------+
-
-

--- a/docs/contributing/pull-request-walkthrough.rst
+++ b/docs/contributing/pull-request-walkthrough.rst
@@ -4,7 +4,7 @@ Pull Request Walkthrough
 Changes to pulpcore are submitted via `GitHub Pull Requests (PR)
 <https://help.github.com/articles/about-pull-requests/>`_ to the `pulp git repository
 <https://github.com/pulp/pulpcore>`_ . Plugin git repositories are listed in the `plugin table
-<https://pulpproject.org/pulp-3-plugins/>`_.
+<https://pulpproject.org/content-plugins/>`_.
 
 Boilerplate
 -----------

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -27,7 +27,7 @@ Source code
 
   * `pulp Github organization <https://github.com/pulp/>`_
   * `pulpcore <https://github.com/pulp/pulpcore/>`_
-  * `plugin repositories <https://pulpproject.org/pulp-3-plugins/>`_
+  * `plugin repositories <https://pulpproject.org/content-plugins/>`_
 
 
 How to Navigate the pulpcore and plugin docs
@@ -38,7 +38,7 @@ Plugin Documentation
 
 If you are a new user who is evaluating Pulp it is recommended that you skim the documentation for
 the plugins that add the content types you are interested in. Links to these docs can be found in
-our `list of plugins <https://pulpproject.org/pulp-3-plugins/>`_
+our `list of plugins <https://pulpproject.org/content-plugins/>`_
 
 Pulpcore Documentation
 ^^^^^^^^^^^^^^^^^^^^^^

--- a/docs/plugins/index.rst
+++ b/docs/plugins/index.rst
@@ -4,7 +4,7 @@ Plugins
 Plugins add support for a type of content to Pulp. For example, the
 `file_plugin <https://github.com/pulp/pulp_file>`_ adds support for Pulp to manage files.
 
-For a list of plugins check out our `list of plugins for Pulp 3 <https://pulpproject.org/pulp-3-plugins/>`_.
+For a list of plugins check out our `list of plugins for Pulp 3 <https://pulpproject.org/content-plugins/>`_.
 
 And don't hesitate to :ref:`contact us<community>` with any questions during development.
 Let us know when the plugin is ready and we will be happy to add it to the list of available plugins for Pulp!

--- a/docs/workflows/index.rst
+++ b/docs/workflows/index.rst
@@ -3,7 +3,7 @@ Workflows and Use Cases
 
 Best practices for content management are discussed here. The goal of this document is to provide a
 framework for users to design their own workflows with any content type. For specific examples,
-users should refer to `plugin documentation <https://pulpproject.org/pulp-3-plugins/>`_. This page
+users should refer to `plugin documentation <https://pulpproject.org/content-plugins/>`_. This page
 assumes that the reader is familiar with the fundamentals discussed in the :doc:`/concepts`.
 
 


### PR DESCRIPTION
I updated the link to the Pulp 3 plugins that was out of date in the docs. 
