### PR TITLE
don't go into an infinite loop when `CONTENT_PATH_PREFIX` is followed by `/`

### DIFF
--- a/CHANGES/7066.bugfix
+++ b/CHANGES/7066.bugfix
@@ -1,0 +1,1 @@
+Fixed denial of service caused by extra slashes in content urls.

--- a/pulpcore/content/handler.py
+++ b/pulpcore/content/handler.py
@@ -151,7 +151,7 @@ class Handler:
         tree = []
         while True:
             base = os.path.split(path)[0]
-            if not base:
+            if not base.lstrip("/"):
                 break
             tree.append(base)
             path = base


### PR DESCRIPTION
this would cause `path` to start with a `/`
and because
```
>>> os.path.split('/path')
('/', 'path')
>>> os.path.split('/')
('/', '')
```
`base` would never end up as `None` but stay as `/` resulting in an infinite loop.

Please be sure you have read our documentation on creating PRs:
https://docs.pulpproject.org/contributing/pull-request-walkthrough.html
