### PR TITLE
Prevents deadlock by locking core_content across update.

### DIFF
--- a/CHANGES/7073.bugfix
+++ b/CHANGES/7073.bugfix
@@ -1,0 +1,1 @@
+Locked Content table to prevent import-deadlock.


### PR DESCRIPTION
THIS IS A TEMPORARY FIX to prevent test_pulpimport failures from
blocking unrelated commits. See the related issue for other
approaches.

Success can be tested in a dev-env with the following bash cmd:

for i in {1..10}; do
  (pytest -v -r sx --color=yes --pyargs \
   pulpcore.tests.functional.api.using_plugin.test_pulpimport > $i.out &)
done

Without this fix, each run sees 1-4 tests fail due to deadlock.
With the fix, repeated executions have shown no failures.

fixes #7073
