### PR TITLE
Remove non-model-fields from Meta.fields of filters

### DIFF
--- a/CHANGES/6915.bugfix
+++ b/CHANGES/6915.bugfix
@@ -1,0 +1,1 @@
+Corrected a number of filters to be django-filter-2.3.0-compliant.

--- a/pulpcore/app/viewsets/content.py
+++ b/pulpcore/app/viewsets/content.py
@@ -35,13 +35,12 @@ class ArtifactFilter(BaseFilterSet):
     class Meta:
         model = Artifact
         fields = {
-            "repository_version": ["exact"],
-            "md5": ["exact"],
-            "sha1": ["exact"],
-            "sha224": ["exact"],
-            "sha256": ["exact"],
-            "sha384": ["exact"],
-            "sha512": ["exact"],
+            "md5",
+            "sha1",
+            "sha224",
+            "sha256",
+            "sha384",
+            "sha512",
         }
 
 
@@ -93,14 +92,6 @@ class ContentFilter(BaseFilterSet):
     repository_version = ContentRepositoryVersionFilter()
     repository_version_added = ContentAddedRepositoryVersionFilter()
     repository_version_removed = ContentRemovedRepositoryVersionFilter()
-
-    class Meta:
-        model = Content
-        fields = {
-            "repository_version": ["exact"],
-            "repository_version_added": ["exact"],
-            "repository_version_removed": ["exact"],
-        }
 
 
 class BaseContentViewSet(NamedModelViewSet):

--- a/pulpcore/app/viewsets/repository.py
+++ b/pulpcore/app/viewsets/repository.py
@@ -144,13 +144,13 @@ class RepositoryVersionFilter(BaseFilterSet):
     number = filters.NumberFilter()
     pulp_created = IsoDateTimeFilter()
     content = RepositoryVersionContentFilter()
+    content__in = RepositoryVersionContentFilter(field_name="content", lookup_expr="in")
 
     class Meta:
         model = RepositoryVersion
         fields = {
             "number": ["exact", "lt", "lte", "gt", "gte", "range"],
             "pulp_created": DATETIME_FILTER_OPTIONS,
-            "content": ["exact", "in"],
         }
 
 

--- a/pulpcore/app/viewsets/task.py
+++ b/pulpcore/app/viewsets/task.py
@@ -122,8 +122,6 @@ class WorkerFilter(BaseFilterSet):
         fields = {
             "name": NAME_FILTER_OPTIONS,
             "last_heartbeat": DATETIME_FILTER_OPTIONS,
-            "online": ["exact"],
-            "missing": ["exact"],
         }
 
     def filter_online(self, queryset, name, value):

--- a/pulpcore/app/viewsets/upload.py
+++ b/pulpcore/app/viewsets/upload.py
@@ -15,18 +15,8 @@ from pulpcore.app.serializers import (
     UploadDetailSerializer,
 )
 from pulpcore.app.serializers.upload import CONTENT_RANGE_PATTERN
-from pulpcore.app.viewsets import BaseFilterSet
-from pulpcore.app.viewsets.base import DATETIME_FILTER_OPTIONS, NamedModelViewSet
-from pulpcore.app.viewsets.custom_filters import IsoDateTimeFilter
+from pulpcore.app.viewsets.base import NamedModelViewSet
 from pulpcore.tasking.tasks import enqueue_with_reservation
-
-
-class UploadFilter(BaseFilterSet):
-    completed = IsoDateTimeFilter(field_name="completed")
-
-    class Meta:
-        model = Upload
-        fields = {"completed": DATETIME_FILTER_OPTIONS + ["isnull"]}
 
 
 class UploadViewSet(
@@ -41,7 +31,6 @@ class UploadViewSet(
 
     endpoint_name = "uploads"
     queryset = Upload.objects.all()
-    filterset_class = UploadFilter
     http_method_names = ["get", "post", "head", "put", "delete"]
 
     content_range_parameter = Parameter(


### PR DESCRIPTION
Changes include:
  * Meta.fields list may only reference fields that exist in Meta.model
  * 'exact' is redundant in Meta.fields qualifiers (per Mongo docs)
  * Upload.completed was removed in cf5bad, remove referencing filter

closes #6915
