### PR TITLE
Fixed WorkerDirectory.delete() causing infinite recursion when permission errors occur

### DIFF
--- a/CHANGES/6504.bugfix
+++ b/CHANGES/6504.bugfix
@@ -1,0 +1,1 @@
+WorkerDirectory.delete() no longer recursively trys to delete itself when encountering a permission error

--- a/pulpcore/tasking/services/storage.py
+++ b/pulpcore/tasking/services/storage.py
@@ -73,16 +73,23 @@ class WorkerDirectory:
         """
         Delete the directory.
 
-        On permission denied - an attempt is made to recursively fix the
+        On permission denied - an attempt is made to fix the
         permissions on the tree and the delete is retried.
+        """
+        try:
+            self._delete()
+        except PermissionError:
+            self._set_permissions()
+            self._delete()
+
+    def _delete(self):
+        """
+        Helper method for delete
         """
         try:
             shutil.rmtree(self.path)
         except FileNotFoundError:
             pass
-        except PermissionError:
-            self._set_permissions()
-            self.delete()
 
     def _set_permissions(self):
         """


### PR DESCRIPTION
WorkerDirectory.delete() now only tries one additional time to delete its directory tree after encountering a PermissionError

fixes #6504
https://pulp.plan.io/issues/6504

