### PR TITLE
Remote certificate doc strings

### DIFF
--- a/CHANGES/plugin_api/6735.removal
+++ b/CHANGES/plugin_api/6735.removal
@@ -1,0 +1,1 @@
+Newlines in certificate string (ca_cert, client_cert, client_key) on Remotes are not required to be escaped.

--- a/pulpcore/app/serializers/repository.py
+++ b/pulpcore/app/serializers/repository.py
@@ -52,15 +52,13 @@ class RemoteSerializer(ModelSerializer):
     )
     url = serializers.CharField(help_text="The URL of an external content source.",)
     ca_cert = serializers.CharField(
-        help_text="A string containing the PEM encoded CA certificate used to validate the server "
-        "certificate presented by the remote server. All new line characters must be "
-        "escaped.",
+        help_text="A PEM encoded CA certificate used to validate the server "
+        "certificate presented by the remote server.",
         required=False,
         allow_null=True,
     )
     client_cert = serializers.CharField(
-        help_text="A string containing the PEM encoded client certificate used for authentication. "
-        "All new line characters must be escaped.",
+        help_text="A PEM encoded client certificate used for authentication.",
         required=False,
         allow_null=True,
     )


### PR DESCRIPTION
PULP doesn't advice to escape newlines for ca_cert, client_cert and client_key fields.

closes: #6735
https://pulp.plan.io/issues/6735