### PR TITLE
Streamed responses are properly returned to handler to be logged

### DIFF
--- a/CHANGES/7002.bugfix
+++ b/CHANGES/7002.bugfix
@@ -1,0 +1,1 @@
+First time on demand content requests appear in the access log.

--- a/pulpcore/content/handler.py
+++ b/pulpcore/content/handler.py
@@ -490,6 +490,7 @@ class Handler:
         for remote_artifact in content_artifact.remoteartifact_set.all():
             try:
                 response = await self._stream_remote_artifact(request, response, remote_artifact)
+                return response
 
             except ClientResponseError:
                 continue
@@ -643,4 +644,7 @@ class Handler:
         if remote.policy != Remote.STREAMED:
             self._save_artifact(download_result, remote_artifact)
         await response.write_eof()
+
+        if response.status == 404:
+            raise HTTPNotFound()
         return response


### PR DESCRIPTION
When a request for content that was on_demand occured for the first time, no logs where present due to the response not properly being return to the content handler, despite the response actually occuring.

fixes #7002
https://pulp.plan.io/issues/7002
