### PR TITLE
Taught export to produce, and import to understand, a table-of-conten…

### DIFF
--- a/CHANGES/6737.feature
+++ b/CHANGES/6737.feature
@@ -1,0 +1,1 @@
+Added table-of-contents to export and gave import a toc= to find/reassemble pieces on import.

--- a/pulpcore/app/serializers/importer.py
+++ b/pulpcore/app/serializers/importer.py
@@ -91,11 +91,30 @@ class PulpImporterSerializer(ImporterSerializer):
 class PulpImportSerializer(ModelSerializer):
     """Serializer for call to import into Pulp."""
 
-    path = serializers.CharField(help_text=_("Path to export that will be imported."))
+    path = serializers.CharField(
+        help_text=_("Path to export that will be imported."), required=False
+    )
+    toc = serializers.CharField(
+        help_text=_(
+            "Path to a table-of-contents file describing chunks to be validated, "
+            + "reassembled, and imported."
+        ),
+        required=False,
+    )
+
+    def _check_path_allowed(self, param, a_path):
+        user_provided_realpath = os.path.realpath(a_path)
+        for allowed_path in settings.ALLOWED_IMPORT_PATHS:
+            if user_provided_realpath.startswith(allowed_path):
+                return user_provided_realpath
+
+        raise serializers.ValidationError(
+            _("{} '{}' is not an allowed import path").format(param, a_path)
+        )
 
     def validate_path(self, value):
         """
-        Check if path is in ALLOWED_IMPORT_PATHS.
+        Check if path exists and is in ALLOWED_IMPORT_PATHS.
 
         Args:
             value (str): The user-provided value path to be validated.
@@ -106,14 +125,48 @@ class PulpImportSerializer(ModelSerializer):
         Returns:
             The validated value.
         """
-        for allowed_path in settings.ALLOWED_IMPORT_PATHS:
-            user_provided_realpath = os.path.realpath(value)
-            if user_provided_realpath.startswith(allowed_path):
-                return value
-        raise serializers.ValidationError(
-            _("Path '{}' is not an allowed import " "path").format(value)
-        )
+        return self._check_path_allowed("path", value)
+
+    def validate_toc(self, value):
+        """
+        Check validity of provided 'toc' parameter.
+
+        'toc' must:
+          * be within ALLOWED_IMPORT_PATHS.
+          * be valid JSON
+          * point to chunked-export-files that exist 'next to' the 'toc' file
+
+        NOTE: this method does NOT validate checksums of the chunked-export-files. That
+        happens asynchronously, due to time/responsiveness constraints.
+
+        Args:
+            value (str): The user-provided toc-file-path to be validated.
+
+        Raises:
+            ValidationError: When toc is not in the ALLOWED_IMPORT_PATHS setting,
+            toc is not a valid JSON table-of-contents file, or when toc points to
+            chunked-export-files that can't be found in the same directory as the toc-file.
+
+        Returns:
+            The validated value.
+        """
+
+        return self._check_path_allowed("toc", value)
+
+    def validate(self, data):
+        # only one-of 'path'/'toc'
+        if data.get("path", None) and data.get("toc", None):
+            raise serializers.ValidationError(_("Only one of 'path' and 'toc' may be specified."))
+
+        # requires one-of 'path'/'toc'
+        if not data.get("path", None) and not data.get("toc", None):
+            raise serializers.ValidationError(_("One of 'path' or 'toc' must be specified."))
+
+        return super().validate(data)
 
     class Meta:
         model = models.Import
-        fields = ("path",)
+        fields = (
+            "path",
+            "toc",
+        )

--- a/pulpcore/app/tasks/importer.py
+++ b/pulpcore/app/tasks/importer.py
@@ -1,6 +1,8 @@
+import hashlib
 import json
 import os
 import re
+import subprocess
 import tempfile
 import tarfile
 from gettext import gettext as _
@@ -148,7 +150,7 @@ def import_repository_version(destination_repo_pk, source_repo_name, tar_path):
             new_version.set_content(content)
 
 
-def pulp_import(importer_pk, path):
+def pulp_import(importer_pk, path, toc):
     """
     Import a Pulp export into Pulp.
 
@@ -157,6 +159,14 @@ def pulp_import(importer_pk, path):
         path (str): Path to the export to be imported
     """
 
+    def _compute_hash(filename):
+        sha256_hash = hashlib.sha256()
+        with open(filename, "rb") as f:
+            # Read and update hash string value in blocks of 4K
+            for byte_block in iter(lambda: f.read(4096), b""):
+                sha256_hash.update(byte_block)
+            return sha256_hash.hexdigest()
+
     def destination_repo(source_repo_name):
         """Find the destination repository based on source repo's name."""
         if importer.repo_mapping and importer.repo_mapping.get(source_repo_name):
@@ -164,6 +174,126 @@ def pulp_import(importer_pk, path):
         else:
             dest_repo_name = source_repo_name
         return Repository.objects.get(name=dest_repo_name)
+
+    def validate_toc(toc_filename):
+        """
+        Check validity of table-of-contents file.
+
+        table-of-contents must:
+          * exist
+          * be valid JSON
+          * point to chunked-export-files that exist 'next to' the 'toc' file
+          * point to chunks whose checksums match the checksums stored in the 'toc' file
+
+        Args:
+            toc_filename (str): The user-provided toc-file-path to be validated.
+
+        Raises:
+            ValidationError: If toc is not a valid JSON table-of-contents file,
+            or when toc points to chunked-export-files that can't be found in the same
+            directory as the toc-file, or the checksums of the chunks do not match the
+            checksums stored in toc.
+        """
+        with open(toc_filename) as json_file:
+            # Valid JSON?
+            the_toc = json.load(json_file)
+            if not the_toc.get("files", None) or not the_toc.get("meta", None):
+                raise ValidationError(_("Missing 'files' or 'meta' keys in table-of-contents!"))
+
+            base_dir = os.path.dirname(toc_filename)
+            # Points at chunks that exist?
+            missing_files = []
+            for f in sorted(the_toc["files"].keys()):
+                if not os.path.isfile(os.path.join(base_dir, f)):
+                    missing_files.append(f)
+            if missing_files:
+                raise ValidationError(
+                    _(
+                        "Missing import-chunks named in table-of-contents: {}.".format(
+                            str(missing_files)
+                        )
+                    )
+                )
+
+            errs = []
+            # validate the sha256 of the toc-entries
+            # gather errors for reporting at the end
+            for chunk in sorted(the_toc["files"].keys()):
+                a_hash = _compute_hash(os.path.join(base_dir, chunk))
+                if not a_hash == the_toc["files"][chunk]:
+                    err_str = "File {} expected checksum : {}, computed checksum : {}".format(
+                        chunk, the_toc["files"][chunk], a_hash
+                    )
+                    errs.append(err_str)
+
+            # if there are any errors, report and fail
+            if errs:
+                raise ValidationError(_("Import chunk hash mismatch: {}).").format(str(errs)))
+
+        return the_toc
+
+    def validate_and_assemble(toc_filename):
+        """Validate checksums of, and reassemble, chunks in table-of-contents file."""
+        the_toc = validate_toc(toc_filename)
+        toc_dir = os.path.dirname(toc_filename)
+        result_file = os.path.join(toc_dir, the_toc["meta"]["file"])
+
+        # if we have only one entry in "files", it must be the full .tar.gz - return it
+        if len(the_toc["files"]) == 1:
+            return os.path.join(toc_dir, list(the_toc["files"].keys())[0])
+
+        # We have multiple chunks.
+        # reassemble into one file 'next to' the toc and return the resulting full-path
+        chunk_size = int(the_toc["meta"]["chunk_size"])
+        offset = 0
+        block_size = 1024
+        blocks_per_chunk = int(chunk_size / block_size)
+
+        # sorting-by-filename is REALLY IMPORTANT here
+        # keys are of the form <base-export-name>.00..<base-export-name>.NN,
+        # and must be reassembled IN ORDER
+        the_chunk_files = sorted(the_toc["files"].keys())
+
+        for chunk in the_chunk_files:
+            # For each chunk, add it to the reconstituted tar.gz, picking up where the previous
+            # chunk left off
+            subprocess.run(
+                [
+                    "dd",
+                    "if={}".format(os.path.join(toc_dir, chunk)),
+                    "of={}".format(result_file),
+                    "bs={}".format(str(block_size)),
+                    "seek={}".format(str(offset)),
+                ],
+            )
+            offset += blocks_per_chunk
+            # To keep from taking up All The Disk, we delete each chunk after it has been added
+            # to the recombined file.
+            try:
+                subprocess.run(["rm", "-f", os.path.join(toc_dir, chunk)])
+            except OSError:
+                log.warning(
+                    _("Failed to remove chunk {} after recombining. Continuing.").format(
+                        os.path.join(toc_dir, chunk)
+                    ),
+                    exc_info=True,
+                )
+
+        combined_hash = _compute_hash(result_file)
+        if combined_hash != the_toc["meta"]["global_hash"]:
+            raise ValidationError(
+                _("Mismatch between combined .tar.gz checksum [{}] and originating [{}]).").format(
+                    combined_hash, the_toc["meta"]["global_hash"]
+                )
+            )
+        # if we get this far, then: the chunk-files all existed, they all pass checksum validation,
+        # and there exists a combined .tar.gz, which *also* passes checksum-validation.
+        # Let the rest of the import process do its thing on the new combined-file.
+        return result_file
+
+    if toc:
+        log.info(_("Validating TOC {}.").format(toc))
+        path = validate_and_assemble(toc)
 
     log.info(_("Importing {}.").format(path))
     importer = PulpImporter.objects.get(pk=importer_pk)
@@ -203,7 +333,7 @@ def pulp_import(importer_pk, path):
                 try:
                     dest_repo = destination_repo(src_repo["name"])
                 except Repository.DoesNotExist:
-                    log.warn(
+                    log.warning(
                         _("Could not find destination repo for {}. " "Skipping.").format(
                             src_repo["name"]
                         )

--- a/pulpcore/app/viewsets/importer.py
+++ b/pulpcore/app/viewsets/importer.py
@@ -103,8 +103,8 @@ class PulpImportViewSet(ImportViewSet):
         serializer = PulpImportSerializer(data=request.data, context={"request": request})
         serializer.is_valid(raise_exception=True)
         path = serializer.validated_data.get("path")
-        # resources = [pulp_importer] +
+        toc = serializer.validated_data.get("toc")
         result = enqueue_with_reservation(
-            pulp_import, [importer], kwargs={"importer_pk": importer.pk, "path": path},
+            pulp_import, [importer], kwargs={"importer_pk": importer.pk, "path": path, "toc": toc},
         )
         return OperationPostponedResponse(result, request)


### PR DESCRIPTION
…ts (toc) file.

Emitted 'next to' the export file or files, named <export-file>-toc.json.

Consists of keys "meta" and "files". "files" is a dictionary of export-file/checksums.
"meta" contains the "file", "chunk_size", and "global_hash" of the export.

Added toc= to import. Import will find and validate the checksums of any chunk_files,
reassemble them into a single .tar.gz, and pass that along to the rest of the
import process. Deletes chunks as it goes, to minimize disk-space.

Updated import-export docs to describe TOC file and its use.

closes #6737
