### PR TITLE
Set a default DJANGO_SETTINGS_MODULE env var in content app

### DIFF
--- a/CHANGES/7179.bugfix
+++ b/CHANGES/7179.bugfix
@@ -1,0 +1,1 @@
+Set a default DJANGO_SETTINGS_MODULE env var in content app

--- a/pulpcore/content/__init__.py
+++ b/pulpcore/content/__init__.py
@@ -10,6 +10,7 @@ from aiohttp import web
 
 import django
 
+os.environ.setdefault("DJANGO_SETTINGS_MODULE", "pulpcore.app.settings")
 django.setup()
 
 from django.conf import settings  # noqa: E402: module level not at top of file


### PR DESCRIPTION
This aligns the content service to the WSGI service (API) which already sets a default env var for DJANGO_SETTINGS_MODULE. By providing a default, the systemd service doesn't have to duplicate this and makes configuration easier.

fixes #7179