### PR TITLE
Updates whitenoise dependency to >=5.0.0,<5.3.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -18,4 +18,4 @@ python-gnupg~=0.4.6
 redis>=3.4.0
 rq>=1.1,<1.6
 setuptools>=39.2.0
-whitenoise>=4.1.3,<5.2.0
+whitenoise>=5.0.0,<5.3.0


### PR DESCRIPTION
whitenoise 5.0.0 dropped Python 2 support which is not needed by Pulp. whitenoise 5.2.0 introduces more mime types
and support for a relative static URL which is feature of Django 3.1.

http://whitenoise.evans.io/en/stable/changelog.html#v5-2-0

[noissue]