### PR TITLE
Enable the swaggerui view supported by spectactular

### DIFF
--- a/CHANGES/7271.feature
+++ b/CHANGES/7271.feature
@@ -1,0 +1,1 @@
+Enable swagger-ui drf-spectactular view

--- a/pulpcore/app/urls.py
+++ b/pulpcore/app/urls.py
@@ -7,6 +7,7 @@ from drf_spectacular.views import (
     SpectacularJSONAPIView,
     SpectacularYAMLAPIView,
     SpectacularRedocView,
+    SpectacularSwaggerView,
 )
 from rest_framework import permissions
 from rest_framework.schemas import get_schema_view
@@ -138,6 +139,15 @@ urlpatterns.append(
         name="schema-yaml",
     )
 )
+
+urlpatterns.append(
+    url(
+        r"^{api_root}docs/swaggerui/".format(api_root=API_ROOT),
+        SpectacularSwaggerView.as_view(url_name='schema'),
+        name='schema-swaggerui',
+    )
+)
+
 
 urlpatterns.append(
     url(


### PR DESCRIPTION
Enable the swaggerui view supported by spectactular

Based on example at:
https://drf-spectacular.readthedocs.io/en/latest/readme.html#take-it-for-a-spin

Fixes #7271
https://pulp.plan.io/issues/7271