### PR TITLE
Exclude pulp fields for QueryModelResources

### DIFF
--- a/CHANGES/plugin_api/7277.feature
+++ b/CHANGES/plugin_api/7277.feature
@@ -1,0 +1,2 @@
+Automatically excluding ``pulp_id``, ``pulp_created``, and ``pulp_last_updated`` for
+``QueryModelResources``.

--- a/pulpcore/plugin/importexport.py
+++ b/pulpcore/plugin/importexport.py
@@ -27,6 +27,9 @@ class QueryModelResource(resources.ModelResource):
         if repo_version:
             self.queryset = self.set_up_queryset()
 
+    class Meta:
+        exclude = ("pulp_id", "pulp_created", "pulp_last_updated")
+
 
 class BaseContentResource(QueryModelResource):
     """
@@ -38,14 +41,7 @@ class BaseContentResource(QueryModelResource):
     """
 
     class Meta:
-        exclude = (
-            "_artifacts",
-            "content",
-            "content_ptr",
-            "pulp_id",
-            "pulp_created",
-            "pulp_last_updated",
-        )
+        exclude = QueryModelResource.Meta.exclude + ("_artifacts", "content", "content_ptr")
 
     def dehydrate_upstream_id(self, content):
         return str(content.pulp_id)


### PR DESCRIPTION
This saves plugin writers from having to define exclude on any of
their resources that extend QueryModelResources.

fixes #7277

Please be sure you have read our documentation on creating PRs:
https://docs.pulpproject.org/contributing/pull-request-walkthrough.html
