### PR TITLE
Skip permissions assignment when there is no user

### DIFF
--- a/CHANGES/plugin_api/7312.bugfix
+++ b/CHANGES/plugin_api/7312.bugfix
@@ -1,0 +1,3 @@
+Allow `pulpcore.plugin.models.AutoAddObjPermsMixin.add_for_object_creator` to skip assignment of
+permissions if there is no known user. This allows endpoints that do not use authorization but still
+create objects in the DB to execute without error.

--- a/pulpcore/app/models/access_policy.py
+++ b/pulpcore/app/models/access_policy.py
@@ -19,9 +19,9 @@ class AccessPolicy(BaseModel):
     Fields:
 
         permissions_assignment (JSONField): A list of dictionaries identifying callables on the
-            `pulpcore.plugin.access_policy.AccessPolicyFromDB` which add user or group permissions
+            ``pulpcore.plugin.access_policy.AccessPolicyFromDB`` which add user or group permissions
             for newly created objects.
-        statements (JSONField): A list of `drf-access-policy` statements.
+        statements (JSONField): A list of ``drf-access-policy`` statements.
         viewset_name (models.CharField): The name of the viewset this instance controls
             authorization for.
 
@@ -34,21 +34,22 @@ class AccessPolicy(BaseModel):
 
 class AutoAddObjPermsMixin:
     """
-    A mixin that automatically adds permissions based on the `permissions_assignment` data.
+    A mixin that automatically adds permissions based on the ``permissions_assignment`` data.
 
-    To use this mixin, your model must support `django-lifecycle`.
+    To use this mixin, your model must support ``django-lifecycle``.
 
-    To use this mixin, you must define a class attribute named `ACCESS_POLICY_VIEWSET_NAME`
+    To use this mixin, you must define a class attribute named ``ACCESS_POLICY_VIEWSET_NAME``
     containing the name of the ViewSet associated with this object.
 
-    This mixin adds an `after_create` hook which properly interprets the `permissions_assignment`
-    data and calls methods also provided by this mixin to add permissions.
+    This mixin adds an ``after_create`` hook which properly interprets the
+    ``permissions_assignment`` data and calls methods also provided by this mixin to add
+    permissions.
 
     Three mixing are provided by default:
 
-    * `add_for_object_creator` will add the permissions to the creator of the object.
-    * `add_for_users` will add the permissions for one or more users by name.
-    * `add_for_groups` will add the permissions for one or more groups by name.
+    * ``add_for_object_creator`` will add the permissions to the creator of the object.
+    * ``add_for_users`` will add the permissions for one or more users by name.
+    * ``add_for_groups`` will add the permissions for one or more groups by name.
 
     """
 
@@ -77,6 +78,21 @@ class AutoAddObjPermsMixin:
         return obj
 
     def add_for_users(self, permissions, users):
+        """
+        Adds object-level permissions for one or more users for this newly created object.
+
+        Args:
+            permissions (str or list): One or more object-level permissions to be added for the
+                users. The permission names are in the form of ``<app_name>.<codename>``, e.g.
+                ``"core.change_task"``. This can either be a single permission as a string, or list
+                of permission names.
+            users (str or list): One or more users who will receive object-level permissions. This
+                can either be a single username as a string or a list of usernames.
+
+        Raises:
+            ObjectDoesNotExist: If any of the users do not exist.
+
+        """
         permissions = self._ensure_iterable(permissions)
         users = self._ensure_iterable(users)
         for username in users:
@@ -85,6 +101,21 @@ class AutoAddObjPermsMixin:
                 assign_perm(perm, user, self)
 
     def add_for_groups(self, permissions, groups):
+        """
+        Adds object-level permissions for one or more groups for this newly created object.
+
+        Args:
+            permissions (str or list): One or more object-level permissions to be added for the
+                groups. The permission names are in the form of ``<app_name>.<codename>``, e.g.
+                ``"core.change_task"``. This can either be a single permission as a string, or list
+                of permission names.
+            groups (str or list): One or more groups who will receive object-level permissions. This
+                can either be a single group name as a string or a list of group names.
+
+        Raises:
+            ObjectDoesNotExist: If any of the groups do not exist.
+
+        """
         permissions = self._ensure_iterable(permissions)
         groups = self._ensure_iterable(groups)
         for group_name in groups:
@@ -93,16 +124,33 @@ class AutoAddObjPermsMixin:
                 assign_perm(perm, group, self)
 
     def add_for_object_creator(self, permissions, *args):
+        """
+        Adds object-level permissions for the user creating the newly created object.
+
+        If the ``django_currentuser.middleware.get_current_authenticated_user`` returns None because
+        the API client did not provide authentication credentials, *no* permissions are added and
+        this passes silently. This allows endpoints which create objects and do not require
+        authorization to execute without error.
+
+        Args:
+            permissions (str or list): One or more object-level permissions to be added for the
+                users. The permission names are in the form of ``<app_name>.<codename>``, e.g.
+                ``"core.change_task"``. This can either be a single permission as a string, or list
+                of permission names.
+
+        """
         permissions = self._ensure_iterable(permissions)
         for perm in permissions:
-            assign_perm(perm, get_current_authenticated_user(), self)
+            current_user = get_current_authenticated_user()
+            if current_user:
+                assign_perm(perm, current_user, self)
 
 
 class AutoDeleteObjPermsMixin:
     """
     A mixin that automatically deletes user and group permissions for an object prior to deletion.
 
-    To use this mixin, your model must support `django-lifecycle`.
+    To use this mixin, your model must support ``django-lifecycle``.
     """
 
     @hook("before_delete")


### PR DESCRIPTION
Allow `pulpcore.plugin.models.AutoAddObjPermsMixin.add_for_object_creator`
to skip assignment of permissions if there is no known user. This allows
endpoints that do not use authorization but still create objects in the
DB to execute without error.

closes #7312
