### PR TITLE
Validate unknown fields

### DIFF
--- a/CHANGES/7245.bugfix
+++ b/CHANGES/7245.bugfix
@@ -1,0 +1,1 @@
+Added validation for unknown serializers' fields

--- a/pulpcore/app/serializers/__init__.py
+++ b/pulpcore/app/serializers/__init__.py
@@ -11,6 +11,7 @@ from .base import (  # noqa
     NestedIdentityField,
     NestedRelatedField,
     RelatedField,
+    ValidateFieldsMixin,
     validate_unknown_fields,
 )
 from .fields import (  # noqa

--- a/pulpcore/app/serializers/base.py
+++ b/pulpcore/app/serializers/base.py
@@ -31,7 +31,20 @@ def validate_unknown_fields(initial_data, defined_fields):
         raise serializers.ValidationError(unknown_fields)
 
 
-class ModelSerializer(QueryFieldsMixin, serializers.HyperlinkedModelSerializer):
+class ValidateFieldsMixin:
+    """A mixin for validating unknown serializers' fields."""
+
+    def validate(self, data):
+        if hasattr(self, "initial_data"):
+            validate_unknown_fields(self.initial_data, self.fields)
+
+        data = super().validate(data)
+        return data
+
+
+class ModelSerializer(
+    ValidateFieldsMixin, QueryFieldsMixin, serializers.HyperlinkedModelSerializer
+):
     """Base serializer for use with :class:`pulpcore.app.models.Model`
 
     This ensures that all Serializers provide values for the 'pulp_href` field.
@@ -80,11 +93,6 @@ class ModelSerializer(QueryFieldsMixin, serializers.HyperlinkedModelSerializer):
             )
 
         return path
-
-    def validate(self, data):
-        if hasattr(self, "initial_data"):
-            validate_unknown_fields(self.initial_data, self.fields)
-        return data
 
     def __init_subclass__(cls, **kwargs):
         """Set default attributes in subclasses.

--- a/pulpcore/app/serializers/repository.py
+++ b/pulpcore/app/serializers/repository.py
@@ -14,6 +14,7 @@ from pulpcore.app.serializers import (
     RepositoryVersionIdentityField,
     RepositoryVersionRelatedField,
     RepositoryVersionsIdentityFromRepositoryField,
+    ValidateFieldsMixin,
 )
 
 
@@ -158,7 +159,7 @@ class RemoteSerializer(ModelSerializer):
         )
 
 
-class RepositorySyncURLSerializer(serializers.Serializer):
+class RepositorySyncURLSerializer(ValidateFieldsMixin, serializers.Serializer):
     remote = DetailRelatedField(
         required=False,
         view_name_pattern=r"remotes(-.*/.*)-detail",
@@ -176,6 +177,8 @@ class RepositorySyncURLSerializer(serializers.Serializer):
     )
 
     def validate(self, data):
+        data = super().validate(data)
+
         try:
             remote = models.Repository.objects.get(pk=self.context["repository_pk"]).remote
         except KeyError:

--- a/pulpcore/app/serializers/upload.py
+++ b/pulpcore/app/serializers/upload.py
@@ -4,13 +4,13 @@ from gettext import gettext as _
 from rest_framework import serializers
 
 from pulpcore.app import models
-from pulpcore.app.serializers import base
+from pulpcore.app.serializers import base, ValidateFieldsMixin
 
 
 CONTENT_RANGE_PATTERN = r"^bytes (\d+)-(\d+)/(\d+|[*])$"
 
 
-class UploadChunkSerializer(serializers.Serializer):
+class UploadChunkSerializer(ValidateFieldsMixin, serializers.Serializer):
     file = serializers.FileField(help_text=_("A chunk of the uploaded file."), write_only=True,)
 
     sha256 = serializers.CharField(
@@ -70,5 +70,5 @@ class UploadDetailSerializer(UploadSerializer):
         fields = UploadSerializer.Meta.fields + ("chunks",)
 
 
-class UploadCommitSerializer(serializers.Serializer):
+class UploadCommitSerializer(ValidateFieldsMixin, serializers.Serializer):
     sha256 = serializers.CharField(help_text=_("The expected sha256 checksum for the file."))

--- a/pulpcore/app/serializers/user.py
+++ b/pulpcore/app/serializers/user.py
@@ -6,7 +6,7 @@ from django.urls import reverse
 from guardian.models.models import GroupObjectPermission
 from rest_framework import serializers
 
-from pulpcore.app.serializers import IdentityField
+from pulpcore.app.serializers import IdentityField, ValidateFieldsMixin
 from pulpcore.app.util import get_viewset_for_model
 
 
@@ -108,7 +108,7 @@ class UserSerializer(serializers.ModelSerializer):
         )
 
 
-class GroupUserSerializer(serializers.ModelSerializer):
+class GroupUserSerializer(ValidateFieldsMixin, serializers.ModelSerializer):
     """Serializer for Users that belong to a Group."""
 
     username = serializers.CharField(
@@ -122,7 +122,7 @@ class GroupUserSerializer(serializers.ModelSerializer):
         fields = ("username", "pulp_href")
 
 
-class GroupSerializer(serializers.ModelSerializer):
+class GroupSerializer(ValidateFieldsMixin, serializers.ModelSerializer):
     """Serializer for Group."""
 
     pulp_href = IdentityField(view_name="groups-detail")

--- a/pulpcore/plugin/serializers/__init__.py
+++ b/pulpcore/plugin/serializers/__init__.py
@@ -26,6 +26,7 @@ from pulpcore.app.serializers import (  # noqa
     RepositoryVersionDistributionSerializer,
     SingleArtifactContentSerializer,
     SingleContentArtifactField,
+    ValidateFieldsMixin,
     validate_unknown_fields,
 )
 


### PR DESCRIPTION
All serializers which inherit from the base DRF serializer and are used in a ViewSet should now validate unknown query parameters.

closes #7245
