### PR TITLE
Upgrade dynaconf

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -14,7 +14,7 @@ djangorestframework-queryfields~=1.0.0
 drf-access-policy~=0.7.0
 drf-nested-routers~=0.91.0
 drf-spectacular>=0.9.12
-dynaconf>=2.2,<4.0
+dynaconf>=3.0,<4.0
 gunicorn>=19.9,<20.1
 jinja2
 pygtrie~=2.3.3


### PR DESCRIPTION
Fix installer CI issue.

[dynaconf 2.22](https://github.com/rochacbruno/dynaconf/blob/2.2.2/setup.py#L50) is conflicting with [black](https://github.com/psf/black/blob/master/setup.py#L73)

Ref: https://pulp.plan.io/issues/7479