### PR TITLE
When export creates a dir, make sure the group can write to it.

### DIFF
--- a/CHANGES/7459.bugfix
+++ b/CHANGES/7459.bugfix
@@ -1,0 +1,1 @@
+Taught export to insure export-dir was writeable by group as well as owner.

--- a/pulpcore/app/tasks/export.py
+++ b/pulpcore/app/tasks/export.py
@@ -166,7 +166,9 @@ def pulp_export(the_export):
         the_export.task = Task.current()
 
         tarfile_fp = the_export.export_tarfile_path()
+
         os.makedirs(pulp_exporter.path, exist_ok=True)
+        os.chmod(pulp_exporter.path, 0o775)  # let owner and group read and write the directory
 
         rslts = {}
         if the_export.validated_chunk_size:


### PR DESCRIPTION
closes #7459

