### PR TITLE
Fix duplicate key error after incomplete sync task

### DIFF
--- a/CHANGES/6463.bugfix
+++ b/CHANGES/6463.bugfix
@@ -1,0 +1,1 @@
+Fixed a bug where creating an incomplete repository version (via canceled or failed task) could cause future operations to fail.

--- a/pulpcore/app/models/repository.py
+++ b/pulpcore/app/models/repository.py
@@ -94,6 +94,10 @@ class Repository(MasterModel):
             pulpcore.app.models.RepositoryVersion: The Created RepositoryVersion
         """
         with transaction.atomic():
+            latest_version = self.versions.latest()
+            if not latest_version.complete:
+                latest_version.delete()
+
             version = RepositoryVersion(
                 repository=self, number=int(self.next_version), base_version=base_version
             )
@@ -108,6 +112,7 @@ class Repository(MasterModel):
             if Task.current():
                 resource = CreatedResource(content_object=version)
                 resource.save()
+
             return version
 
     def finalize_new_version(self, new_version):


### PR DESCRIPTION
closes: #6463
https://pulp.plan.io/issues/6463