### PR TITLE
Pin drf-spectular to 0.9.13 and add changelog

### DIFF
--- a/CHANGES/7510.bugfix
+++ b/CHANGES/7510.bugfix
@@ -1,0 +1,1 @@
+Fixed broken bindings resulting from drf-spectacular 0.9.13 release.

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,7 +13,7 @@ djangorestframework~=3.10.3
 djangorestframework-queryfields~=1.0.0
 drf-access-policy~=0.7.0
 drf-nested-routers~=0.91.0
-drf-spectacular>=0.9.12
+drf-spectacular==0.9.13
 dynaconf>=3.0,<4.0
 gunicorn>=19.9,<20.1
 jinja2


### PR DESCRIPTION
First, pin drf-spectacular to 0.9.13 since our code no longer works
against 0.9.12.

Secondly, add a changelog entry to call out that we've fixed the
schema/bindings.

Please be sure you have read our documentation on creating PRs:
https://docs.pulpproject.org/contributing/pull-request-walkthrough.html
