### PR TITLE
Adds docs on reverse proxy url customization

### DIFF
--- a/CHANGES/plugin_api/7471.doc
+++ b/CHANGES/plugin_api/7471.doc
@@ -1,0 +1,2 @@
+Adds plugin writer docs on how to ship snippets which override default webserver routes provided by
+the installer.


### PR DESCRIPTION
The snippets feature of plugins can be used to customize the behavior of
the reverse proxy by including "more specific" routes that take
precedence over less-specific routes the installer provides.

closes #7471

