### PR TITLE
Get rid of failure message on task cancellation

### DIFF
--- a/CHANGES/4559.bugfix
+++ b/CHANGES/4559.bugfix
@@ -1,0 +1,1 @@
+Fix a warning inappropriately logged when cancelling a task.


### PR DESCRIPTION
_release_resources() task checks whether task status is still set to
"running". In the case of cancelation, that is still true if the
transaction hasn't been committed yet.

closes: #4559
https://pulp.plan.io/issues/4559