### PR TITLE
Handles duplicate content in the stages API.

### DIFF
--- a/CHANGES/7147.bugfix
+++ b/CHANGES/7147.bugfix
@@ -1,0 +1,1 @@
+Properly handle duplicate content during synchronization and migration from Pulp 2 to 3.

--- a/pulpcore/plugin/stages/artifact_stages.py
+++ b/pulpcore/plugin/stages/artifact_stages.py
@@ -258,6 +258,11 @@ class RemoteArtifactSaver(Stage):
         """
         remotes_present = set()
         for d_content in batch:
+            # If the attribute is set in a previous batch on the very first item in this batch, the
+            # rest of the items in this batch will not get the attribute set during prefetch.
+            # https://code.djangoproject.com/ticket/32089
+            if hasattr(d_content.content, "_remote_artifact_saver_cas"):
+                delattr(d_content.content, "_remote_artifact_saver_cas")
             for d_artifact in d_content.d_artifacts:
                 if d_artifact.remote:
                     remotes_present.add(d_artifact.remote)


### PR DESCRIPTION
If the very first Content in a batch has already been prefetched in a previous call to prefetch_related_objects,
Django does not set the attribute specified in 'to_attr' when prefetching the rest of the items in the batch. As
a result, the '_remote_artifact_saver_cas' attribute is not set on the Content instances and AttributeError is
raised when '_remote_artifact_saver_cas' is accessed by the RemoteArtifactSaverStage.

This patch removes any existing '_remote_artifact_saver_cas' attributes on Content before calling into Django's
prefetch_related_objects().

fixes: #7147
https://pulp.plan.io/issues/7147
