### PR TITLE
Expose pulpcore_version to plugin writers

### DIFF
--- a/CHANGES/plugin_api/7624.feature
+++ b/CHANGES/plugin_api/7624.feature
@@ -1,0 +1,1 @@
+Added a constant holding the pulpcore version which can be imported by plugins - `pulpcore.plugin.pulpcore_version`.

--- a/pulpcore/plugin/__init__.py
+++ b/pulpcore/plugin/__init__.py
@@ -1,2 +1,5 @@
 # plugins declare that they are a pulp plugin by subclassing PulpPluginAppConfig
 from pulpcore.app.apps import PulpPluginAppConfig  # noqa
+
+# allow plugins to access the pulpcore version
+from pulpcore import __version__ as pulpcore_version  # noqa


### PR DESCRIPTION
Give plugin writers a way to access the pulpcore version.
This is possiblyuseful in case they want to support more than one
version of the plugin API at the same time.

[noissue]