### PR TITLE
Rest framework template

### DIFF
--- a/CHANGES/7634.bugfix
+++ b/CHANGES/7634.bugfix
@@ -1,0 +1,1 @@
+Change dropped DRF filter to django urlize.

--- a/pulpcore/app/templates/rest_framework/api.html
+++ b/pulpcore/app/templates/rest_framework/api.html
@@ -173,9 +173,9 @@
 
               <div class="response-info" aria-label="{% trans "response info" %}">
                 <pre class="prettyprint"><span class="meta nocode"><b>HTTP {{ response.status_code }} {{ response.status_text }}</b>{% autoescape off %}{% for key, val in response_headers|items %}
-<b>{{ key }}:</b> <span class="lit">{{ val|break_long_headers|urlize_quoted_links|urlize_quoted_hrefs }}</span>{% endfor %}
+<b>{{ key }}:</b> <span class="lit">{{ val|break_long_headers|urlize|urlize_quoted_hrefs }}</span>{% endfor %}
 
-</span>{{ content|urlize_quoted_links|urlize_quoted_hrefs }}</pre>{% endautoescape %}
+</span>{{ content|urlize|urlize_quoted_hrefs }}</pre>{% endautoescape %}
               </div>
             </div>
 


### PR DESCRIPTION
Change dropped DRF filter to django urlize.

closes: #7634
https://pulp.plan.io/issues/7634
