### PR TITLE
Update dynaconf dependency

### DIFF
--- a/CHANGES/7682.bugfix
+++ b/CHANGES/7682.bugfix
@@ -1,0 +1,1 @@
+Updated dynaconf requirement to prevent use of older buggy versions.

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,7 +14,7 @@ djangorestframework-queryfields~=1.0.0
 drf-access-policy~=0.8.0
 drf-nested-routers~=0.91.0
 drf-spectacular==0.9.14
-dynaconf>=3.0,<4.0
+dynaconf~=3.1.2
 gunicorn>=19.9,<20.1
 jinja2
 pygtrie~=2.3.3


### PR DESCRIPTION
I've had to debug a few bugs in dynaconf that were caused by older
versions of dynaconf:

https://github.com/rochacbruno/dynaconf/issues/443
https://github.com/rochacbruno/dynaconf/issues/391

Update the dynaconf requirement to prevent users from using older
versions that cause bugs.

Please be sure you have read our documentation on creating PRs:
https://docs.pulpproject.org/contributing/pull-request-walkthrough.html
