### PR TITLE
Always set a default for DJANGO_SETTINGS_MODULE

### DIFF
--- a/CHANGES/7720.feature
+++ b/CHANGES/7720.feature
@@ -1,0 +1,1 @@
+Always set a default for DJANGO_SETTINGS_MODULE. This means the services files don't need to.

--- a/pulpcore/content/handler.py
+++ b/pulpcore/content/handler.py
@@ -10,6 +10,7 @@ from aiohttp.web_exceptions import HTTPForbidden, HTTPFound, HTTPNotFound
 
 import django
 
+os.environ.setdefault("DJANGO_SETTINGS_MODULE", "pulpcore.app.settings")
 django.setup()
 
 from django.conf import settings  # noqa: E402: module level not at top of file

--- a/pulpcore/tasking/worker.py
+++ b/pulpcore/tasking/worker.py
@@ -14,6 +14,7 @@ from rq.worker import Worker
 
 import django
 
+os.environ.setdefault("DJANGO_SETTINGS_MODULE", "pulpcore.app.settings")
 django.setup()
 
 from guardian.shortcuts import get_users_with_perms  # noqa: E402: module level not at top of file


### PR DESCRIPTION
6a2e7f304c31adcbf12d964753f639c5e3ea4cce already set this in one place for the handler, but this does it everywhere before calling django.setup. This means the services files don't need to.