### PR TITLE
Expose ProgressReportSerializer on pulpcore.plugin

### DIFF
--- a/CHANGES/plugin_api/7759.feature
+++ b/CHANGES/plugin_api/7759.feature
@@ -1,0 +1,1 @@
+Expose ProgressReportSerializer through `pulpcore.plugin`

--- a/pulpcore/plugin/serializers/__init__.py
+++ b/pulpcore/plugin/serializers/__init__.py
@@ -16,6 +16,7 @@ from pulpcore.app.serializers import (  # noqa
     MultipleArtifactContentSerializer,
     NestedRelatedField,
     NoArtifactContentSerializer,
+    ProgressReportSerializer,
     PublicationDistributionSerializer,
     PublicationExportSerializer,
     PublicationSerializer,


### PR DESCRIPTION
Currently it is only possible to import  `ProgressReportSerializer` through
`pulpcore.app.serializers` and it is useful to have it on
`pulpcore.plugin.serializers`

Related PR: https://github.com/ansible/galaxy_ng/pull/526

closes #7759
