### PR TITLE
Pin some requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
-aiohttp
-aiodns
-aiofiles
-backoff
+aiohttp~=3.7.1
+aiodns~=2.0.0
+aiofiles==0.5.0
+backoff~=1.10.0
 Django~=2.2.16  # LTS version, switch only if we have a compelling reason to
 django-currentuser~=0.5.1
 django-cleanup~=5.1.0


### PR DESCRIPTION
Today I spent some time debugging a strange sync issue. Turns out it was [a bug in aiohttp 3.7.0](https://github.com/aio-libs/aiohttp/issues/5110). We should set stricter requirements to avoid this situation in the future.

[noissue]

Please be sure you have read our documentation on creating PRs:
https://docs.pulpproject.org/contributing/pull-request-walkthrough.html
