### PR TITLE
Fix duplicate key error after incomplete sync task

### DIFF
--- a/CHANGES/7737.bugfix
+++ b/CHANGES/7737.bugfix
@@ -1,0 +1,1 @@
+Fixed a bug where creating an incomplete repository version (via canceled or failed task) could cause future operations to fail. (Backported from https://pulp.plan.io/issues/6463)

--- a/pulpcore/app/models/repository.py
+++ b/pulpcore/app/models/repository.py
@@ -94,6 +94,10 @@ class Repository(MasterModel):
             pulpcore.app.models.RepositoryVersion: The Created RepositoryVersion
         """
         with transaction.atomic():
+            latest_version = self.versions.latest()
+            if not latest_version.complete:
+                latest_version.delete()
+
             version = RepositoryVersion(
                 repository=self, number=int(self.next_version), base_version=base_version
             )
@@ -108,6 +112,7 @@ class Repository(MasterModel):
             if Task.current():
                 resource = CreatedResource(content_object=version)
                 resource.save()
+
             return version
 
     def finalize_new_version(self, new_version):


### PR DESCRIPTION
fixes #7737
https://pulp.plan.io/issues/7737
backports #6463
https://pulp.plan.io/issues/6463
(cherry picked from commit 1851b70ec76d39ac8a05fa2dbbd96d0fc157253a)
