### PR TITLE
update drf-nested-routers-pin

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -11,7 +11,7 @@ django-lifecycle~=0.8.0
 djangorestframework~=3.12.1
 djangorestframework-queryfields~=1.0.0
 drf-access-policy~=0.8.1
-drf-nested-routers==0.92.0
+drf-nested-routers==0.92.1
 drf-spectacular==0.9.14
 dynaconf~=3.1.2
 gunicorn>=19.9,<20.1


### PR DESCRIPTION
0.92 has a broken source release on pypi, and 0.92.1 fixes that.
there are no other changes besides the version bump:
  https://github.com/alanjds/drf-nested-routers/compare/v0.92.0...v0.92.1

[noissue]
