### PR TITLE
Removes use of django.conf.settings from orphan cleanup tests

### DIFF
--- a/functest_requirements.txt
+++ b/functest_requirements.txt
@@ -1,6 +1,6 @@
 django
 dynaconf
-pulp-smash
+pulp-smash>=1!0.12.0
 pulpcore-client
 pulp-file-client
 pytest


### PR DESCRIPTION
re: #7690
https://pulp.plan.io/issues/7690