### PR TITLE
Minor resync perf improvement

### DIFF
--- a/pulpcore/plugin/stages/artifact_stages.py
+++ b/pulpcore/plugin/stages/artifact_stages.py
@@ -263,6 +263,7 @@ class RemoteArtifactSaver(Stage):
             # https://code.djangoproject.com/ticket/32089
             if hasattr(d_content.content, "_remote_artifact_saver_cas"):
                 delattr(d_content.content, "_remote_artifact_saver_cas")
+
             for d_artifact in d_content.d_artifacts:
                 if d_artifact.remote:
                     remotes_present.add(d_artifact.remote)


### PR DESCRIPTION
10% of resync time (file plugin) was spent inside these tight loops that we can replace with cheaper dictionary lookups.  No queries changed.

Time spent inside Python code of the QueryExistingContent stage (excluding function calls) drops from 11.4% to 0.4%

[noissue]
