### PR TITLE
Adding check that exporter path exists

### DIFF
--- a/CHANGES/7829.bugfix
+++ b/CHANGES/7829.bugfix
@@ -1,0 +1,2 @@
+Fixed bug where exporter directory existed and was writable but not owned by worker process and thus
+not chmod-able.

--- a/pulpcore/app/tasks/export.py
+++ b/pulpcore/app/tasks/export.py
@@ -168,8 +168,9 @@ def pulp_export(the_export):
 
         tarfile_fp = the_export.export_tarfile_path()
 
-        os.makedirs(pulp_exporter.path, exist_ok=True)
-        os.chmod(pulp_exporter.path, 0o775)  # let owner and group read and write the directory
+        path = Path(pulp_exporter.path)
+        if not path.is_dir():
+            path.mkdir(mode=0o775, parents=True)
 
         rslts = {}
         if the_export.validated_chunk_size:


### PR DESCRIPTION
Adding check that exporter path exists before trying to create and modify it.

fixes #7829

Please be sure you have read our documentation on creating PRs:
https://docs.pulpproject.org/contributing/pull-request-walkthrough.html
