### PR TITLE
Fix jquery version for API html rendering

### DIFF
--- a/CHANGES/7850.bugfix
+++ b/CHANGES/7850.bugfix
@@ -1,0 +1,1 @@
+Update jquery version from 3.3.1 to 3.5.1 in API.html template. It is the version provided by djangorestframework~=3.12.2 

--- a/pulpcore/app/templates/rest_framework/api.html
+++ b/pulpcore/app/templates/rest_framework/api.html
@@ -290,7 +290,7 @@
           csrfCookieName: "{{ csrf_cookie_name|default:'csrftoken' }}"
         };
       </script>
-      <script src="{% static "rest_framework/js/jquery-3.3.1.min.js" %}"></script>
+      <script src="{% static "rest_framework/js/jquery-3.5.1.min.js" %}"></script>
       <script src="{% static "rest_framework/js/ajax-form.js" %}"></script>
       <script src="{% static "rest_framework/js/csrf.js" %}"></script>
       <script src="{% static "rest_framework/js/bootstrap.min.js" %}"></script>


### PR DESCRIPTION
As of 3.12.2 version of django-rest-framework the embeded
jquery version is now 3.5.1 (vs 3.3.1)

Please be sure you have read our documentation on creating PRs:
https://docs.pulpproject.org/contributing/pull-request-walkthrough.html
