### PR TITLE
Add asciinema terminal params

### DIFF
--- a/docs/contributing/record-a-demo.rst
+++ b/docs/contributing/record-a-demo.rst
@@ -9,7 +9,11 @@ While demos with audio are more than welcome, audio is not required.
 
 If your demo involves only a terminal recording, feel free to use a tool such as `asciinema <https://asciinema.org/>`_.
 
+If you use `asciinema <https://asciinema.org/>`_, adjust your terminal window to 90x45 characters to maintain the consistency of each of the demos.
+
 You can also use `Saftladen <https://github.com/mdellweg/saftladen>`_ - a bundle of scripts to generate asciinema demos for Pulp topics without live user interaction.
 
 If you think that your change is not substantive enough to require a demo, mention that in the body of the pull request.
 However, those reviewing the pull request might ask you to record a demo if they think it would help the wider community understand the change.
+
+Please tag `@melcorr <https://github.com/melcorr>`_ in the body of your pull request to alert her to add your new demo to the list of demos. 


### PR DESCRIPTION
* Update record-a-demo file

[noissue]

We discussed this in a team meeting on Nov 16th and agreed it would be good to restrict the terminal size so we don't have embedded videos of various shapes and sizes on the demo page of the website. 

Should I also add a line to tag me, or send the video to me, so I can add it to the site? 