### PR TITLE
Simplify DATABASE engine name

### DIFF
--- a/pulpcore/app/settings.py
+++ b/pulpcore/app/settings.py
@@ -175,7 +175,7 @@ USE_TZ = True
 # https://docs.djangoproject.com/en/1.11/ref/settings/#databases
 DATABASES = {
     "default": {
-        "ENGINE": "django.db.backends.postgresql_psycopg2",
+        "ENGINE": "django.db.backends.postgresql",
         "NAME": "pulp",
         "USER": "pulp",
         "CONN_MAX_AGE": 0,


### PR DESCRIPTION
As of Django 1.9 there is no need to add the _pycopg2 postfix as the
backend was renamed.

See: https://docs.djangoproject.com/en/3.1/releases/1.9/

[noissue]

Please be sure you have read our documentation on creating PRs:
https://docs.pulpproject.org/contributing/pull-request-walkthrough.html
