### PR TITLE
Expose the ALL_KNOWN_CONTENT_CHECKSUMS constant in the plugin api

### DIFF
--- a/CHANGES/plugin_api/7897.feature
+++ b/CHANGES/plugin_api/7897.feature
@@ -1,0 +1,1 @@
+Exposed ``pulpcore.plugin.constants.ALL_KNOWN_CONTENT_CHECKSUMS``.

--- a/pulpcore/plugin/constants.py
+++ b/pulpcore/plugin/constants.py
@@ -1,4 +1,5 @@
 from pulpcore.constants import (  # noqa
+    ALL_KNOWN_CONTENT_CHECKSUMS,
     API_ROOT,
     SYNC_MODES,
     SYNC_CHOICES,


### PR DESCRIPTION
fixes #7897

Please be sure you have read our documentation on creating PRs:
https://docs.pulpproject.org/contributing/pull-request-walkthrough.html
