### PR TITLE
Use subclaassed plugin downloaders during the pulp repair.

### DIFF
--- a/CHANGES/7909.bugfix
+++ b/CHANGES/7909.bugfix
@@ -1,0 +1,1 @@
+Use subclassed plugin downloaders during the pulp repair.

--- a/pulpcore/app/tasks/repository.py
+++ b/pulpcore/app/tasks/repository.py
@@ -59,7 +59,7 @@ async def _repair_ca(content_artifact, repaired=None):
         return False
 
     for remote_artifact in remote_artifacts:
-        downloader = remote_artifact.remote.get_downloader(remote_artifact)
+        downloader = remote_artifact.remote.cast().get_downloader(remote_artifact)
         dl_result = await downloader.run()
         if dl_result.artifact_attributes["sha256"] == content_artifact.artifact.sha256:
             with open(dl_result.path, "rb") as src:


### PR DESCRIPTION
closes #7909
https://pulp.plan.io/issues/7909

Please be sure you have read our documentation on creating PRs:
https://docs.pulpproject.org/contributing/pull-request-walkthrough.html
