### PR TITLE
Adds additional lock cleanup to worker cleanup

### DIFF
--- a/CHANGES/7907.bugfix
+++ b/CHANGES/7907.bugfix
@@ -1,0 +1,2 @@
+Prevented a Redis failure scenario from causing the tasking system to back up due to "tasking system
+locks" not being released, even on worker restart.


### PR DESCRIPTION
As another layer of security to guard against lock cleanup not occuring
due to Redis not delivering the _release_resource task, ensure all locks
are also cleaned up even for tasks that are in their final states.

closes #7907

