### PR TITLE
Make DistributionFilter accessible via the plugin API

### DIFF
--- a/CHANGES/plugin_api/8059.feature
+++ b/CHANGES/plugin_api/8059.feature
@@ -1,0 +1,1 @@
+Made DistributionFilter accessible to plugin writers.

--- a/pulpcore/app/viewsets/__init__.py
+++ b/pulpcore/app/viewsets/__init__.py
@@ -37,6 +37,7 @@ from .publication import (  # noqa
     BaseDistributionViewSet,
     ContentGuardFilter,
     ContentGuardViewSet,
+    DistributionFilter,
     PublicationFilter,
     PublicationViewSet,
 )

--- a/pulpcore/plugin/viewsets/__init__.py
+++ b/pulpcore/plugin/viewsets/__init__.py
@@ -9,6 +9,7 @@ from pulpcore.app.viewsets import (  # noqa
     ContentGuardFilter,
     ContentGuardViewSet,
     ContentViewSet,
+    DistributionFilter,
     ExportViewSet,
     ExporterViewSet,
     ImmutableRepositoryViewSet,


### PR DESCRIPTION
closes #8059
