### PR TITLE
Fix regression with CHUNKED_UPLOAD_DIR outside MEDIA_ROOT

### DIFF
--- a/CHANGES/8099.bugfix
+++ b/CHANGES/8099.bugfix
@@ -1,0 +1,12 @@
+Fix a regression where `CHUNKED_UPLOAD_DIR` was not allowed to be outside of `MEDIA_ROOT`.
+
+In Django, any file that's uploaded outside a `FileSystemStorage` (which `MEDIA_ROOT` is)`, is a
+`SuspicuousOperation`. It generally indicates an attempt to write outside of a designated area which
+is a common attack vector.
+
+In the default Pulp deployment, `MEDIA_ROOT` is `/var/lib/pulp` and `CHUNKED_UPLOAD_DIR` is
+`/var/lib/pulp/tmp`.
+
+As part of #4498, uploads are done to an absolute path rather than use a FileSystemStorage for this.
+In deployments where `MEDIA_ROOT` is different (such as `/var/lib/pulp/media`, it suddenly becomes a
+problem.

--- a/pulpcore/app/models/storage.py
+++ b/pulpcore/app/models/storage.py
@@ -7,6 +7,9 @@ from django.core.files.move import file_move_safe
 from django.core.files.storage import FileSystemStorage
 
 
+CHUNKED_UPLOAD_STORAGE = FileSystemStorage(location=settings.CHUNKED_UPLOAD_DIR)
+
+
 class FileSystem(FileSystemStorage):
     """
     Django's FileSystemStorage with modified _save() and get_available_name behaviors
@@ -123,19 +126,6 @@ def get_temp_file_path(pulp_id):
     """
     pulp_id_str = str(pulp_id)
     return os.path.join("tmp/files", pulp_id_str[:2], pulp_id_str[2:])
-
-
-def get_upload_chunk_file_path(pulp_id):
-    """
-    Determine the absolute path where a file backing an uploaded chunk should be stored.
-
-    Args:
-        pulp_id (uuid): An identifier identifying the file for UploadChunk
-    Returns:
-        A string representing the absolute path where a file backing UploadChunk should be
-        stored
-    """
-    return os.path.join(settings.CHUNKED_UPLOAD_DIR, str(pulp_id))
 
 
 def get_tls_path(model, name):

--- a/pulpcore/app/models/upload.py
+++ b/pulpcore/app/models/upload.py
@@ -56,9 +56,11 @@ class UploadChunk(HandleTempFilesMixin, BaseModel):
             name (str): Original name of uploaded file. It is ignored by this method because the
                 pulp_id is used to determine a file path instead.
         """
-        return storage.get_upload_chunk_file_path(self.pulp_id)
+        return str(self.pulp_id)
 
-    file = fields.FileField(null=False, upload_to=storage_path, max_length=255)
+    file = fields.FileField(
+        null=False, storage=storage.CHUNKED_UPLOAD_STORAGE, upload_to=storage_path, max_length=255
+    )
     upload = models.ForeignKey(Upload, on_delete=models.CASCADE, related_name="chunks")
     offset = models.BigIntegerField()
     size = models.BigIntegerField()


### PR DESCRIPTION
In Django, any file that's uploaded outside a `FileSystemStorage` (which `MEDIA_ROOT` is)`, is a `SuspicuousOperation`. It generally indicates an attempt to write outside of a designated area which is a common attack vector.

In the default Pulp deployment, `MEDIA_ROOT` is `/var/lib/pulp` and `CHUNKED_UPLOAD_DIR` is `/var/lib/pulp/tmp`.

As part of #4498 (1b6c7360c30cc7d9e2d3b9fc5062ac1f7d69c2de), uploads are done to an absolute path rather than use a FileSystemStorage for this.  In deployments where `MEDIA_ROOT` is different (such as `/var/lib/pulp/media`, it suddenly becomes a problem.

Fixes #8099