### PR TITLE
Avoid circular import when getting User

### DIFF
--- a/pulpcore/app/models/access_policy.py
+++ b/pulpcore/app/models/access_policy.py
@@ -13,9 +13,6 @@ from guardian.shortcuts import assign_perm
 from pulpcore.app.models import BaseModel
 
 
-User = get_user_model()
-
-
 class AccessPolicy(BaseModel):
     """
     A model storing a viewset authorization policy and permission assignment of new objects created.
@@ -101,7 +98,7 @@ class AutoAddObjPermsMixin:
         permissions = self._ensure_iterable(permissions)
         users = self._ensure_iterable(users)
         for username in users:
-            user = User.objects.get(username=username)
+            user = get_user_model().objects.get(username=username)
             for perm in permissions:
                 assign_perm(perm, user, self)
 


### PR DESCRIPTION
When using Galaxy:
```
"/home/vagrant/devel/pulpcore/pulpcore/app/apps.py:72: FutureWarning: The plugin `galaxy` is missing a version attribute. Starting with pulpcore==3.10, 
plugins are required to define their version on the PulpPluginAppConfig subclass.
  warnings.warn(msg, FutureWarning)
Traceback (most recent call last):
  File \"/usr/local/lib/pulp/bin/pulpcore-manager\", line 33, in <module>
    sys.exit(load_entry_point('pulpcore', 'console_scripts', 'pulpcore-manager')())
  File \"/home/vagrant/devel/pulpcore/pulpcore/app/manage.py\", line 11, in manage
    execute_from_command_line(sys.argv)
  File \"/usr/local/lib/pulp/lib64/python3.9/site-packages/django/core/management/__init__.py\", line 381, in execute_from_command_line
    utility.execute()
  File \"/usr/local/lib/pulp/lib64/python3.9/site-packages/django/core/management/__init__.py\", line 357, in execute
    django.setup()
  File \"/usr/local/lib/pulp/lib64/python3.9/site-packages/django/__init__.py\", line 24, in setup
    apps.populate(settings.INSTALLED_APPS)
  File \"/usr/local/lib/pulp/lib64/python3.9/site-packages/django/apps/registry.py\", line 114, in populate
    app_config.import_models()
  File \"/usr/local/lib/pulp/lib64/python3.9/site-packages/django/apps/config.py\", line 211, in import_models
    self.models_module = import_module(models_module_name)
  File \"/usr/lib64/python3.9/importlib/__init__.py\", line 127, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
  File \"<frozen importlib._bootstrap>\", line 1030, in _gcd_import
  File \"<frozen importlib._bootstrap>\", line 1007, in _find_and_load
  File \"<frozen importlib._bootstrap>\", line 986, in _find_and_load_unlocked
  File \"<frozen importlib._bootstrap>\", line 680, in _load_unlocked
  File \"<frozen importlib._bootstrap_external>\", line 790, in exec_module
  File \"<frozen importlib._bootstrap>\", line 228, in _call_with_frames_removed
  File \"/home/vagrant/devel/pulpcore/pulpcore/app/models/__init__.py\", line 7, in <module>
    from .access_policy import AccessPolicy, AutoAddObjPermsMixin, AutoDeleteObjPermsMixin  # noqa
  File \"/home/vagrant/devel/pulpcore/pulpcore/app/models/access_policy.py\", line 16, in <module>
    User = get_user_model()
  File \"/usr/local/lib/pulp/lib64/python3.9/site-packages/django/contrib/auth/__init__.py\", line 165, in get_user_model
    return django_apps.get_model(settings.AUTH_USER_MODEL, require_ready=False)
  File \"/usr/local/lib/pulp/lib64/python3.9/site-packages/django/apps/registry.py\", line 208, in get_model
    app_config.import_models()
  File \"/usr/local/lib/pulp/lib64/python3.9/site-packages/django/apps/config.py\", line 211, in import_models
    self.models_module = import_module(models_module_name)
  File \"/usr/lib64/python3.9/importlib/__init__.py\", line 127, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
  File \"/home/vagrant/devel/galaxy_ng/galaxy_ng/app/models/__init__.py\", line 5, in <module>
    from .collectionimport import (
      File \"/home/vagrant/devel/galaxy_ng/galaxy_ng/app/models/collectionimport.py\", line 5, in <module>
    from pulpcore.plugin.models import (
      File \"/home/vagrant/devel/pulpcore/pulpcore/plugin/models/__init__.py\", line 7, in <module>
    from pulpcore.app.models import (  # noqa
ImportError: cannot import name 'AccessPolicy' from partially initialized module 'pulpcore.app.models' (most likely due to a circular import) 
(/home/vagrant/devel/pulpcore/pulpcore/app/models/__init__.py)
```


Please be sure you have read our documentation on creating PRs:
https://docs.pulpproject.org/contributing/pull-request-walkthrough.html
