### PR TITLE
Fix the default value of CHUNKED_UPLOAD_DIR

### DIFF
--- a/CHANGES/8099.removal
+++ b/CHANGES/8099.removal
@@ -1,0 +1,1 @@
+CHUNKED_UPLOAD_DIR was converted to a relative path inside MEDIA_ROOT.

--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -152,9 +152,11 @@ WORKING_DIRECTORY
 CHUNKED_UPLOAD_DIR
 ^^^^^^^^^^^^^^^^^^
 
-   A directory used exclusively for uploaded chunks. The uploaded chunks are stored in the default
-   storage specified by ``DEFAULT_FILE_STORAGE``. This option allows users to customize the actual
-   place where chunked uploads should be stored within the declared storage.
+   A relative path inside the MEDIA_ROOT directory used exclusively for uploaded chunks. The
+   uploaded chunks are stored in the default storage specified by ``DEFAULT_FILE_STORAGE``. This
+   option allows users to customize the actual place where chunked uploads should be stored within
+   the declared storage. The default, ``upload``, is sufficient for most use cases. A change to
+   this setting only applies to uploads created after the change.
 
 CONTENT_ORIGIN
 ^^^^^^^^^^^^^^

--- a/pulpcore/app/models/storage.py
+++ b/pulpcore/app/models/storage.py
@@ -127,12 +127,12 @@ def get_temp_file_path(pulp_id):
 
 def get_upload_chunk_file_path(pulp_id):
     """
-    Determine the absolute path where a file backing an uploaded chunk should be stored.
+    Determine the relative path where a file backing an uploaded chunk should be stored.
 
     Args:
         pulp_id (uuid): An identifier identifying the file for UploadChunk
     Returns:
-        A string representing the absolute path where a file backing UploadChunk should be
+        A string representing the relative path where a file backing UploadChunk should be
         stored
     """
     return os.path.join(settings.CHUNKED_UPLOAD_DIR, str(pulp_id))

--- a/pulpcore/app/settings.py
+++ b/pulpcore/app/settings.py
@@ -46,7 +46,7 @@ DEFAULT_FILE_STORAGE = "pulpcore.app.models.storage.FileSystem"
 
 FILE_UPLOAD_TEMP_DIR = os.path.join(MEDIA_ROOT, "tmp/")
 WORKING_DIRECTORY = os.path.join(MEDIA_ROOT, "tmp/")
-CHUNKED_UPLOAD_DIR = os.path.join(MEDIA_ROOT, "upload/")
+CHUNKED_UPLOAD_DIR = "upload"
 
 # List of upload handler classes to be applied in order.
 FILE_UPLOAD_HANDLERS = ("pulpcore.app.files.HashingFileUploadHandler",)


### PR DESCRIPTION
This patch changes the default value of CHUNKED_UPLOAD_DIR to `upload`.
This value is a relative path inside the MEDIA_ROOT. Doc strings have
also been updated to match the actual behavior of functions used to
form the path used by the UploadChunk's file field. The documentation
was also updated to make it more clear that CHUNKED_UPLOAD_DIR is
supposed to be a relative path inside MEDIA_ROOT.

fixes: #8099
https://pulp.plan.io/issues/8099
