### PR TITLE
Switches plugin reporting to use Django name

### DIFF
--- a/.ci/ansible/start_container.yaml
+++ b/.ci/ansible/start_container.yaml
@@ -81,13 +81,22 @@
           command: "docker logs pulp"
           failed_when: true
 
-    - name: "Check version of component being tested"
-      assert:
-        that:
-          - (result.json.versions | items2dict(key_name="component", value_name="version"))[component_name] | canonical_semver == (component_version | canonical_semver)
-        fail_msg: |
-          Component {{ component_name }} was expected to be installed in version {{ component_version }}.
-          Instead it is reported as version {{ (result.json.versions | items2dict(key_name="component", value_name="version"))[component_name] }}.
+    - block:
+        - name: "Check version of component being tested"
+          assert:
+            that:
+              - (result.json.versions | items2dict(key_name="component", value_name="version"))[component_name] | canonical_semver == (component_version | canonical_semver)
+            fail_msg: |
+              Component {{ component_name }} was expected to be installed in version {{ component_version }}.
+              Instead it is reported as version {{ (result.json.versions | items2dict(key_name="component", value_name="version"))[component_name] }}.
+      rescue:
+        - name: "Check version of component being tested (legacy)"
+          assert:
+            that:
+              - (result.json.versions | items2dict(key_name="component", value_name="version"))[legacy_component_name] | canonical_semver == (component_version | canonical_semver)
+            fail_msg: |
+              Component {{ legacy_component_name }} was expected to be installed in version {{ component_version }}.
+              Instead it is reported as version {{ (result.json.versions | items2dict(key_name="component", value_name="version"))[legacy_component_name] }}.
 
     - name: "Set pulp password in .netrc"
       copy:

--- a/.github/workflows/scripts/before_install.sh
+++ b/.github/workflows/scripts/before_install.sh
@@ -34,7 +34,8 @@ else
 fi
 mkdir .ci/ansible/vars || true
 echo "---" > .ci/ansible/vars/main.yaml
-echo "component_name: pulpcore" >> .ci/ansible/vars/main.yaml
+echo "legacy_component_name: pulpcore" >> .ci/ansible/vars/main.yaml
+echo "component_name: core" >> .ci/ansible/vars/main.yaml
 echo "component_version: '${COMPONENT_VERSION}'" >> .ci/ansible/vars/main.yaml
 
 export PRE_BEFORE_INSTALL=$PWD/.github/workflows/scripts/pre_before_install.sh

--- a/CHANGES/8198.removal
+++ b/CHANGES/8198.removal
@@ -1,0 +1,3 @@
+The ``component`` field of the ``versions`` section of the status API ```/pulp/api/v3/status/`` now
+lists the Django app name, not the Python package name. Similarly the OpenAPI schema at
+``/pulp/api/v3`` does also.

--- a/pulpcore/openapi/__init__.py
+++ b/pulpcore/openapi/__init__.py
@@ -18,11 +18,10 @@ from drf_spectacular.plumbing import (
 from drf_spectacular.settings import spectacular_settings
 from drf_spectacular.types import OpenApiTypes
 from drf_spectacular.utils import OpenApiParameter
-from pkg_resources import get_distribution
 from rest_framework import mixins, serializers
 from rest_framework.schemas.utils import get_pk_description
 
-from pulpcore.app.settings import INSTALLED_PULP_PLUGINS
+from pulpcore.app.apps import pulp_plugin_configs
 
 
 class PulpAutoSchema(AutoSchema):
@@ -446,11 +445,12 @@ class PulpSchemaGenerator(SchemaGenerator):
         result["info"]["x-logo"] = {
             "url": "https://pulp.plan.io/attachments/download/517478/pulp_logo_word_rectangle.svg"
         }
+
         # Adding plugin version config
-        components = ["pulpcore"] + INSTALLED_PULP_PLUGINS
-        result["info"]["x-pulp-app-versions"] = {
-            component: get_distribution(component).version for component in components
-        }
+        result["info"]["x-pulp-app-versions"] = {}
+        for app in pulp_plugin_configs():
+            result["info"]["x-pulp-app-versions"][app.label] = app.version
+
         # Adding current host as server (it will provide a default value for the bindings)
         server_url = "http://localhost:24817" if not request else request.build_absolute_uri("/")
         result["servers"] = [{"url": server_url}]

--- a/template_config.yml
+++ b/template_config.yml
@@ -19,7 +19,7 @@ deploy_daily_client_to_rubygems: true
 deploy_to_pypi: true
 docker_fixtures: true
 docs_test: true
-plugin_app_label: pulpcore
+plugin_app_label: core
 plugin_camel: Pulpcore
 plugin_camel_short: Pulpcore
 plugin_caps: PULPCORE


### PR DESCRIPTION
The Status API and the OpenAPI schema API now both use the Django name.
This is a backwards incompatible change, but necessary to fix the bug
which was using Python package names incorrectly instead.

This also reapplies the plugin template changes required from the PR
below:

https://github.com/pulp/plugin_template/pull/341/files

closes #8198