### PR TITLE
Deprecate get_plugin_storage_path() method in plugin API

### DIFF
--- a/CHANGES/plugin_api/7935.deprecation
+++ b/CHANGES/plugin_api/7935.deprecation
@@ -1,0 +1,1 @@
+The ``pulpcore.plugin.storage.get_plugin_storage_path()`` method has been deprecated.

--- a/pulpcore/plugin/storage.py
+++ b/pulpcore/plugin/storage.py
@@ -1,4 +1,5 @@
 import os
+import warnings
 
 from pulpcore.app.apps import get_plugin_config
 
@@ -26,5 +27,9 @@ def get_plugin_storage_path(plugin_app_label):
         :class:`~pulpcore.exceptions.plugin.MissingPlugin`: When plugin with the requested app
             label is not installed.
     """
+    warnings.warn(
+        "get_plugin_storage_path() is deprecated and will be removed in pulpcore==3.11.",
+        warnings.DeprecationWarning,
+    )
     get_plugin_config(plugin_app_label)
     return os.path.join("/var/lib/pulp/shared", plugin_app_label, "")


### PR DESCRIPTION
fixes: #7935
https://pulp.plan.io/issues/7935