### PR TITLE
Fixes migration imports to use apps.get_model

### DIFF
--- a/CHANGES/8203.misc
+++ b/CHANGES/8203.misc
@@ -1,0 +1,1 @@
+Switches migrations to import models using `apps.get_model(...)`.

--- a/pulpcore/app/migrations/0042_rbac_for_tasks.py
+++ b/pulpcore/app/migrations/0042_rbac_for_tasks.py
@@ -2,8 +2,6 @@
 
 from django.db import migrations
 
-from pulpcore.app.models import AccessPolicy
-
 
 TASK_STATEMENTS = [
     {
@@ -39,6 +37,7 @@ TASK_PERMISSIONS_ASSIGNMENT = [
 
 
 def populate_access_policy(apps, schema_editor):
+    AccessPolicy = apps.get_model('core', 'AccessPolicy')
     AccessPolicy.objects.create(
         viewset_name="TaskViewSet",
         statements=TASK_STATEMENTS,

--- a/pulpcore/app/migrations/0050_namespace_access_policies.py
+++ b/pulpcore/app/migrations/0050_namespace_access_policies.py
@@ -2,17 +2,17 @@
 
 from django.db import migrations
 
-from pulpcore.app.models import AccessPolicy
-
 
 def namespace_access_policies_up(apps, schema_editor):
+    AccessPolicy = apps.get_model('core', 'AccessPolicy')
     task_policy = AccessPolicy.objects.get(viewset_name="TaskViewSet")
     task_policy.viewset_name = "tasks"
     task_policy.save()
 
 
 def namespace_access_policies_down(apps, schema_editor):
-    AccessPolicy.objects.get(viewset_name="tasks").delete()
+    AccessPolicy = apps.get_model('core', 'AccessPolicy')
+    task_policy = AccessPolicy.objects.get(viewset_name="tasks").delete()
     task_policy.viewset_name = "TaskViewSet"
     task_policy.save()
 


### PR DESCRIPTION
In various places in the migrations Models are imported directly and then
used. This is a hazard for future changes because when the model
definition changes this code can break.

This PR switches data migrations to use apps.get_model(...) intead. It
also fixes a syntax migration I noticed on the downmigrate in migration
50.

closes #8203

