### PR TITLE
Make the generated openapi spec more concrete and compliant to standard

### DIFF
--- a/pulpcore/openapi/__init__.py
+++ b/pulpcore/openapi/__init__.py
@@ -380,8 +380,6 @@ class PulpSchemaGenerator(SchemaGenerator):
 
             schema = view.schema
 
-            path = self.convert_endpoint_path_params(path, view, schema)
-
             # beware that every access to schema yields a fresh object (descriptor pattern)
             operation = schema.get_operation(path, path_regex, method, self.registry)
 


### PR DESCRIPTION
ie, instead of {ansible_repository_href}, the
api urls are of form /pulp/api/v3/repositories/ansible/ansible/

Also makes the generated spec compliant to the openapi standard,
including not allowing endpoints to start with '{' and requiring
endpoints to start with '/'

Please be sure you have read our documentation on creating PRs:
https://docs.pulpproject.org/contributing/pull-request-walkthrough.html
