### PR TITLE
Removes md5 and sha1 from checksum defaults

### DIFF
--- a/.github/workflows/scripts/install.sh
+++ b/.github/workflows/scripts/install.sh
@@ -61,7 +61,7 @@ services:
 VARSYAML
 
 cat >> vars/main.yaml << VARSYAML
-pulp_settings: {"allowed_content_checksums": ["sha1", "sha224", "sha256", "sha384", "sha512"], "allowed_export_paths": ["/tmp"], "allowed_import_paths": ["/tmp"]}
+pulp_settings: {"allowed_export_paths": ["/tmp"], "allowed_import_paths": ["/tmp"]}
 VARSYAML
 
 if [[ "$TEST" == "pulp" || "$TEST" == "performance" || "$TEST" == "s3" || "$TEST" == "plugin-from-pypi" ]]; then

--- a/.github/workflows/scripts/script.sh
+++ b/.github/workflows/scripts/script.sh
@@ -34,7 +34,7 @@ if [[ "$TEST" = "docs" || "$TEST" = "publish" ]]; then
   echo "Validating OpenAPI schema..."
   cat $PWD/.ci/scripts/schema.py | cmd_stdin_prefix bash -c "cat > /tmp/schema.py"
   cmd_prefix bash -c "python3 /tmp/schema.py"
-  # cmd_prefix bash -c "pulpcore-manager spectacular --file pulp_schema.yml --validate"
+  cmd_prefix bash -c "pulpcore-manager spectacular --file pulp_schema.yml --validate"
 
   if [ -f $POST_DOCS_TEST ]; then
     source $POST_DOCS_TEST

--- a/CHANGES/8246.removal
+++ b/CHANGES/8246.removal
@@ -1,0 +1,3 @@
+Adjusted the ``ALLOWED_CONTENT_CHECKSUMS`` setting to remove ``md5`` and ``sha1`` since they are
+insecure. Now, by default, the ``ALLOWED_CONTENT_CHECKSUMS`` contain ``sha224``, ``sha256``,
+``sha384``, and ``sha512``.

--- a/CHANGES/plugin_api/8246.removal
+++ b/CHANGES/plugin_api/8246.removal
@@ -1,0 +1,3 @@
+Adjusted the ``ALLOWED_CONTENT_CHECKSUMS`` setting to remove ``md5`` and ``sha1`` since they are
+insecure. Now, by default, the ``ALLOWED_CONTENT_CHECKSUMS`` contain ``sha224``, ``sha256``,
+``sha384``, and ``sha512``.

--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -247,22 +247,18 @@ PROFILE_STAGES_API
 ALLOWED_CONTENT_CHECKSUMS
 ^^^^^^^^^^^^^^^^^^^^^^^^^
 
-    The list of content-checksums this pulp-instance is **allowed to use**. This list is a
-    proper subset of the checksums defined by the Artifact model. You may safely list fewer
-    algorithms than the Artifact model supports (although see the warning below regarding ``sha256``),
-    but adding unknown algorithms will cause unexpected behavior.
+    The list of content-checksums this pulp-instance is **allowed to use**. By default the following
+    are used::
 
-    See :ref:`Configuration` for details on how to change configuration-options.
+        ALLOWED_CONTENT_CHECKSUMS = ["sha224", "sha256", "sha384", "sha512"]
+
+    The entire set of supported checksums are: ``md5``, ``sha1``, ``sha224``, ``sha256``,
+    ``sha384``, and ``sha512``. After modifying this setting, you likely will need to run
+    ``pulpcore-manager handle-artifact-checksums`` or Pulp will refuse to start.
 
     .. warning::
       Due to its use as a primary content-identifier, "sha256"" **IS REQUIRED**. Pulp will
       fail to start if it is not found in this set.
-
-    .. warning::
-      Specifying checksums that are not available to models.Artifact will cause Pulp to fail to start.
-      The complete set of supported checksum algorithms includes the following:
-
-      ``{"md5", "sha1", "sha224", "sha256", "sha384", "sha512"}``
 
     .. warning::
       If Pulp fails to start because forbidden checkums have been identified or required ones are

--- a/pulpcore/app/settings.py
+++ b/pulpcore/app/settings.py
@@ -254,7 +254,7 @@ SPECTACULAR_SETTINGS = {
 # NOTE : "sha256"" IS REQUIRED - Pulp will fail to start if it is not found in this set
 # NOTE: specifying checksums that are not listed under ALL_KNOWN_CONTENT_CHECKSUMS will fail
 #       at startup
-ALLOWED_CONTENT_CHECKSUMS = ["md5", "sha1", "sha224", "sha256", "sha384", "sha512"]
+ALLOWED_CONTENT_CHECKSUMS = ["sha224", "sha256", "sha384", "sha512"]
 
 # HERE STARTS DYNACONF EXTENSION LOAD (Keep at the very bottom of settings.py)
 # Read more at https://dynaconf.readthedocs.io/en/latest/guides/django.html

--- a/template_config.yml
+++ b/template_config.yml
@@ -30,12 +30,6 @@ plugin_name: pulpcore
 plugin_snake: pulpcore
 publish_docs_to_pulpprojectdotorg: true
 pulp_settings:
-  allowed_content_checksums:
-  - sha1
-  - sha224
-  - sha256
-  - sha384
-  - sha512
   allowed_export_paths:
   - /tmp
   allowed_import_paths:


### PR DESCRIPTION
The md5 and sha1 checksums are not considered secure and therefore
should not be included as available hashers for Pulp to perform Artifact
integrity checks with.

This PR:
* Removes them from the default in settings
* Updates the `ALLOWED_CONTENT_CHECKSUMS` settings documentation.
* Re-applies the plugin_tepmlate to no longer modify the set of allowed
  checksums in the CI environment.

closes #8246

