### PR TITLE
Adds additional d_artifact.remote check

### DIFF
--- a/CHANGES/7876.bugfix
+++ b/CHANGES/7876.bugfix
@@ -1,0 +1,2 @@
+Fixed a bug experienced by the migration plugin where all content objects are assumed to have a
+remote associated with them.

--- a/pulpcore/plugin/stages/artifact_stages.py
+++ b/pulpcore/plugin/stages/artifact_stages.py
@@ -293,11 +293,11 @@ class RemoteArtifactSaver(Stage):
                     raise ValueError(
                         msg.format(rp=content_artifact.relative_path, c=d_content.content)
                     )
-                for remote_artifact in content_artifact._remote_artifact_saver_ras:
-                    if remote_artifact.remote_id == d_artifact.remote.pk:
-                        break
-                else:
-                    if d_artifact.remote:
+                if d_artifact.remote:
+                    for remote_artifact in content_artifact._remote_artifact_saver_ras:
+                        if remote_artifact.remote_id == d_artifact.remote.pk:
+                            break
+                    else:
                         remote_artifact = self._create_remote_artifact(d_artifact, content_artifact)
                         needed_ras.append(remote_artifact)
         return needed_ras


### PR DESCRIPTION
Not all d_artifact objects have remotes, e.g. the migration plugin does
not. Other places in the code account for this, but there is one area
that does not. This adds an additional check to one codepath that checks
for equality of `d_artifact.remote.pk` only if `d_artifact.remote`
exists.

closes #7876
