### PR TITLE
Add choices to task state filter

### DIFF
--- a/pulpcore/app/viewsets/task.py
+++ b/pulpcore/app/viewsets/task.py
@@ -24,12 +24,12 @@ from pulpcore.app.viewsets.custom_filters import (
     ReservedResourcesFilter,
     CreatedResourcesFilter,
 )
-from pulpcore.constants import TASK_INCOMPLETE_STATES, TASK_STATES
+from pulpcore.constants import TASK_INCOMPLETE_STATES, TASK_STATES, TASK_CHOICES
 from pulpcore.tasking.util import cancel as cancel_task
 
 
 class TaskFilter(BaseFilterSet):
-    state = filters.CharFilter()
+    state = filters.ChoiceFilter(choices=TASK_CHOICES)
     worker = HyperlinkRelatedFilter()
     name = filters.CharFilter()
     started_at = IsoDateTimeFilter(field_name="started_at")


### PR DESCRIPTION
This change will issue an error response instead of an empty list, if an
invalid state is provided to filter by.

[noissue]
