### PR TITLE
Gracefully handle unrepresentable objects

### DIFF
--- a/CHANGES/8048.bugfix
+++ b/CHANGES/8048.bugfix
@@ -1,0 +1,1 @@
+Added a fallback text in the permission view for resources that cannot be represented by a pulp uri.

--- a/pulpcore/app/serializers/user.py
+++ b/pulpcore/app/serializers/user.py
@@ -24,9 +24,12 @@ class ContentObjectField(serializers.CharField):
     def to_representation(self, obj):
         content_object = getattr(obj, "content_object", None)
         if content_object:
-            viewset = get_viewset_for_model(obj.content_object)
-            serializer = viewset.serializer_class(obj.content_object, context={"request": None})
-            return serializer.data.get("pulp_href")
+            try:
+                viewset = get_viewset_for_model(obj.content_object)
+                serializer = viewset.serializer_class(obj.content_object, context={"request": None})
+                return serializer.data.get("pulp_href")
+            except LookupError:
+                return "<unaddressable resource>"
 
 
 class PermissionSerializer(serializers.Serializer):


### PR DESCRIPTION
In the object permission view objects are supposed to be represented by
their pulp uri. This is obviously impossible for objects, that do not
have one. This will change the behaviour from failing badly to returning
a string that indicates the problem.

fixes #8048
https://pulp.plan.io/issues/8048