### PR TITLE
Have the content app handle UnsupportedDigestValidationError 

### DIFF
--- a/CHANGES/7989.feature
+++ b/CHANGES/7989.feature
@@ -1,0 +1,1 @@
+Added support in content app for properly handling unknown or forbidden digest errors.

--- a/pulpcore/content/handler.py
+++ b/pulpcore/content/handler.py
@@ -30,6 +30,7 @@ from pulpcore.app.models import (  # noqa: E402: module level not at top of file
     Remote,
     RemoteArtifact,
 )
+from pulpcore.exceptions import UnsupportedDigestValidationError  # noqa: E402
 
 from jinja2 import Template  # noqa: E402: module level not at top of file
 
@@ -501,7 +502,12 @@ class Handler:
                 response = await self._stream_remote_artifact(request, response, remote_artifact)
                 return response
 
-            except ClientResponseError:
+            except (ClientResponseError, UnsupportedDigestValidationError) as e:
+                log.warn(
+                    _("Could not download remote artifact at '{}': {}").format(
+                        remote_artifact.url, str(e)
+                    )
+                )
                 continue
 
         raise HTTPNotFound()


### PR DESCRIPTION
In https://pulp.plan.io/issues/8435 we added a check to downloader to
prevent the download of files without allowed checksums. This code 
updates the downloader to handle the exception that gets raised.

fixes #7989

Please be sure you have read our documentation on creating PRs:
https://docs.pulpproject.org/contributing/pull-request-walkthrough.html
