### PR TITLE
Add check to downloader to prevent use of forbidden checksums

### DIFF
--- a/CHANGES/plugin_api/7853.feature
+++ b/CHANGES/plugin_api/7853.feature
@@ -1,0 +1,1 @@
+Added a digest check to downloaders to prevent use of forbidden checksums.


### PR DESCRIPTION
This is strictly a plugin api feature at the moment since the pulpcore
code always filters by DIGEST_FIELDS on Artifact before sending
digests to the downloader and DIGEST_FIELDS takes
ALLOWED_CONTENT_CHECKSUMS into account.

fixes #7854

Please be sure you have read our documentation on creating PRs:
https://docs.pulpproject.org/contributing/pull-request-walkthrough.html
