### PR TITLE
Deprecate WorkingDirectory

### DIFF
--- a/CHANGES/plugin_api/8231.deprecation
+++ b/CHANGES/plugin_api/8231.deprecation
@@ -1,0 +1,1 @@
+``pulpcore.plugin.tasking.WorkingDirectory`` has been deprecated.

--- a/CHANGES/plugin_api/8231.doc
+++ b/CHANGES/plugin_api/8231.doc
@@ -1,0 +1,1 @@
+The use of ``tempdir.TemporaryDirectory`` in tasks has been documented.

--- a/docs/plugins/plugin-writer/concepts/index.rst
+++ b/docs/plugins/plugin-writer/concepts/index.rst
@@ -82,6 +82,17 @@ to understand the internals of the pulpcore tasking system, workers automaticall
 RQ, including tasks deployed by plugins.
 
 
+**Worker and Tasks Directories**
+
+In pulp each worker is assigned a unique working directory living in ``/var/lib/pulp/tmp/``, and
+each started task will have its own clean temporary subdirectory therein as its current working
+directory. Those will automatically be cleaned up once the task is finished.
+
+If a task needs to create more temporary directories, it is encouraged to use
+``tempfile.TemporaryDirectory(dir=".")`` from the python standard library to place them in the
+tasks working directory. This can be necessary, if the amount of temporarily saved data is too much
+to wait for the automatic cleanup at the end of the task processing or to avoid naming conflicts.
+
 **Making Temporary Files Available to Tasks**
 
 Sometimes, files must be brought forward from a ViewSet to an executing task. The files may or may
@@ -389,7 +400,7 @@ In 3.8 the following changes happen:
 2. The existing method signature ``def foo(a, b)`` is left in-tact.
 3. The ``foo`` method would have the a Python ``DeprecationWarning`` added to it such as::
 
-    warnings.warn("foo() is deprecated and will be removed in pulpcore==3.9; use the_new_foo().", warnings.DeprecationWarning)
+    warnings.warn("foo() is deprecated and will be removed in pulpcore==3.9; use the_new_foo().", DeprecationWarning)
 
 4. A ``CHANGES/plugin_api/XXXX.deprecation`` changelog entry is created explaining how to port
    plugin code onto the new call interface.

--- a/docs/plugins/reference/metadata-signing.rst
+++ b/docs/plugins/reference/metadata-signing.rst
@@ -100,12 +100,11 @@ The following procedure may be taken into account for the plugin writers:
 
                  http POST :24817/pulp/api/v3/repositories/file/file/ name=foo metadata_signing_service=http://localhost:24817/pulp/api/v3/signing-services/5506c8ac-8eae-4f34-bb5a-3bc08f82b088/
 
-    3. Sign a file by calling the method ``sign()`` inside the context manager implemented in pulpcore, i.e.
-       :class:`pulpcore.plugin.tasking.WorkingDirectory`:
+    3. Sign a file by calling the method ``sign()``:
 
        .. code-block:: python
 
-           with WorkingDirectory():
+           with tempfile.TemporaryDirectory("."):
                try:
                    signature = metadata_signing_service.sign(metadata.filepath)
                except RuntimeError:

--- a/pulpcore/app/access_policy.py
+++ b/pulpcore/app/access_policy.py
@@ -41,6 +41,6 @@ class AccessPolicyFromDB(AccessPolicy):
             warnings.warn(
                 "Addressing AccessPolicy via the viewset's classname is deprecated"
                 "and will be removed in pulpcore==3.10; use the viewset's urlpattern().",
-                warnings.DeprecationWarning,
+                DeprecationWarning,
             )
         return access_policy_obj.statements

--- a/pulpcore/plugin/stages/declarative_version.py
+++ b/pulpcore/plugin/stages/declarative_version.py
@@ -1,6 +1,5 @@
 import asyncio
-
-from pulpcore.plugin.tasking import WorkingDirectory
+import tempfile
 
 from .api import create_pipeline, EndStage
 from .artifact_stages import (
@@ -136,7 +135,7 @@ class DeclarativeVersion:
         """
         Perform the work. This is the long-blocking call where all syncing occurs.
         """
-        with WorkingDirectory():
+        with tempfile.TemporaryDirectory(dir="."):
             with self.repository.new_version() as new_version:
                 loop = asyncio.get_event_loop()
                 stages = self.pipeline_stages(new_version)

--- a/pulpcore/plugin/storage.py
+++ b/pulpcore/plugin/storage.py
@@ -29,7 +29,7 @@ def get_plugin_storage_path(plugin_app_label):
     """
     warnings.warn(
         "get_plugin_storage_path() is deprecated and will be removed in pulpcore==3.11.",
-        warnings.DeprecationWarning,
+        DeprecationWarning,
     )
     get_plugin_config(plugin_app_label)
     return os.path.join("/var/lib/pulp/shared", plugin_app_label, "")

--- a/pulpcore/tasking/storage.py
+++ b/pulpcore/tasking/storage.py
@@ -1,6 +1,7 @@
 import os
 import random
 import shutil
+import warnings
 from gettext import gettext as _
 
 from django.conf import settings
@@ -186,6 +187,13 @@ class WorkingDirectory(_WorkingDir):
         Raises:
             RuntimeError: When used outside of an RQ task.
         """
+        warnings.warn(
+            _(
+                "WorkingDirectory is deprecated and will be removed in pulpcore==3.12; "
+                'use tempfile.TemporaryDirectory(dir=".") instead.'
+            ),
+            DeprecationWarning,
+        )
         try:
             job = get_current_job()
             self.hostname = job.origin


### PR DESCRIPTION
Additionally document the use of tempfile.TemporaryDirectory.

fixes #8231
https://pulp.plan.io/issues/8231