### PR TITLE
Disable Dynaconf loading of .env files

### DIFF
--- a/pulpcore/app/settings.py
+++ b/pulpcore/app/settings.py
@@ -269,6 +269,7 @@ settings = dynaconf.DjangoDynaconf(
         "{}.app.settings".format(plugin_name) for plugin_name in INSTALLED_PULP_PLUGINS
     ],
     ENVVAR_FOR_DYNACONF="PULP_SETTINGS",
+    load_dotenv=False,
 )
 # HERE ENDS DYNACONF EXTENSION LOAD (No more code below this line)
 


### PR DESCRIPTION
In production we don't need django to load .env files.

[noissue]

Please be sure you have read our documentation on creating PRs:
https://docs.pulpproject.org/contributing/pull-request-walkthrough.html
