### PR TITLE
Revert "Add warning if on-demand content does not have allowed checksum"

### DIFF
--- a/CHANGES/7985.feature
+++ b/CHANGES/7985.feature
@@ -1,1 +1,0 @@
-Added a warning message if there is on-demand content with no allowed checksums.


### PR DESCRIPTION
Revert the RemoteArtifact warning for 3.11 as users don't have a way to remedy the problem and also it doesn't handle plugins who can have RemoteArtifact without checksums.