### PR TITLE
Remove enforcement of RemoteArtifact forbidden checksums for 3.11

### DIFF
--- a/CHANGES/7854.feature
+++ b/CHANGES/7854.feature
@@ -1,1 +1,1 @@
-Raise error when syncing content with a checksum not included in 'ALLOWED_CONTENT_CHECKSUMS'.
+Raise error when syncing content with a checksum not included in ``ALLOWED_CONTENT_CHECKSUMS``.

--- a/pulpcore/plugin/stages/artifact_stages.py
+++ b/pulpcore/plugin/stages/artifact_stages.py
@@ -24,9 +24,10 @@ def _check_for_forbidden_checksume_type(artifact):
         if digest_value:
             # To use shared message constant when #7988 is merged
             raise UnsupportedDigestValidationError(
-                "Artifact contains forbidden checksum type {}. "
-                "You can allow it with 'ALLOWED_CONTENT_CHECKSUMS' "
-                "setting.".format(digest_type)
+                _(
+                    "Artifact contains forbidden checksum type {}. You can allow it with "
+                    "'ALLOWED_CONTENT_CHECKSUMS' setting."
+                ).format(digest_type)
             )
 
 
@@ -318,8 +319,6 @@ class RemoteArtifactSaver(Stage):
                     else:
                         remote_artifact = self._create_remote_artifact(d_artifact, content_artifact)
                         needed_ras.append(remote_artifact)
-        for ra in needed_ras:
-            _check_for_forbidden_checksume_type(ra)
         return needed_ras
 
     @staticmethod


### PR DESCRIPTION
refs #7854

Please be sure you have read our documentation on creating PRs:
https://docs.pulpproject.org/contributing/pull-request-walkthrough.html
