### PR TITLE
Document ALLOWED_CONTENT_CHECKSUMS as not finished

### DIFF
--- a/CHANGES/8342.doc
+++ b/CHANGES/8342.doc
@@ -1,0 +1,2 @@
+Added a warning banner to the ``ALLOWED_CONTENT_CHECKSUMS`` setting section indicating the setting
+is not fully enforcing in ``pulpcore`` code and various plugins.

--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -257,6 +257,11 @@ PROFILE_STAGES_API
 ALLOWED_CONTENT_CHECKSUMS
 ^^^^^^^^^^^^^^^^^^^^^^^^^
 
+    .. warning::
+      Enforcement of this setting in ``pulpcore`` and various plugins is not fully in place. It is
+      possible that checksums not in this list may still be used in various places. This banner will
+      be removed when it is believed all ``pulpcore`` and plugin code fully enforces this setting.
+
     The list of content-checksums this pulp-instance is **allowed to use**. By default the following
     are used::
 


### PR DESCRIPTION
The ALLOWED_CONTENT_CHECKSUMS is not fully enforcing with 3.11, so this
adds a banner to the settings page that identifies this for users.

closes #8342

