### PR TITLE
Artifact checksums report

### DIFF
--- a/CHANGES/7986.feature
+++ b/CHANGES/7986.feature
@@ -1,0 +1,1 @@
+User can evaluate how many content units are affected with checksum type change with 'pulpcore-manager handle-artifact-checksums --report'.

--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -271,6 +271,17 @@ ALLOWED_CONTENT_CHECKSUMS
     ``sha384``, and ``sha512``. After modifying this setting, you likely will need to run
     ``pulpcore-manager handle-artifact-checksums`` or Pulp will refuse to start.
 
+    You can run ``pulpcore-manager handle-artifact-checksums --report`` to find out
+    how many content units are affected with actual ``ALLOWED_CONTENT_CHECKSUMS`` settings.
+    Also, you can run ``pulpcore-manager handle-artifact-checksums --report`` with ``--checksums``
+    argument specifying comma separated list of checksums you want to use to perform this check
+    before changing the setting.
+
+    .. warning::
+      ``--report`` and ``--checksums`` arguments are tech-preview and may change in backwards
+      incompatible ways in future releases.
+
+
     .. warning::
       Due to its use as a primary content-identifier, "sha256"" **IS REQUIRED**. Pulp will
       fail to start if it is not found in this set.

--- a/pulpcore/app/management/commands/handle-artifact-checksums.py
+++ b/pulpcore/app/management/commands/handle-artifact-checksums.py
@@ -4,9 +4,16 @@ from gettext import gettext as _
 
 from django.conf import settings
 from django.core.management import BaseCommand, CommandError
+from django.db.models import Q, Sum
 from pulpcore import constants
 from pulpcore.app import pulp_hashlib
-from pulpcore.plugin.models import Artifact
+from pulpcore.plugin.models import (
+    Artifact,
+    Content,
+    ContentArtifact,
+    RemoteArtifact,
+    RepositoryVersion,
+)
 
 import logging
 
@@ -21,6 +28,96 @@ class Command(BaseCommand):
     """
 
     help = _("Handle missing and forbidden checksums on the artifacts")
+
+    def add_arguments(self, parser):
+        parser.add_argument("--report", action="store_true")
+        parser.add_argument("--checksums", help=_("Comma separated list of checksums to evaluate"))
+
+    def _print_out_repository_version_hrefs(self, repo_versions):
+        """
+        Print out repository version href from a query of repo versions.
+
+        Args:
+            repo_versions (django.db.models.QuerySet): repository versions query
+
+        Returns None
+        """
+        for repo_version in repo_versions.iterator():
+            self.stdout.write(
+                _(
+                    "/repositories/{plugin}/{type}/{pk}/versions/{number}/".format(
+                        plugin=repo_version.repository.pulp_type.split(".")[0],
+                        type=repo_version.repository.pulp_type.split(".")[1],
+                        pk=str(repo_version.repository.pk),
+                        number=repo_version.number,
+                    )
+                )
+            )
+
+    def _show_on_demand_content(self, checksums):
+        query = Q(pk__in=[])
+        for checksum in checksums:
+            query |= Q(**{f"{checksum}__isnull": False})
+
+        remote_artifacts = RemoteArtifact.objects.filter(query).filter(
+            content_artifact__artifact__isnull=True
+        )
+        ras_size = remote_artifacts.aggregate(Sum("size"))["size__sum"]
+
+        content_artifacts = ContentArtifact.objects.filter(remoteartifact__pk__in=remote_artifacts)
+        content = Content.objects.filter(contentartifact__pk__in=content_artifacts)
+        repo_versions = RepositoryVersion.versions_containing_content(content).select_related(
+            "repository"
+        )
+
+        self.stdout.write(
+            _("Found {} on-demand content units with forbidden checksums.").format(content.count())
+        )
+        if content.count():
+            self.stdout.write(
+                _("There is approx {:.2f}Mb of content to be downloaded.").format(
+                    ras_size / (1024 ** 2)
+                )
+            )
+
+        if repo_versions.exists():
+            self.stdout.write(_("\nAffected repository versions with remote content:"))
+            self._print_out_repository_version_hrefs(repo_versions)
+
+    def _show_immediate_content(self, forbidden_checksums):
+        allowed_checksums = set(
+            constants.ALL_KNOWN_CONTENT_CHECKSUMS.symmetric_difference(forbidden_checksums)
+        )
+        query_forbidden = Q()
+        query_required = Q()
+        for checksum in forbidden_checksums:
+            query_forbidden |= Q(**{f"{checksum}__isnull": False})
+
+        for allowed_checksum in allowed_checksums:
+            query_required |= Q(**{f"{allowed_checksum}__isnull": True})
+
+        artifacts = Artifact.objects.filter(query_forbidden | query_required)
+        content_artifacts = ContentArtifact.objects.filter(artifact__in=artifacts)
+        content = Content.objects.filter(contentartifact__pk__in=content_artifacts)
+        repo_versions = RepositoryVersion.versions_containing_content(content).select_related(
+            "repository"
+        )
+
+        self.stdout.write(
+            _("Found {} downloaded content units with forbidden or missing checksums.").format(
+                content.count()
+            )
+        )
+        if content.count() > 0:
+            self.stdout.write(
+                _("There is approx. {:.2f}Mb content data to be re-hashed.").format(
+                    artifacts.aggregate(Sum("size"))["size__sum"] / (1024 ** 2)
+                )
+            )
+
+        if repo_versions.exists():
+            self.stdout.write(_("\nAffected repository versions with present content:"))
+            self._print_out_repository_version_hrefs(repo_versions)
 
     def _download_artifact(self, artifact, checksum, file_path):
         restored = False
@@ -44,7 +141,36 @@ class Command(BaseCommand):
                 break
         return restored
 
+    def _report(self, allowed_checksums):
+        if allowed_checksums:
+            allowed_checksums = allowed_checksums.split(",")
+            if "sha256" not in allowed_checksums:
+                raise CommandError(_("Checksums must contain sha256"))
+        else:
+            allowed_checksums = settings.ALLOWED_CONTENT_CHECKSUMS
+
+        forbidden_checksums = set(constants.ALL_KNOWN_CONTENT_CHECKSUMS).difference(
+            allowed_checksums
+        )
+
+        self.stderr.write(
+            _(
+                "Warning: the handle-artifact-checksums report is in "
+                "tech preview and may change in the future."
+            )
+        )
+        self._show_on_demand_content(forbidden_checksums)
+        self._show_immediate_content(forbidden_checksums)
+
     def handle(self, *args, **options):
+
+        if options["report"]:
+            self._report(options["checksums"])
+            return
+
+        if options["checksums"] and not options["report"]:
+            self.stdout.write(_("Checksums cannot be supplied without --report argument"))
+            exit(1)
 
         log.setLevel(logging.ERROR)
         hrefs = set()

--- a/pulpcore/app/models/repository.py
+++ b/pulpcore/app/models/repository.py
@@ -468,6 +468,32 @@ class RepositoryVersion(BaseModel):
         get_latest_by = "number"
         ordering = ("number",)
 
+    @classmethod
+    def versions_containing_content(cls, content):
+        """
+        Returns a query of repository versions containing the provided content units.
+
+        Args:
+            content (django.db.models.QuerySet): query of content
+
+        Returns:
+            django.db.models.QuerySet: Repository versions which contains content.
+        """
+        query = models.Q(pk__in=[])
+        repo_content = RepositoryContent.objects.filter(content__pk__in=content)
+
+        for rc in repo_content.iterator():
+            filter = models.Q(
+                repository__pk=rc.repository.pk,
+                number__gte=rc.version_added.number,
+            )
+            if rc.version_removed:
+                filter &= models.Q(number__lt=rc.version_removed.number)
+
+            query |= filter
+
+        return cls.objects.filter(query)
+
     def _content_relationships(self):
         """
         Returns a set of repository_content for a repository version


### PR DESCRIPTION
`pulpcore-manager handle-artifact-checksums --report` reports local and remote artifacts with forbidden checksum type and approx size of it.

re #7986
https://pulp.plan.io/issues/7986