### PR TITLE
Remove "key" field from signing service response

### DIFF
--- a/CHANGES/plugin_api/8398.removal
+++ b/CHANGES/plugin_api/8398.removal
@@ -1,0 +1,2 @@
+Removed deprecated `key` field returned by the signing service.
+Plugin writers must now refer directly to the `public_key` field on the signing service object.


### PR DESCRIPTION
This was deprecated, since the SigningService contains the information
in the public_key field already.

closes #8398
https://pulp.plan.io/issues/8398

