### PR TITLE
Disable Dynaconf loading of .env files

### DIFF
--- a/CHANGES/8373.bugfix
+++ b/CHANGES/8373.bugfix
@@ -1,0 +1,1 @@
+No longer load .env files. They are not used by Pulp but potentially can break the setup.

--- a/pulpcore/app/settings.py
+++ b/pulpcore/app/settings.py
@@ -246,6 +246,7 @@ settings = dynaconf.DjangoDynaconf(
         "{}.app.settings".format(plugin_name) for plugin_name in INSTALLED_PULP_PLUGINS
     ],
     ENVVAR_FOR_DYNACONF="PULP_SETTINGS",
+    load_dotenv=False,
 )
 # HERE ENDS DYNACONF EXTENSION LOAD (No more code below this line)
 


### PR DESCRIPTION
In production we don't need django to load .env files.

closes #8373
https://pulp.plan.io/issues/8373

backports a fix from 3.11, no redmine issue

(cherry picked from commit efc089f2cfdde92cf6f993551142a8a28b76359e)

