### PR TITLE
Fix error for unique constraint violation

### DIFF
--- a/CHANGES/8430.bugfix
+++ b/CHANGES/8430.bugfix
@@ -1,0 +1,2 @@
+Fixed bug during sync where a unique constraint violation for ``Content`` would raise an "X matching
+query does not exist" error.


### PR DESCRIPTION
In the case where there's a unique constraint that isn't part of the
natural key, using q() won't find the record. This erroneously raises a
DoesNotExist exception.

fixes #8430

Please be sure you have read our documentation on creating PRs:
https://docs.pulpproject.org/contributing/pull-request-walkthrough.html
