### PR TITLE
Wrap Exporter update and destroy calls in tasks

### DIFF
--- a/CHANGES/7438.bugfix
+++ b/CHANGES/7438.bugfix
@@ -1,0 +1,1 @@
+Added asynchronous tasking to the Update and Delete endpoints of PulpExporter to provide proper locking on resources.

--- a/CHANGES/7438.removal
+++ b/CHANGES/7438.removal
@@ -1,0 +1,1 @@
+The Update and Delete endpoints of Exporters changed to now return 202 with tasks.

--- a/pulpcore/app/viewsets/exporter.py
+++ b/pulpcore/app/viewsets/exporter.py
@@ -21,6 +21,8 @@ from pulpcore.app.serializers import (
 from pulpcore.app.tasks.export import pulp_export
 
 from pulpcore.app.viewsets import (
+    AsyncRemoveMixin,
+    AsyncUpdateMixin,
     BaseFilterSet,
     NamedModelViewSet,
 )
@@ -51,10 +53,10 @@ class ExporterFilter(BaseFilterSet):
 class ExporterViewSet(
     NamedModelViewSet,
     mixins.CreateModelMixin,
-    mixins.UpdateModelMixin,
+    AsyncUpdateMixin,
     mixins.RetrieveModelMixin,
     mixins.ListModelMixin,
-    mixins.DestroyModelMixin,
+    AsyncRemoveMixin,
 ):
     """
     ViewSet for viewing exporters.

--- a/pulpcore/tests/functional/api/using_plugin/test_filesystemexport.py
+++ b/pulpcore/tests/functional/api/using_plugin/test_filesystemexport.py
@@ -105,7 +105,8 @@ class BaseExporterCase(unittest.TestCase):
         cmd = ("rm", "-rf", exporter.path)
         cli_client.run(cmd, sudo=True)
 
-        self.exporter_api.delete(exporter.pulp_href)
+        result = self.exporter_api.delete(exporter.pulp_href)
+        monitor_task(result.task)
 
     def _create_exporter(self):
         """
@@ -141,7 +142,8 @@ class FilesystemExporterTestCase(BaseExporterCase):
         """Update a FilesystemExporter's path."""
         exporter_created, body = self._create_exporter()
         body = {"path": "/tmp/{}".format(uuid4())}
-        self.exporter_api.partial_update(exporter_created.pulp_href, body)
+        result = self.exporter_api.partial_update(exporter_created.pulp_href, body)
+        monitor_task(result.task)
         exporter_read = self.exporter_api.read(exporter_created.pulp_href)
         self.assertNotEqual(exporter_created.path, exporter_read.path)
         self.assertEqual(body["path"], exporter_read.path)
@@ -157,7 +159,8 @@ class FilesystemExporterTestCase(BaseExporterCase):
     def test_delete(self):
         """Delete a pulpExporter."""
         exporter = self.exporter_api.create({"name": "test", "path": "/tmp/abc"})
-        self.exporter_api.delete(exporter.pulp_href)
+        result = self.exporter_api.delete(exporter.pulp_href)
+        monitor_task(result.task)
         with self.assertRaises(ApiException) as ae:
             self.exporter_api.read(exporter.pulp_href)
         self.assertEqual(404, ae.exception.status)

--- a/pulpcore/tests/functional/api/using_plugin/test_pulpexport.py
+++ b/pulpcore/tests/functional/api/using_plugin/test_pulpexport.py
@@ -151,7 +151,8 @@ class PulpExporterTestCase(BaseExporterCase):
         """Update a PulpExporter's path."""
         (exporter_created, body) = self._create_exporter()
         body = {"path": "/tmp/{}".format(uuid4())}
-        self.exporter_api.partial_update(exporter_created.pulp_href, body)
+        result = self.exporter_api.partial_update(exporter_created.pulp_href, body)
+        monitor_task(result.task)
         exporter_read = self.exporter_api.read(exporter_created.pulp_href)
         self.assertNotEqual(exporter_created.path, exporter_read.path)
         self.assertEqual(body["path"], exporter_read.path)

--- a/pulpcore/tests/functional/api/using_plugin/utils.py
+++ b/pulpcore/tests/functional/api/using_plugin/utils.py
@@ -129,4 +129,5 @@ def delete_exporter(exporter):
     cmd = ("rm", "-rf", exporter.path)
 
     cli_client.run(cmd, sudo=True)
-    exporter_api.delete(exporter.pulp_href)
+    result = exporter_api.delete(exporter.pulp_href)
+    monitor_task(result.task)


### PR DESCRIPTION
Exporter is a resource that needs to be reserved to change it. Running
an export task, while the exporter is being changed can lead to problems
otherwise.

fixes #7438