### PR TITLE
Allow plugins to unset attribute in NamedModelViewSet

### DIFF
--- a/CHANGES/plugin_api/8438.bugfix
+++ b/CHANGES/plugin_api/8438.bugfix
@@ -1,0 +1,1 @@
+Allow plugins to unset the ``queryset_filtering_required_permission`` attribute in ``NamedModelViewSet``.

--- a/pulpcore/app/viewsets/base.py
+++ b/pulpcore/app/viewsets/base.py
@@ -326,12 +326,10 @@ class NamedModelViewSet(viewsets.GenericViewSet):
                 filters[lookup] = self.kwargs[key]
             qs = qs.filter(**filters)
 
-        try:
-            permission_name = self.queryset_filtering_required_permission
-        except AttributeError:
-            pass
-        else:
+        permission_name = getattr(self, "queryset_filtering_required_permission", None)
+        if permission_name:
             qs = get_objects_for_user(self.request.user, permission_name, klass=qs)
+
         return qs
 
     @classmethod


### PR DESCRIPTION
Allow plugins to set `queryset_filtering_required_permission` attribute to
`None` and have it behave the same way as if the attribute were not present.

fixes #8438
https://pulp.plan.io/issues/8438