### PR TITLE
Remove checksum filtering in Remote.get_downloader and add checksum t…

### DIFF
--- a/CHANGES/plugin_api/8435.feature
+++ b/CHANGES/plugin_api/8435.feature
@@ -1,0 +1,1 @@
+Added checksum type enforcement to ``pulpcore.plugin.download.BaseDownloader``.

--- a/CHANGES/plugin_api/8435.removal
+++ b/CHANGES/plugin_api/8435.removal
@@ -1,0 +1,1 @@
+Removed checksum type filtering from ``pulpcore.plugin.models.Remote.get_downloader`` and ``pulpcore.plugin.stages.DeclarativeArtifact.download``.

--- a/pulpcore/app/models/repository.py
+++ b/pulpcore/app/models/repository.py
@@ -13,6 +13,7 @@ from django.db import models, transaction
 from django.urls import reverse
 
 from pulpcore.app.util import batch_qs, get_view_name_for_model
+from pulpcore.constants import ALL_KNOWN_CONTENT_CHECKSUMS
 from pulpcore.download.factory import DownloaderFactory
 from pulpcore.exceptions import ResourceImmutableError
 
@@ -349,7 +350,7 @@ class Remote(MasterModel):
         if remote_artifact:
             url = remote_artifact.url
             expected_digests = {}
-            for digest_name in Artifact.DIGEST_FIELDS:
+            for digest_name in ALL_KNOWN_CONTENT_CHECKSUMS:
                 digest_value = getattr(remote_artifact, digest_name)
                 if digest_value:
                     expected_digests[digest_name] = digest_value

--- a/pulpcore/plugin/stages/models.py
+++ b/pulpcore/plugin/stages/models.py
@@ -2,6 +2,7 @@ from gettext import gettext as _
 
 import asyncio
 
+from pulpcore.constants import ALL_KNOWN_CONTENT_CHECKSUMS
 from pulpcore.plugin.models import Artifact
 
 
@@ -74,7 +75,7 @@ class DeclarativeArtifact:
         """
         expected_digests = {}
         validation_kwargs = {}
-        for digest_name in self.artifact.DIGEST_FIELDS:
+        for digest_name in ALL_KNOWN_CONTENT_CHECKSUMS:
             digest_value = getattr(self.artifact, digest_name)
             if digest_value:
                 expected_digests[digest_name] = digest_value

--- a/pulpcore/tests/unit/download/test_download_base.py
+++ b/pulpcore/tests/unit/download/test_download_base.py
@@ -1,0 +1,60 @@
+from unittest import mock
+
+from django.test import TestCase
+
+from pulpcore.download import BaseDownloader
+from pulpcore.plugin.exceptions import UnsupportedDigestValidationError
+
+
+class BaseDownloaderInitTestCase(TestCase):
+    @mock.patch(
+        "pulpcore.app.models.Artifact.DIGEST_FIELDS",
+        new_callable=mock.PropertyMock,
+        return_value=set(["sha512", "sha256"]),
+    )
+    def test_no_trusted_digest(self, mock_DIGEST_FIELDS):
+        url = "http://example.com"
+        with self.assertRaises(UnsupportedDigestValidationError):
+            BaseDownloader(
+                url,
+                custom_file_object=None,
+                expected_digests={"sha1": "912ec803b2ce49e4a541068d495ab570"},
+                expected_size=None,
+                semaphore=None,
+            )
+
+    @mock.patch(
+        "pulpcore.app.models.Artifact.DIGEST_FIELDS",
+        new_callable=mock.PropertyMock,
+        return_value=set(["sha512", "sha256"]),
+    )
+    def test_no_expected_digests(self, mock_DIGEST_FIELDS):
+        url = "http://example.com"
+        downloader = BaseDownloader(
+            url,
+            custom_file_object=None,
+            expected_digests=None,
+            expected_size=None,
+            semaphore=None,
+        )
+        assert downloader.expected_digests is None
+
+    @mock.patch(
+        "pulpcore.app.models.Artifact.DIGEST_FIELDS",
+        new_callable=mock.PropertyMock,
+        return_value=set(["sha512", "sha256"]),
+    )
+    def test_expected_digests(self, mock_DIGEST_FIELDS):
+        url = "http://example.com"
+        digests = {
+            "sha1": "912ec803b2ce49e4a541068d495ab570",
+            "sha256": "b361886f33f1b6089626dc8bd80961356f9a2911091ecb2ffa33730beb83bbdb",
+        }
+        downloader = BaseDownloader(
+            url,
+            custom_file_object=None,
+            expected_digests=digests,
+            expected_size=None,
+            semaphore=None,
+        )
+        assert downloader.expected_digests == digests


### PR DESCRIPTION
…ype enforcement to downloaders itself

closes #8435

Please be sure you have read our documentation on creating PRs:
https://docs.pulpproject.org/contributing/pull-request-walkthrough.html
