### PR TITLE
RemoteArtifacts checksum type check

### DIFF
--- a/CHANGES/8423.feature
+++ b/CHANGES/8423.feature
@@ -1,0 +1,1 @@
+Added sync check that raises error when only forbidden checksums are found for on-demand content.

--- a/pulpcore/plugin/stages/artifact_stages.py
+++ b/pulpcore/plugin/stages/artifact_stages.py
@@ -323,7 +323,7 @@ class RemoteArtifactSaver(Stage):
 
     @staticmethod
     def _create_remote_artifact(d_artifact, content_artifact):
-        return RemoteArtifact(
+        ra = RemoteArtifact(
             url=d_artifact.url,
             size=d_artifact.artifact.size,
             md5=d_artifact.artifact.md5,
@@ -335,3 +335,5 @@ class RemoteArtifactSaver(Stage):
             content_artifact=content_artifact,
             remote=d_artifact.remote,
         )
+        ra.validate_checksums()
+        return ra


### PR DESCRIPTION
RemoteArtifacts are checked for forbidden checksums.

closes: #8423
https://pulp.plan.io/issues/8423
