### PR TITLE
Deprecates BaseDistribution and related objects

### DIFF
--- a/CHANGES/plugin_api/8385.deprecation
+++ b/CHANGES/plugin_api/8385.deprecation
@@ -1,0 +1,21 @@
+The following objects were deprecated:
+* ``pulpcore.plugin.models.BaseDistribution`` -- Instead use
+  ``pulpcore.plugin.models.Distribution``.
+* ``pulpcore.plugin.viewset.BaseDistributionViewSet`` -- Instead use
+  ``pulpcore.plugin.viewset.DistributionViewSet``.
+* ``pulpcore.plugin.serializer.BaseDistributionSerializer`` -- Instead use
+  ``pulpcore.plugin.serializer.DistributionSerializer``.
+* ``pulpcore.plugin.serializer.PublicationDistributionSerializer`` -- Instead use define the
+  ``publication`` field directly on your detail distribution object. See the docstring for
+  ``pulpcore.plugin.serializer.DistributionSerializer`` for an example.
+* ``pulpcore.plugin.serializer.RepositoryVersionDistributionSerializer`` -- Instead use define the
+  ``repository_version`` field directly on your detail distribution object. See the docstring for
+  ``pulpcore.plugin.serializer.DistributionSerializer`` for an example.
+* ``pulpcore.plugin.viewset.DistributionFilter`` -- Instead use
+  ``pulpcore.plugin.viewset.NewDistributionFilter``.
+
+.. note::
+
+    You will have to define a migration to move your data from
+    ``pulpcore.plugin.models.BaseDistribution`` to ``pulpcore.plugin.models.Distribution``. See the
+    pulp_file migration 0009 as a reference example.

--- a/pulpcore/app/models/publication.py
+++ b/pulpcore/app/models/publication.py
@@ -1,3 +1,6 @@
+from gettext import gettext as _
+import warnings
+
 from django.db import IntegrityError, models, transaction
 
 from .base import MasterModel, BaseModel
@@ -285,6 +288,17 @@ class BaseDistribution(MasterModel):
 
     content_guard = models.ForeignKey(ContentGuard, null=True, on_delete=models.SET_NULL)
     remote = models.ForeignKey(Remote, null=True, on_delete=models.SET_NULL)
+
+    def __init__(self, *args, **kwargs):
+        """ Initialize a BaseDistribution and emit DeprecationWarnings"""
+        warnings.warn(
+            _(
+                "BaseDistribution is deprecated and could be removed as early as pulpcore==3.13; "
+                "use pulpcore.plugin.models.Distribution instead."
+            ),
+            DeprecationWarning,
+        )
+        return super().__init__(*args, **kwargs)
 
     def content_handler(self, path):
         """

--- a/pulpcore/app/serializers/publication.py
+++ b/pulpcore/app/serializers/publication.py
@@ -1,4 +1,5 @@
 from gettext import gettext as _
+import warnings
 
 from django.db.models import Q
 from rest_framework import serializers
@@ -129,6 +130,17 @@ class BaseDistributionSerializer(ModelSerializer):
             "name",
         )
 
+    def __init__(self, *args, **kwargs):
+        """ Initialize a BaseDistributionSerializer and emit DeprecationWarnings"""
+        warnings.warn(
+            _(
+                "BaseDistributionSerializer is deprecated and could be removed as early as "
+                "pulpcore==3.13; use pulpcore.plugin.serializers.DistributionSerializer instead."
+            ),
+            DeprecationWarning,
+        )
+        return super().__init__(*args, **kwargs)
+
     def _validate_path_overlap(self, path):
         # look for any base paths nested in path
         search = path.split("/")[0]
@@ -166,6 +178,18 @@ class PublicationDistributionSerializer(BaseDistributionSerializer):
         allow_null=True,
     )
 
+    def __init__(self, *args, **kwargs):
+        """ Initialize a PublicationDistributionSerializer and emit DeprecationWarnings"""
+        warnings.warn(
+            _(
+                "PublicationDistributionSerializer is deprecated and could be removed as early as "
+                "pulpcore==3.13; use pulpcore.plugin.serializers.DistributionSerializer instead. "
+                "See its docstring for more details."
+            ),
+            DeprecationWarning,
+        )
+        return super().__init__(*args, **kwargs)
+
     class Meta:
         abstract = True
         fields = BaseDistributionSerializer.Meta.fields + ("publication",)
@@ -182,6 +206,18 @@ class RepositoryVersionDistributionSerializer(BaseDistributionSerializer):
     repository_version = RepositoryVersionRelatedField(
         required=False, help_text=_("RepositoryVersion to be served"), allow_null=True
     )
+
+    def __init__(self, *args, **kwargs):
+        """ Initialize a RepositoryVersionDistributionSerializer and emit DeprecationWarnings"""
+        warnings.warn(
+            _(
+                "PublicationDistributionSerializer is deprecated and could be removed as early as "
+                "pulpcore==3.13; use pulpcore.plugin.serializers.DistributionSerializer instead. "
+                "See its docstring for more details."
+            ),
+            DeprecationWarning,
+        )
+        return super().__init__(*args, **kwargs)
 
     class Meta:
         abstract = True

--- a/pulpcore/app/viewsets/publication.py
+++ b/pulpcore/app/viewsets/publication.py
@@ -1,3 +1,6 @@
+from gettext import gettext as _
+import warnings
+
 from django_filters.rest_framework import DjangoFilterBackend, filters
 from rest_framework import mixins
 from rest_framework.filters import OrderingFilter
@@ -98,6 +101,17 @@ class DistributionFilter(BaseFilterSet):
     base_path = filters.CharFilter()
     pulp_label_select = LabelSelectFilter()
 
+    def __init__(self, *args, **kwargs):
+        """ Initialize a DistributionFilter and emit DeprecationWarnings"""
+        warnings.warn(
+            _(
+                "DistributionFilter is deprecated and could be removed as early as "
+                "pulpcore==3.13; use pulpcore.plugin.serializers.NewDistributionFilter instead."
+            ),
+            DeprecationWarning,
+        )
+        return super().__init__(*args, **kwargs)
+
     class Meta:
         model = BaseDistribution
         fields = {
@@ -124,6 +138,17 @@ class BaseDistributionViewSet(
     queryset = BaseDistribution.objects.all()
     serializer_class = BaseDistributionSerializer
     filterset_class = DistributionFilter
+
+    def __init__(self, *args, **kwargs):
+        """ Initialize a BaseDistributionViewSet and emit DeprecationWarnings"""
+        warnings.warn(
+            _(
+                "BaseDistributionViewSet is deprecated and could be removed as early as "
+                "pulpcore==3.13; use pulpcore.plugin.viewsets.DistributionViewset instead."
+            ),
+            DeprecationWarning,
+        )
+        return super().__init__(*args, **kwargs)
 
     def async_reserved_resources(self, instance):
         """Return resource that locks all Distributions."""


### PR DESCRIPTION
This deprecates the following objects and adds warnings when they are
used:

* `pulpcore.plugin.models.BaseDistribution`
* `pulpcore.plugin.viewset.BaseDistributionViewSet`
* `pulpcore.plugin.viewset.DistributionFilter`
* `pulpcore.plugin.serializer.BaseDistributionSerializer`
* `pulpcore.plugin.serializer.PublicationDistributionSerializer`
* `pulpcore.plugin.serializer.RepositoryVersionDistributionSerializer`

closes #8385

