### PR TITLE
Fixed distributions not being viewable in content app

### DIFF
--- a/CHANGES/8475.bugfix
+++ b/CHANGES/8475.bugfix
@@ -1,0 +1,1 @@
+Distributions are now viewable again at the base url of the content app

--- a/pulpcore/content/handler.py
+++ b/pulpcore/content/handler.py
@@ -119,7 +119,7 @@ class Handler:
             base_paths = list(BaseDistribution.objects.values_list("base_path", flat=True))
         else:
             base_paths = list(self.distribution_model.objects.values_list("base_path", flat=True))
-        directory_list = ["{}/".format(d.base_path) for d in base_paths]
+        directory_list = ["{}/".format(base_path) for base_path in base_paths]
         return HTTPOk(headers={"Content-Type": "text/html"}, body=self.render_html(directory_list))
 
     async def stream_content(self, request):

--- a/pulpcore/tests/functional/api/using_plugin/constants.py
+++ b/pulpcore/tests/functional/api/using_plugin/constants.py
@@ -13,6 +13,10 @@ from pulp_smash.pulp3.constants import (
 
 PULP_FIXTURES_BASE_URL = config.get_config().get_fixtures_url()
 
+PULP_CONTENT_HOST_BASE_URL = config.get_config().get_content_host_base_url()
+
+PULP_CONTENT_BASE_URL = urljoin(PULP_CONTENT_HOST_BASE_URL, "pulp/content/")
+
 FILE_CONTENT_NAME = "file.file"
 
 FILE_CONTENT_PATH = urljoin(BASE_CONTENT_PATH, "file/files/")


### PR DESCRIPTION
fixes: #8475
https://pulp.plan.io/issues/8475

This fixes a regression that was introduce here https://github.com/pulp/pulpcore/commit/a9a536a2765ce84fc863434047496343e01cc040.  This should be backported to 3.11

Please be sure you have read our documentation on creating PRs:
https://docs.pulpproject.org/contributing/pull-request-walkthrough.html
