### PR TITLE
Fixed artifact_stages edge case for multi-artifact/multi-remote batches.

### DIFF
--- a/CHANGES/8377.bugfix
+++ b/CHANGES/8377.bugfix
@@ -1,0 +1,1 @@
+Fixed artifact-stage to handle an edge-case when multiple multi-artifact content, from different remotes, is in a single batch.

--- a/pulpcore/plugin/stages/artifact_stages.py
+++ b/pulpcore/plugin/stages/artifact_stages.py
@@ -303,8 +303,11 @@ class RemoteArtifactSaver(Stage):
         )
         needed_ras = []
         for d_content in batch:
-            for content_artifact in d_content.content._remote_artifact_saver_cas:
-                for d_artifact in d_content.d_artifacts:
+            for d_artifact in d_content.d_artifacts:
+                if not d_artifact.remote:
+                    continue
+
+                for content_artifact in d_content.content._remote_artifact_saver_cas:
                     if d_artifact.relative_path == content_artifact.relative_path:
                         break
                 else:
@@ -312,13 +315,13 @@ class RemoteArtifactSaver(Stage):
                     raise ValueError(
                         msg.format(rp=content_artifact.relative_path, c=d_content.content)
                     )
-                if d_artifact.remote:
-                    for remote_artifact in content_artifact._remote_artifact_saver_ras:
-                        if remote_artifact.remote_id == d_artifact.remote.pk:
-                            break
-                    else:
-                        remote_artifact = self._create_remote_artifact(d_artifact, content_artifact)
-                        needed_ras.append(remote_artifact)
+
+                for remote_artifact in content_artifact._remote_artifact_saver_ras:
+                    if remote_artifact.remote_id == d_artifact.remote.pk:
+                        break
+                else:
+                    remote_artifact = self._create_remote_artifact(d_artifact, content_artifact)
+                    needed_ras.append(remote_artifact)
         return needed_ras
 
     @staticmethod


### PR DESCRIPTION
Only encountered while 2to3-migrating specific content in specific orders.

fixes #8377
[nocoverage]

