### PR TITLE
Adds new `dispatch` call and deprecate the old one

### DIFF
--- a/CHANGES/plugin_api/8496.deprecation
+++ b/CHANGES/plugin_api/8496.deprecation
@@ -1,0 +1,2 @@
+Deprecated the ``pulpcore.plugin.tasking.enqueue_with_reservation``. Instead use the
+``pulpcore.plugin.tasking.dispatch`` interface.

--- a/CHANGES/plugin_api/8496.feature
+++ b/CHANGES/plugin_api/8496.feature
@@ -1,0 +1,7 @@
+Adds the ``pulpcore.plugin.tasking.dispatch`` interface which replcaes the
+``pulpcore.plugin.tasking.enqueue_with_reservation`` interface. It is the same except:
+* It returns a ``pulpcore.plugin.models.Task`` instead of an RQ object
+* It does not support the ``options`` keyword argument
+
+Additionally the ``pulpcore.plugin.viewsets.OperationPostponedResponse`` was updated to support both
+the ``dispatch`` and ``enqueue_with_reservation`` interfaces.

--- a/CHANGES/plugin_api/8496.feature
+++ b/CHANGES/plugin_api/8496.feature
@@ -1,4 +1,4 @@
-Adds the ``pulpcore.plugin.tasking.dispatch`` interface which replcaes the
+Adds the ``pulpcore.plugin.tasking.dispatch`` interface which replaces the
 ``pulpcore.plugin.tasking.enqueue_with_reservation`` interface. It is the same except:
 * It returns a ``pulpcore.plugin.models.Task`` instead of an RQ object
 * It does not support the ``options`` keyword argument

--- a/docs/plugins/plugin-writer/concepts/subclassing/viewsets.rst
+++ b/docs/plugins/plugin-writer/concepts/subclassing/viewsets.rst
@@ -62,7 +62,7 @@ Kick off Tasks
 Some endpoints may need to deploy tasks to the tasking system. The following is an example of how
 this is accomplished.
 
-See :class:`~pulpcore.plugin.tasking.enqueue_with_reservation` for more details.
+See :class:`~pulpcore.plugin.tasking.dispatch` for more details.
 
 .. code-block:: python
 
@@ -82,7 +82,7 @@ See :class:`~pulpcore.plugin.tasking.enqueue_with_reservation` for more details.
             mirror = serializer.validated_data.get('mirror', False)
 
             # This is how tasks are kicked off.
-            result = enqueue_with_reservation(
+            result = dispatch(
                 tasks.synchronize,
                 [repository, remote],
                 kwargs={

--- a/pulpcore/app/models/publication.py
+++ b/pulpcore/app/models/publication.py
@@ -290,7 +290,7 @@ class BaseDistribution(MasterModel):
     remote = models.ForeignKey(Remote, null=True, on_delete=models.SET_NULL)
 
     def __init__(self, *args, **kwargs):
-        """ Initialize a BaseDistribution and emit DeprecationWarnings"""
+        """ Initialize a BaseDistribution and emit deprecation warnings"""
         deprecation_logger.warn(
             _(
                 "BaseDistribution is deprecated and could be removed as early as pulpcore==3.13; "

--- a/pulpcore/app/response.py
+++ b/pulpcore/app/response.py
@@ -15,11 +15,17 @@ class OperationPostponedResponse(Response):
         }
     """
 
-    def __init__(self, result, request):
+    def __init__(self, task, request):
         """
         Args:
-            result (rq.job.Job): A :class:`rq.job.Job` object used to generate the response.
+            task (pulpcore.plugin.models.Task or rq.job.Job): A
+                :class:`~pulpcore.plugin.models.Task` or :class:`rq.job.Job` object used to generate
+                the response.
             request (rest_framework.request.Request): Request used to generate the pulp_href urls
         """
-        resp = {"task": reverse("tasks-detail", args=[result.id], request=None)}
+        try:
+            pk = task.id  # task is of type RQ.job
+        except AttributeError:
+            pk = task.pk  # task is of type pulpcore.models.Task
+        resp = {"task": reverse("tasks-detail", args=[pk], request=None)}
         super().__init__(data=resp, status=202)

--- a/pulpcore/app/serializers/publication.py
+++ b/pulpcore/app/serializers/publication.py
@@ -155,7 +155,7 @@ class BaseDistributionSerializer(ModelSerializer, BasePathOverlapMixin):
     )
 
     def __init__(self, *args, **kwargs):
-        """ Initialize a BaseDistributionSerializer and emit DeprecationWarnings"""
+        """ Initialize a BaseDistributionSerializer and emit deprecation warnings"""
         deprecation_logger.warn(
             _(
                 "BaseDistributionSerializer is deprecated and could be removed as early as "
@@ -297,7 +297,7 @@ class PublicationDistributionSerializer(BaseDistributionSerializer):
     )
 
     def __init__(self, *args, **kwargs):
-        """ Initialize a PublicationDistributionSerializer and emit DeprecationWarnings"""
+        """ Initialize a PublicationDistributionSerializer and emit deprecation warnings"""
         deprecation_logger.warn(
             _(
                 "PublicationDistributionSerializer is deprecated and could be removed as early as "
@@ -325,7 +325,7 @@ class RepositoryVersionDistributionSerializer(BaseDistributionSerializer):
     )
 
     def __init__(self, *args, **kwargs):
-        """ Initialize a RepositoryVersionDistributionSerializer and emit DeprecationWarnings"""
+        """ Initialize a RepositoryVersionDistributionSerializer and emit deprecation warnings"""
         deprecation_logger.warn(
             _(
                 "PublicationDistributionSerializer is deprecated and could be removed as early as "

--- a/pulpcore/app/tasks/importer.py
+++ b/pulpcore/app/tasks/importer.py
@@ -34,7 +34,7 @@ from pulpcore.app.modelresource import (
     ContentArtifactResource,
 )
 from pulpcore.constants import TASK_STATES
-from pulpcore.tasking.tasks import enqueue_with_reservation
+from pulpcore.tasking.tasks import dispatch
 
 log = getLogger(__name__)
 
@@ -403,7 +403,7 @@ def pulp_import(importer_pk, path, toc):
                     )
                     continue
 
-                enqueue_with_reservation(
+                dispatch(
                     import_repository_version,
                     [dest_repo],
                     args=[importer.pk, dest_repo.pk, src_repo["name"], path],

--- a/pulpcore/app/views/orphans.py
+++ b/pulpcore/app/views/orphans.py
@@ -4,7 +4,7 @@ from rest_framework.views import APIView
 from pulpcore.app.response import OperationPostponedResponse
 from pulpcore.app.serializers import AsyncOperationResponseSerializer
 from pulpcore.app.tasks import orphan_cleanup
-from pulpcore.tasking.tasks import enqueue_with_reservation
+from pulpcore.tasking.tasks import dispatch
 
 
 class OrphansView(APIView):
@@ -18,6 +18,6 @@ class OrphansView(APIView):
         """
         Cleans up all the Content and Artifact orphans in the system
         """
-        async_result = enqueue_with_reservation(orphan_cleanup, [])
+        task = dispatch(orphan_cleanup, [])
 
-        return OperationPostponedResponse(async_result, request)
+        return OperationPostponedResponse(task, request)

--- a/pulpcore/app/views/repair.py
+++ b/pulpcore/app/views/repair.py
@@ -4,7 +4,7 @@ from rest_framework.views import APIView
 from pulpcore.app.response import OperationPostponedResponse
 from pulpcore.app.serializers import AsyncOperationResponseSerializer, RepairSerializer
 from pulpcore.app.tasks import repair_all_artifacts
-from pulpcore.tasking.tasks import enqueue_with_reservation
+from pulpcore.tasking.tasks import dispatch
 
 
 class RepairView(APIView):
@@ -25,6 +25,6 @@ class RepairView(APIView):
 
         verify_checksums = serializer.validated_data["verify_checksums"]
 
-        async_result = enqueue_with_reservation(repair_all_artifacts, [], args=[verify_checksums])
+        task = dispatch(repair_all_artifacts, [], args=[verify_checksums])
 
-        return OperationPostponedResponse(async_result, request)
+        return OperationPostponedResponse(task, request)

--- a/pulpcore/app/viewsets/exporter.py
+++ b/pulpcore/app/viewsets/exporter.py
@@ -27,7 +27,7 @@ from pulpcore.app.viewsets import (
     NamedModelViewSet,
 )
 from pulpcore.app.viewsets.base import NAME_FILTER_OPTIONS
-from pulpcore.plugin.tasking import enqueue_with_reservation
+from pulpcore.plugin.tasking import dispatch
 from pulpcore.app.response import OperationPostponedResponse
 
 
@@ -132,6 +132,6 @@ class PulpExportViewSet(ExportViewSet):
         export.validated_start_versions = serializer.validated_data.get("start_versions", None)
         export.validated_chunk_size = serializer.validated_data.get("chunk_size", None)
 
-        result = enqueue_with_reservation(pulp_export, [exporter], kwargs={"the_export": export})
+        task = dispatch(pulp_export, [exporter], kwargs={"the_export": export})
 
-        return OperationPostponedResponse(result, request)
+        return OperationPostponedResponse(task, request)

--- a/pulpcore/app/viewsets/importer.py
+++ b/pulpcore/app/viewsets/importer.py
@@ -23,7 +23,7 @@ from pulpcore.app.viewsets import (
     NamedModelViewSet,
 )
 from pulpcore.app.viewsets.base import NAME_FILTER_OPTIONS
-from pulpcore.tasking.tasks import enqueue_with_reservation
+from pulpcore.tasking.tasks import dispatch
 
 
 class ImporterFilter(BaseFilterSet):
@@ -104,7 +104,7 @@ class PulpImportViewSet(ImportViewSet):
         serializer.is_valid(raise_exception=True)
         path = serializer.validated_data.get("path")
         toc = serializer.validated_data.get("toc")
-        result = enqueue_with_reservation(
+        task = dispatch(
             pulp_import, [importer], kwargs={"importer_pk": importer.pk, "path": path, "toc": toc}
         )
-        return OperationPostponedResponse(result, request)
+        return OperationPostponedResponse(task, request)

--- a/pulpcore/app/viewsets/publication.py
+++ b/pulpcore/app/viewsets/publication.py
@@ -103,7 +103,7 @@ class DistributionFilter(BaseFilterSet):
     pulp_label_select = LabelSelectFilter()
 
     def __init__(self, *args, **kwargs):
-        """ Initialize a DistributionFilter and emit DeprecationWarnings"""
+        """ Initialize a DistributionFilter and emit deprecation warnings"""
         deprecation_logger.warn(
             _(
                 "DistributionFilter is deprecated and could be removed as early as "
@@ -158,7 +158,7 @@ class BaseDistributionViewSet(
     filterset_class = DistributionFilter
 
     def __init__(self, *args, **kwargs):
-        """ Initialize a BaseDistributionViewSet and emit DeprecationWarnings"""
+        """ Initialize a BaseDistributionViewSet and emit deprecation warnings"""
         deprecation_logger.warn(
             _(
                 "BaseDistributionViewSet is deprecated and could be removed as early as "

--- a/pulpcore/app/viewsets/upload.py
+++ b/pulpcore/app/viewsets/upload.py
@@ -15,7 +15,7 @@ from pulpcore.app.serializers import (
     UploadDetailSerializer,
 )
 from pulpcore.app.viewsets.base import NamedModelViewSet
-from pulpcore.tasking.tasks import enqueue_with_reservation
+from pulpcore.tasking.tasks import dispatch
 
 
 class UploadViewSet(
@@ -95,7 +95,5 @@ class UploadViewSet(
         sha256 = serializer.validated_data["sha256"]
 
         upload = self.get_object()
-        async_result = enqueue_with_reservation(
-            tasks.upload.commit, [upload], args=(upload.pk, sha256)
-        )
-        return OperationPostponedResponse(async_result, request)
+        task = dispatch(tasks.upload.commit, [upload], args=(upload.pk, sha256))
+        return OperationPostponedResponse(task, request)

--- a/pulpcore/plugin/actions.py
+++ b/pulpcore/plugin/actions.py
@@ -8,7 +8,7 @@ from pulpcore.app.serializers import (
     AsyncOperationResponseSerializer,
     RepositoryAddRemoveContentSerializer,
 )
-from pulpcore.tasking.tasks import enqueue_with_reservation
+from pulpcore.tasking.tasks import dispatch
 
 
 __all__ = ["ModifyRepositoryActionMixin"]
@@ -50,7 +50,7 @@ class ModifyRepositoryActionMixin:
                     content = self.get_resource(url, Content)
                     remove_content_units.append(content.pk)
 
-        result = enqueue_with_reservation(
+        task = dispatch(
             tasks.repository.add_and_remove,
             [repository],
             kwargs={
@@ -60,4 +60,4 @@ class ModifyRepositoryActionMixin:
                 "remove_content_units": remove_content_units,
             },
         )
-        return OperationPostponedResponse(result, request)
+        return OperationPostponedResponse(task, request)

--- a/pulpcore/plugin/tasking.py
+++ b/pulpcore/plugin/tasking.py
@@ -1,5 +1,6 @@
 # Support plugins dispatching tasks
 from pulpcore.tasking.tasks import enqueue_with_reservation  # noqa
+from pulpcore.tasking.tasks import dispatch  # noqa
 
 # Support plugins working with the working directory.
 from pulpcore.tasking.storage import WorkingDirectory  # noqa

--- a/pulpcore/tasking/storage.py
+++ b/pulpcore/tasking/storage.py
@@ -190,7 +190,7 @@ class WorkingDirectory(_WorkingDir):
         """
         deprecation_logger.warn(
             _(
-                "WorkingDirectory is deprecated and will be removed in pulpcore==3.12; "
+                "WorkingDirectory is deprecated and will be removed in pulpcore==3.13; "
                 'use tempfile.TemporaryDirectory(dir=".") instead.'
             )
         )


### PR DESCRIPTION
This adds a new `pulpcore.plugin.tasking.dispatch` interface which will
replace the `pulpcore.plugin.tasking.enqueue_with_reservation`
interface. This also deprecates the
`pulpcore.plugin.tasking.enqueue_with_reservation` and causes it to
emit warnings if used.

Additionally the `pulpcore.plugin.viewsets.OperationPostponedResponse`
has been ported to support both the `dispatch` and
`enqueue_with_reservation` interfaces.

closes #8496

