### PR TITLE
Pass the request's context to the serializers

### DIFF
--- a/CHANGES/8396.bugfix
+++ b/CHANGES/8396.bugfix
@@ -1,0 +1,1 @@
+Fixed an issue that caused the request's context to be ignored in the serializers.

--- a/pulpcore/app/serializers/task.py
+++ b/pulpcore/app/serializers/task.py
@@ -12,7 +12,7 @@ from pulpcore.app.serializers import (
     TaskGroupStatusCountField,
 )
 from pulpcore.constants import TASK_STATES
-from pulpcore.app.util import get_viewset_for_model
+from pulpcore.app.util import get_viewset_for_model, get_request_without_query_params
 
 
 class CreatedResourceSerializer(RelatedField):
@@ -29,19 +29,11 @@ class CreatedResourceSerializer(RelatedField):
         # query parameters can be ignored because we are looking just for 'pulp_href'; still,
         # we need to use the request object due to contextual references required by some
         # serializers
-        request = self._get_request_without_query_params()
+        request = get_request_without_query_params(self.context)
 
         viewset = get_viewset_for_model(data.content_object)
         serializer = viewset.serializer_class(data.content_object, context={"request": request})
         return serializer.data.get("pulp_href")
-
-    def _get_request_without_query_params(self):
-        """Remove all query parameters from the request object."""
-        request = self.context["request"]
-        request.query_params._mutable = True
-        request.query_params.clear()
-        request.query_params._mutable = False
-        return request
 
     class Meta:
         model = models.CreatedResource

--- a/pulpcore/app/serializers/user.py
+++ b/pulpcore/app/serializers/user.py
@@ -7,7 +7,7 @@ from guardian.models.models import GroupObjectPermission
 from rest_framework import serializers
 
 from pulpcore.app.serializers import IdentityField, ValidateFieldsMixin
-from pulpcore.app.util import get_viewset_for_model
+from pulpcore.app.util import get_viewset_for_model, get_request_without_query_params
 
 
 class PermissionField(serializers.CharField):
@@ -25,7 +25,10 @@ class ContentObjectField(serializers.CharField):
         content_object = getattr(obj, "content_object", None)
         if content_object:
             viewset = get_viewset_for_model(obj.content_object)
-            serializer = viewset.serializer_class(obj.content_object, context={"request": None})
+
+            request = get_request_without_query_params(self.context)
+
+            serializer = viewset.serializer_class(obj.content_object, context={"request": request})
             return serializer.data.get("pulp_href")
 
 

--- a/pulpcore/app/util.py
+++ b/pulpcore/app/util.py
@@ -127,3 +127,35 @@ def get_view_urlpattern(view):
     if hasattr(view, "parent_viewset") and view.parent_viewset:
         return os.path.join(view.parent_viewset.urlpattern(), view.urlpattern())
     return view.urlpattern()
+
+
+def get_request_without_query_params(context):
+    """
+    Remove query parameters from a request object.
+
+    Removing query parameters should not influence the features provided by the library
+    'djangorestframework-queryfields'. But, once a user selects which fields should be sent in the
+    API response, any other fields are going to be filtered out even though they are still required
+    for serialization purposes in the future.
+
+    Some serializers need to be aware of the context that triggered the operation. For example, when
+    a Task is serialized, created resources need to be serialized as well. Missing context lead to
+    invalid serialization if the created resources do not have knowledge about the initial request.
+
+    This method modifies the request object in-place, meaning that all other objects that reference
+    this object may be affected.
+
+    Args:
+        context (dict): A context containing the request object.
+
+    Returns:
+        rest_framework.request.Request: a request object without query parameters
+    """
+    request = context.get("request")
+
+    if request is not None:
+        request.query_params._mutable = True
+        request.query_params.clear()
+        request.query_params._mutable = False
+
+    return request

--- a/pulpcore/app/viewsets/user.py
+++ b/pulpcore/app/viewsets/user.py
@@ -65,7 +65,9 @@ class UserViewSet(NamedModelViewSet, mixins.RetrieveModelMixin, mixins.ListModel
         List user permissions.
         """
         user = self.get_object()
-        object_permission = PermissionSerializer(user.userobjectpermission_set.all(), many=True)
+        object_permission = PermissionSerializer(
+            user.userobjectpermission_set.all(), many=True, context={"request": request}
+        )
         permissions = PermissionSerializer(user.user_permissions.all(), many=True)
         return Response(object_permission.data + permissions.data)
 
@@ -293,7 +295,9 @@ class GroupObjectPermissionViewSet(NamedModelViewSet):
     @extend_schema(description="Retrieve a model permission from a group.")
     def retrieve(self, request, group_pk, pk):
         instance = get_object_or_404(GroupObjectPermission, pk=pk)
-        serializer = PermissionSerializer(instance, context={"group_pk": group_pk})
+        serializer = PermissionSerializer(
+            instance, context={"group_pk": group_pk, "request": request}
+        )
         return Response(serializer.data)
 
     @extend_schema(
@@ -308,10 +312,14 @@ class GroupObjectPermissionViewSet(NamedModelViewSet):
 
         page = self.paginate_queryset(queryset)
         if page is not None:
-            serializer = PermissionSerializer(page, context={"group_pk": group_pk}, many=True)
+            serializer = PermissionSerializer(
+                page, context={"group_pk": group_pk, "request": request}, many=True
+            )
             return self.get_paginated_response(serializer.data)
 
-        serializer = PermissionSerializer(queryset, context={"group_pk": group_pk}, many=True)
+        serializer = PermissionSerializer(
+            queryset, context={"group_pk": group_pk, "request": request}, many=True
+        )
         return Response(serializer.data)
 
     @extend_schema(
@@ -331,7 +339,9 @@ class GroupObjectPermissionViewSet(NamedModelViewSet):
             object_pk=object_pk,
         )
         object_permission.save()
-        serializer = PermissionSerializer(object_permission, context={"group_pk": group_pk})
+        serializer = PermissionSerializer(
+            object_permission, context={"group_pk": group_pk, "request": request}
+        )
         return Response(serializer.data, status=status.HTTP_201_CREATED)
 
     @extend_schema(description="Remove an object permission from a group.")
@@ -394,7 +404,7 @@ class GroupUserViewSet(NamedModelViewSet):
 
         page = self.paginate_queryset(queryset)
         if page is not None:
-            serializer = GroupUserSerializer(page, context={"request": None}, many=True)
+            serializer = GroupUserSerializer(page, context={"request": request}, many=True)
             return self.get_paginated_response(serializer.data)
 
         serializer = self.get_serializer(queryset, many=True)
@@ -415,7 +425,7 @@ class GroupUserViewSet(NamedModelViewSet):
             raise ValidationError(str(exc))
         group.user_set.add(user)
         group.save()
-        serializer = GroupUserSerializer(user, context={"request": None})
+        serializer = GroupUserSerializer(user, context={"request": request})
         return Response(serializer.data, status=status.HTTP_201_CREATED)
 
     def destroy(self, request, group_pk, pk):


### PR DESCRIPTION
In pulp_container, we are relying on the request's context when retrieving the host from a URL in ContainerDistributionSerializer. Since object-level permissions are tied to specific objects, the linked error was triggered only during the serialization of ContainerDistribution objects. Similarly, when a user tried to list permissions which contained task permissions, the missing context caused CreatedResourceSerializer to raise an internal error.

As of this commit, all RBAC-related serializers can benefit from the initial request's context.

closes #8396
