### PR TITLE
Non-JSON serializable args and kwargs deprecated

### DIFF
--- a/CHANGES/plugin_api/8505.deprecation
+++ b/CHANGES/plugin_api/8505.deprecation
@@ -1,0 +1,3 @@
+The usage of non-JSON serializable types of ``args`` and ``kwargs`` to tasks is deprecated. Future
+releases of pulpcore may discontinue accepting complex argument types. Note, UUID objects are not
+JSON serializable. A deprecated warning is logged if a non-JSON serializable is used.


### PR DESCRIPTION
The use of non-JSON serializable `args` and `kwargs` is now deprecated.

closes #8505
