### PR TITLE
Fix missing REDIS_SSL parameter in rqconfig.py

### DIFF
--- a/CHANGES/8525.bugfix
+++ b/CHANGES/8525.bugfix
@@ -1,0 +1,1 @@
+Fixed missing ``REDIS_SSL`` parameter in RQ config.

--- a/pulpcore/rqconfig.py
+++ b/pulpcore/rqconfig.py
@@ -2,6 +2,14 @@ import sys
 
 from pulpcore.app.settings import settings
 
-rq_settings = ["REDIS_URL", "REDIS_HOST", "REDIS_PORT", "REDIS_DB", "REDIS_PASSWORD", "SENTINEL"]
+rq_settings = [
+    "REDIS_URL",
+    "REDIS_HOST",
+    "REDIS_PORT",
+    "REDIS_DB",
+    "REDIS_PASSWORD",
+    "REDIS_SSL",
+    "SENTINEL",
+]
 
 settings.populate_obj(sys.modules[__name__], keys=rq_settings)


### PR DESCRIPTION
closes: #8525
https://pulp.plan.io/issues/8525

Please be sure you have read our documentation on creating PRs:
https://docs.pulpproject.org/contributing/pull-request-walkthrough.html
