### PR TITLE
Be explicit about Pulp installer doc

### DIFF
--- a/CHANGES/8477.doc
+++ b/CHANGES/8477.doc
@@ -1,0 +1,1 @@
+Make the reference to the Pulp installer documentation more explicit. 

--- a/docs/installation/instructions.rst
+++ b/docs/installation/instructions.rst
@@ -18,8 +18,13 @@ Fedora, CentOS, and Mac OSX.
 Ansible Installation (Recommended)
 ----------------------------------
 
-`Pulp 3 Ansible Installer <https://pulp-installer.readthedocs.io/>`__ can be used to
-install plugins. For example if your host is in your Ansible inventory as ``myhost`` you
+You can use the Pulp 3 Ansible Installer to install Pulp and any content plugins that you want.
+For comprehensive instructions on using the Pulp Ansible installer, see the
+`Pulp Installer documentation <https://pulp-installer.readthedocs.io/>`__.
+
+The examples in this section provide an overview but do not fully describe all the considerations. 
+
+For example if your host is in your Ansible inventory as ``myhost`` you
 can install onto it with:
 
 .. code-block:: bash


### PR DESCRIPTION
fixes #8477

I find it problematic that we have Pulp installer docs in two places. 
I have found that they are out of date. I think @mikedep333 mentioned that there might be an error here. 
I want to leave no doubt for the user which version of the docs is the most important. 
I tried to express this here. 
Happy to make any changes needed. 

Please be sure you have read our documentation on creating PRs:
https://docs.pulpproject.org/contributing/pull-request-walkthrough.html
