### PR TITLE
Update link

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -38,7 +38,7 @@ Plugin Documentation
 
 If you are a new user who is evaluating Pulp it is recommended that you skim the documentation for
 the plugins that add the content types you are interested in. Links to these docs can be found in
-our `list of plugins <https://pulpproject.org/content-plugins/>`_
+our `list of plugins <https://docs.pulpproject.org/pulpcore/plugins/index.html#plugins>`_
 
 Pulpcore Documentation
 ^^^^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
[noissue]

A while back I added a list of plugins and their docs to docs.pulpplugin.org
I didn't link to that here it seems. I want to ensure there is no need to move out of docs back to the site. 

* Link to plugin section list
* Remove link to site

Please be sure you have read our documentation on creating PRs:
https://docs.pulpproject.org/contributing/pull-request-walkthrough.html
