### PR TITLE
Fix pulp_labels type check

### DIFF
--- a/CHANGES/8541.bugfix
+++ b/CHANGES/8541.bugfix
@@ -1,0 +1,2 @@
+Fixed bug where using forms submissions to create resources (e.g. ``Remotes``) raised exception
+about the format of ``pulp_labels``.

--- a/pulpcore/app/serializers/fields.py
+++ b/pulpcore/app/serializers/fields.py
@@ -405,7 +405,7 @@ class LabelsField(serializers.DictField):
         Raises:
             rest_framework.serializers.ValidationError: if data is invalid (eg not a dict)
         """
-        if type(data) != dict:
+        if not isinstance(data, dict):
             raise serializers.ValidationError(_("Data must be supplied as a key/value hash."))
         for key, value in data.items():
             if not re.match(r"^[\w ]+$", key):


### PR DESCRIPTION
When submitting form data, pulp_labels is a MultiValueDict which is a
type of dict. isinstance() will recognize if data is a subclass of dict.

fixes #8541

Please be sure you have read our documentation on creating PRs:
https://docs.pulpproject.org/contributing/pull-request-walkthrough.html
