### PR TITLE
Allow to use PyYAML 5.4 which addresses CVE-2020-14343

### DIFF
--- a/CHANGES/8540.bugfix
+++ b/CHANGES/8540.bugfix
@@ -1,0 +1,1 @@
+Allowed to use PyYAML 5.4 which contains a patch for `CVE-2020-14343 <https://nvd.nist.gov/vuln/detail/CVE-2020-14343>`_.

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,7 +18,7 @@ gunicorn>=19.9,<20.1
 jinja2
 pygtrie~=2.3.3
 psycopg2>=2.7,<2.9
-PyYAML>=5.1.1,<5.4.0
+PyYAML>=5.1.1,<5.5.0
 python-gnupg~=0.4.6
 redis>=3.4.0
 rq>=1.1,<1.6


### PR DESCRIPTION
https://github.com/advisories/GHSA-8q59-q68h-6hv4
https://nvd.nist.gov/vuln/detail/CVE-2020-14343

closes #8540
https://pulp.plan.io/issues/8540


