### PR TITLE
Add sequential steps for storage docs

### DIFF
--- a/CHANGES/8597.doc
+++ b/CHANGES/8597.doc
@@ -1,0 +1,1 @@
+Add sequential steps for storage docs

--- a/docs/installation/storage.rst
+++ b/docs/installation/storage.rst
@@ -10,6 +10,9 @@ Storage
   to use another storage backend such as Amazon Simple Storage Service (S3), you'll need to
   configure Pulp.
 
+  You can also configure Pulp to use Amazon S3 and Azure storage using the Pulp installer. For more information
+  see the `Pulp installer documentation <https://pulp-installer.readthedocs.io/en/latest/quickstart/#storage>`_
+
 Amazon S3
 ^^^^^^^^^
 
@@ -24,22 +27,20 @@ To complete these steps, consult the official Amazon S3 documentation.
 3. In AWS Identity and Access Management (IAM), create a user that Pulp can use to access your S3 bucket.
 4. Save the access key id and secret access key.
 
-Configuring Pulp
-----------------
+Configuring Pulp to use Amazon S3
+---------------------------------
 
-  To have Pulp use S3, you'll need to install the optional django-storages and boto3 Python packages in the pulp
-  virtual environment::
+To have Pulp use S3, complete the following steps:
+
+1. Install the optional django-storages and boto3 Python packages in the pulp virtual environment::
 
       pip install django-storages[boto3]
 
-  Next you'll need to set ``DEFAULT_FILE_STORAGE`` to ``storages.backends.s3boto3.S3Boto3Storage``
-  in your Pulp settings. At a minimum, you'll also need to set ``AWS_ACCESS_KEY_ID``,
-  ``AWS_SECRET_ACCESS_KEY``, and ``AWS_STORAGE_BUCKET_NAME``. For more S3 configuration options, see
-  the `django-storages documents <https://django-storages.readthedocs.io/en/latest/backends/amazon-S3.html>`_.
+2. Depending on which method you use to install or configure Pulp, you must set ``DEFAULT_FILE_STORAGE`` to ``storages.backends.s3boto3.S3Boto3Storage`` in Pulp Settings. For example, if you use the `Pulp installer <https://pulp-installer.readthedocs.io/en/latest/quickstart/>`_, the ``default_file_storage`` is part of the ``pulp_settings`` Ansible variables you can define in your Ansible playbook.
 
-  You will also want to set the ``MEDIA_ROOT`` configuration option. This will be the path in your
-  bucket that Pulp will use. An empty string is acceptable as well if you want Pulp to create its
-  folders in the top level of the bucket.
+3. In that same way, add your Amazon S3 configuration settings to ``AWS_ACCESS_KEY_ID``, ``AWS_SECRET_ACCESS_KEY``, and ``AWS_STORAGE_BUCKET_NAME``. For more S3 configuration options, see the `django-storages documents <https://django-storages.readthedocs.io/en/latest/backends/amazon-S3.html>`_.
+
+4. Set the ``MEDIA_ROOT`` configuration option. This will be the path in your bucket that Pulp will use. If you want Pulp to create its folders in the top level of the bucket, an empty string is acceptable.
 
   Here is an example configuration that will use a bucket called ``pulp3`` that is hosted in
   region ``eu-central-1``::
@@ -73,23 +74,23 @@ Azure Blob storage
 Setting up Azure Blob storage
 -----------------------------
 
-  In order to use Azure Blob Storage, you'll need to set up an Azure account. Then create a storage
-  account, and in that storage account, create a container under Blob service. The access credentials
-  can be found at the storage account level, at Access keys (these are automatically generated).
+Before you can configure Azure Blob storage to use with Pulp, ensure that you complete the following steps.
+To complete these steps, consult the official Azure Blob documentation.
 
-Configuring Pulp
-----------------
+1. Set up an Azure account and create a storage account.
+2. In your storage account, create a container under `Blob` service.
+3. Obtain the access credentials so that you can later configure Pulp to access your Azure Blob storage. You can find the access credentials
+   at the storage account level, at Access keys (these are automatically generated).
 
-  To have Pulp use Azure Blob storage, you'll need to install the optional django-storages[azure]
-  package in the pulp virtual environment::
+Configuring Pulp to use Azure Blob storage
+------------------------------------------
+
+1. Install the optional django-storages[azure] package in the pulp virtual environment::
 
       pip install django-storages[azure]
 
-  Next you'll need to set the ``DEFAULT_FILE_STORAGE`` to
-  ``storages.backends.azure_storage.AzureStorage`` in your pulp settings, and configure following
-  parameters in your pulp settings file (for a comprehensive overview of all possible options for
-  the Azure Blob storage backend see the `django-storages[azure] documents
-  <https://django-storages.readthedocs.io/en/latest/backends/azure.html>_`)::
+2. Depending on which method you use to install or configure Pulp, you must set ``DEFAULT_FILE_STORAGE`` to ``storages.backends.azure_storage.AzureStorage`` in Pulp Settings. For example, if you use the `Pulp installer <https://pulp-installer.readthedocs.io/en/latest/quickstart/>`_, the ``default_file_storage`` is part of the ``pulp_settings`` Ansible variables you can define in your Ansible playbook.
+3. In the same way, configure the following parameters::
 
       AZURE_ACCOUNT_NAME = 'Storage account name'
       AZURE_CONTAINER = 'Container name (as created within the blob service of your storage account)'
@@ -97,3 +98,6 @@ Configuring Pulp
       AZURE_URL_EXPIRATION_SECS = 60
       AZURE_OVERWRITE_FILES = 'True'
       AZURE_LOCATION = 'the folder within the container where your pulp objects will be stored'
+
+  For a comprehensive overview of all possible options for the Azure Blob storage backend see the `django-storages[azure] documents
+  <https://django-storages.readthedocs.io/en/latest/backends/azure.html>_`


### PR DESCRIPTION
If it is OK with everyone, I would like to change the style of these docs to a set of sequential steps with the use of imperative voice. 
I would also like to be more specific. In these Storage docs, there is a mention of "Pulp settings". Is this draft, I've used settings.py although I know that's more than likely wrong. Can we be specific here about the exact file? 

fixes #8477

part of general installation work

Please be sure you have read our documentation on creating PRs:
https://docs.pulpproject.org/contributing/pull-request-walkthrough.html
