### PR TITLE
Taught PulpImporter to retry (once) on _import_file() failure.

### DIFF
--- a/CHANGES/8633.bugfix
+++ b/CHANGES/8633.bugfix
@@ -1,0 +1,1 @@
+Addressed a race-condition in PulpImport that could fail with unique-constraint violations.

--- a/pulpcore/app/modelresource.py
+++ b/pulpcore/app/modelresource.py
@@ -92,7 +92,9 @@ class ContentArtifactResource(QueryModelResource):
         row["content"] = str(linked_content.pulp_id)
 
     def set_up_queryset(self):
-        return ContentArtifact.objects.filter(content__in=self.repo_version.content)
+        return ContentArtifact.objects.filter(content__in=self.repo_version.content).order_by(
+            "content", "relative_path"
+        )
 
     class Meta:
         model = ContentArtifact


### PR DESCRIPTION
There's a race condition in django-import-export's get_or_init_instance()
that is exercised by importing repo-versions concurrently. We attempt
an import and check for errors, retrying ONCE if encountered. On a
second error, fail the attempt.

The test added for pulp_rpm #7904 cover this case.

fixes #8633
ref #7904
[nocoverage]