### PR TITLE
Add path to content-disposition header

### DIFF
--- a/pulpcore/app/settings.py
+++ b/pulpcore/app/settings.py
@@ -55,6 +55,12 @@ FILE_UPLOAD_HANDLERS = ("pulpcore.app.files.HashingFileUploadHandler",)
 
 SECRET_KEY = True
 
+# regex to alter path in content-disposition header & str to replace them with
+# wrapped in parens to prevent dynaconf from thinking this is a list :/
+#S3_REPO_MANGLE_REGEX = r'([^-a-zA-Z0-9._])'
+S3_REPO_MANGLE_REGEX = r'([/=;])'
+S3_REPO_MANGLE_TO = '__'
+
 # Application definition
 
 INSTALLED_APPS = [


### PR DESCRIPTION
I'm using this basic thing to provide the repo path in query strings, making it easier to determine from CloudFront logs what repo and file were requested by a user without having to gather the Pulp logs together.  Before I create the issue, I thought I'd toss the PR out and see if there's any interest in such a thing.  Or if there's anything significant that should be changed to make this more palatable. If it's of interest, I'll open a proper ticket and add a changelog entry.  Otherwise I'll just keep maintaining a local patch.

* Add path to artifact to content-disposition header using a local x-pulp-artifact-path extension attribute
* Add config values S3_REPO_MANGLE_REGEX and S3_REPO_MANGLE_TO to configure values in artifact path which should be replaced (and what they're replaced with), because different URL libraries escape and unescape chars, breaking signatures.
