### PR TITLE
Stabilize URLs before generating redirects

### DIFF
--- a/CHANGES/8670.bugfix
+++ b/CHANGES/8670.bugfix
@@ -1,0 +1,1 @@
+Altered redirect URL escaping, preventing invalidation of signed URLs for artifacts using cloud storage.

--- a/pulpcore/content/handler.py
+++ b/pulpcore/content/handler.py
@@ -9,6 +9,7 @@ from gettext import gettext as _
 from aiohttp.client_exceptions import ClientResponseError
 from aiohttp.web import FileResponse, StreamResponse, HTTPOk
 from aiohttp.web_exceptions import HTTPForbidden, HTTPFound, HTTPNotFound
+from yarl import URL
 
 import django
 
@@ -710,10 +711,12 @@ class Handler:
         elif settings.DEFAULT_FILE_STORAGE == "storages.backends.s3boto3.S3Boto3Storage":
             content_disposition = f"attachment;filename={content_artifact.relative_path}"
             parameters = {"ResponseContentDisposition": content_disposition}
-            url = artifact_file.storage.url(artifact_name, parameters=parameters)
+            url = URL(
+                artifact_file.storage.url(artifact_file.name, parameters=parameters), encoded=True
+            )
             raise HTTPFound(url)
         elif settings.DEFAULT_FILE_STORAGE == "storages.backends.azure_storage.AzureStorage":
-            url = artifact_file.storage.url(artifact_name)
+            url = URL(artifact_file.storage.url(artifact_name), encoded=True)
             raise HTTPFound(url)
         else:
             raise NotImplementedError()

--- a/requirements.txt
+++ b/requirements.txt
@@ -27,3 +27,4 @@ redis>=3.4.0
 rq~=1.8.1
 setuptools>=39.2.0
 whitenoise>=5.0.0,<5.3.0
+yarl>1.0.0


### PR DESCRIPTION
The aio URL object mangles query strings when they're passed in. Specifically, it unescapes http entities which are escaped but which don't need escaped.  This is normally ok, but in the case of signed CloudFront URLs, changing anything about the URL invalidates the signature, including the querystring.  By pre-creating a yarl.URL object before raising the redirect exception, the parsing doesn't happen in aiohttp.  Passing in the "encoding=True" stops the reparsing when the object is created.

Fixes #8670
Relates to #1294, and boto/botocore#2363