### PR TITLE
3.11 backport pin django to 2.2.20

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ aiohttp~=3.7.4
 aiodns~=2.0.0
 aiofiles==0.6.0
 backoff~=1.10.0
-Django~=2.2.19  # LTS version, switch only if we have a compelling reason to
+Django==2.2.20  # LTS version, switch only if we have a compelling reason to
 django-currentuser~=0.5.2
 django-filter~=2.4.0
 django-guardian~=2.3.0


### PR DESCRIPTION
Temporarily pin django

Pin django to 2.2.20 until https://pulp.plan.io/issues/8691 is resolved.

[noissue]

(cherry picked from commit 4a6c1abaf5baabb58f79e2215b7348c446b98967)
