### PR TITLE
Adds compatability with Django==2.2.21

### DIFF
--- a/CHANGES/8691.bugfix
+++ b/CHANGES/8691.bugfix
@@ -1,0 +1,1 @@
+Fixed compatibility with Django 2.2 LTS. Pulp now requires Django~=2.2.23

--- a/pulpcore/app/models/upload.py
+++ b/pulpcore/app/models/upload.py
@@ -1,4 +1,5 @@
 import hashlib
+import os
 
 from django.core.files.base import ContentFile
 from django.db import models
@@ -33,7 +34,8 @@ class Upload(BaseModel):
             raise serializers.ValidationError("Checksum does not match chunk upload.")
 
         upload_chunk = UploadChunk(upload=self, offset=offset, size=len(chunk))
-        upload_chunk.file.save("", ContentFile(chunk_read))
+        filename = os.path.basename(upload_chunk.storage_path(""))
+        upload_chunk.file.save(filename, ContentFile(chunk_read))
 
 
 class UploadChunk(HandleTempFilesMixin, BaseModel):

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ aiodns~=2.0.0
 aiofiles==0.6.0
 backoff~=1.10.0
 click~=7.1.2
-Django==2.2.20  # LTS version, switch only if we have a compelling reason to
+Django~=2.2.23  # LTS version, switch only if we have a compelling reason to
 django-currentuser~=0.5.3
 django-filter~=2.4.0
 django-guardian~=2.3.0


### PR DESCRIPTION
Switches the ArtifactFileField handling to use
`django.db.models.fields.Field` and specifies the `name` which causes
Django to no longer try to generate one from the filename.

closes #8691

