### PR TITLE
Skip allowed content checks on collectstatic

### DIFF
--- a/CHANGES/8711.bugfix
+++ b/CHANGES/8711.bugfix
@@ -1,0 +1,1 @@
+Skip allowed content checks on collectstatic

--- a/pulpcore/app/settings.py
+++ b/pulpcore/app/settings.py
@@ -318,7 +318,9 @@ FORBIDDEN_CHECKSUMS = set(constants.ALL_KNOWN_CONTENT_CHECKSUMS).difference(
     ALLOWED_CONTENT_CHECKSUMS
 )
 
-if not (len(sys.argv) >= 2 and sys.argv[1] in ["handle-artifact-checksums", "migrate"]):
+_SKIPPED_COMMANDS_FOR_CONTENT_CHECKS = ["handle-artifact-checksums", "migrate", "collectstatic"]
+
+if not (len(sys.argv) >= 2 and sys.argv[1] in _SKIPPED_COMMANDS_FOR_CONTENT_CHECKS):
     try:
         with connection.cursor() as cursor:
             for checksum in ALLOWED_CONTENT_CHECKSUMS:


### PR DESCRIPTION
Since 9a9a06f1e37f5367e36a24b9aa3aca6ca78dab53 DB access is always needed. In later commits this was extended with additional checks.

However, collectstatic should be a fully offline operation that doesn't access the network. As such, content checking is not needed.

Doing this allows the Foreman/Katello installer to run it more freely.  The alternative is to add additional ordering. However, I'd argue that this is better and also slightly faster.

Fixes #8711