### PR TITLE
Move directory listing template external [WIP]

### DIFF
--- a/pulpcore/app/static/directory_listing.css
+++ b/pulpcore/app/static/directory_listing.css
@@ -1,0 +1,3 @@
+ul {
+  list-style-type: square;
+}

--- a/pulpcore/app/templates/content/directory_listing.html
+++ b/pulpcore/app/templates/content/directory_listing.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>{% load static %}
+<html>
+    <head>
+        <link rel="stylesheet" href="{% static 'directory_listing.css' %}">
+    </head>
+    <body>
+        <ul>{% autoescape on %}
+        {% for name in dir_list %}
+            <li><a href="{{ name }}">{{ name }}</a></li>
+        {% endfor %}
+        </ul>{% endautoescape %}
+    </body>
+</html>
+{# vim: set syntax=htmldjango et sw=4 ts=8: #}


### PR DESCRIPTION
It'd be nice to be able to make the content server's download page a little prettier without having to custom-build pulp.  In order to do that, this PR moves the download page to an external Django template, and adds support to serve static file content from the regular django static location (as opposed to adding the content as a release).  If a conflict occurs between existing content and the static path, the actual pulp content distribution wins out.  So this is backwards compatible for anyone who is using /static in a current publication.