### PR TITLE
Use a common entrypoint for workers

### DIFF
--- a/CHANGES/8721.feature
+++ b/CHANGES/8721.feature
@@ -1,0 +1,1 @@
+Added a ``pulpcore-worker`` entrypoint to simplify and unify the worker command.

--- a/docs/components.rst
+++ b/docs/components.rst
@@ -73,7 +73,7 @@ Worker
 Resource Manager
   A different type of Pulp worker that plays a coordinating role for the tasking system. You must
   run exactly one of these for Pulp to operate correctly. The ``resource-manager`` is identified by
-  configuring using exactly the name ``resource-manager`` with the ``-n 'resource_manager'`` option.
+  configuring using exactly the name ``resource-manager`` with the ``--resource-manager`` option.
 
   *N* ``resource-manager`` rq processes can be started with 1 being active and *N-1* being passive.
   The *N-1* will exit and should be configured to auto-relaunch with either systemd, supervisord, or

--- a/docs/installation/instructions.rst
+++ b/docs/installation/instructions.rst
@@ -88,8 +88,8 @@ PyPI Installation
     In place of using the systemd unit files provided in the `systemd-setup` section, you can run
     the commands yourself inside of a shell. This is fine for development but not recommended in production::
 
-    $ /path/to/python/bin/rq worker -n 'resource-manager' -w 'pulpcore.tasking.worker.PulpWorker' -c 'pulpcore.rqconfig'
-    $ /path/to/python/bin/rq worker -w 'pulpcore.tasking.worker.PulpWorker' -c 'pulpcore.rqconfig'
+    $ /path/to/python/bin/pulpcore-worker --resource-manager
+    $ /path/to/python/bin/pulpcore-worker
 
 10. Collect Static Media for live docs and browsable API::
 

--- a/pulpcore/tasking/entrypoint.py
+++ b/pulpcore/tasking/entrypoint.py
@@ -1,0 +1,38 @@
+import click
+import logging
+import os
+import sys
+
+from rq.cli import main
+
+_logger = logging.getLogger(__name__)
+
+
+@click.option(
+    "--resource-manager",
+    is_flag=True,
+    help="Whether this worker should be started as a resource-manager",
+)
+@click.option("--pid", help="Write the process ID number to a file at the specified path")
+@click.command()
+def worker(resource_manager, pid):
+    """A Pulp worker."""
+
+    if pid:
+        with open(os.path.expanduser(pid), "w") as fp:
+            fp.write(str(os.getpid()))
+
+    _logger.info("Starting rq type worker")
+    args = [
+        "rq",
+        "worker",
+        "-w",
+        "pulpcore.tasking.worker.PulpWorker",
+        "-c",
+        "pulpcore.rqconfig",
+        "--disable-job-desc-logging",
+    ]
+    if resource_manager:
+        args.extend(["-n", "resource-manager"])
+    sys.argv = args
+    main()

--- a/pulpcore/tasking/worker.py
+++ b/pulpcore/tasking/worker.py
@@ -61,16 +61,16 @@ class PulpWorker(Worker):
 
     def __init__(self, queues, **kwargs):
 
-        if kwargs["name"]:
+        if kwargs.get("name"):
             kwargs["name"] = kwargs["name"].replace("%h", socket.getfqdn())
         else:
             kwargs["name"] = "{pid}@{hostname}".format(pid=os.getpid(), hostname=socket.getfqdn())
 
         if kwargs["name"] == TASKING_CONSTANTS.RESOURCE_MANAGER_WORKER_NAME:
-            queues = [Queue("resource-manager", connection=kwargs["connection"])]
+            queues = [Queue("resource-manager", connection=kwargs.get("connection"))]
             self.is_resource_manager = True
         else:
-            queues = [Queue(kwargs["name"], connection=kwargs["connection"])]
+            queues = [Queue(kwargs["name"], connection=kwargs.get("connection"))]
             self.is_resource_manager = False
 
         kwargs["default_worker_ttl"] = WORKER_TTL

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,7 @@ aiohttp~=3.7.4
 aiodns~=2.0.0
 aiofiles==0.6.0
 backoff~=1.10.0
+click~=7.1.2
 Django==2.2.20  # LTS version, switch only if we have a compelling reason to
 django-currentuser~=0.5.3
 django-filter~=2.4.0

--- a/setup.py
+++ b/setup.py
@@ -36,5 +36,10 @@ setup(
         "Programming Language :: Python :: 3.7",
     ],
     scripts=["bin/pulp-content"],
-    entry_points={"console_scripts": ["pulpcore-manager = pulpcore.app.manage:manage"]},
+    entry_points={
+        "console_scripts": [
+            "pulpcore-manager = pulpcore.app.manage:manage",
+            "pulpcore-worker = pulpcore.tasking.entrypoint:worker",
+        ]
+    },
 )


### PR DESCRIPTION
With this change, workers should be started with `pulpcore-worker` and
the resource-manager with `pulpcore-worker --resource-manager`
accordingly.

fixes #8721
https://pulp.plan.io/issues/8721
