### PR TITLE
Undeprecate the use od UUID in task args

### DIFF
--- a/CHANGES/plugin_api/8723.feature
+++ b/CHANGES/plugin_api/8723.feature
@@ -1,0 +1,1 @@
+Undeprecated the use of ``uuid.UUID`` in task arguments. With this, primary keys do not need to be explicitely cast to ``str``.

--- a/pulpcore/tasking/tasks.py
+++ b/pulpcore/tasking/tasks.py
@@ -173,6 +173,8 @@ def _queue_reserved_task(func, inner_task_id, resources, inner_args, inner_kwarg
 
 class NonJSONWarningEncoder(json.JSONEncoder):
     def default(self, obj):
+        if isinstance(obj, uuid.UUID):
+            return str(obj)
         try:
             return json.JSONEncoder.default(self, obj)
         except TypeError:
@@ -180,7 +182,7 @@ class NonJSONWarningEncoder(json.JSONEncoder):
                 _(
                     "The argument {obj} is of type {type}, which is not JSON serializable. The use "
                     "of non JSON serializable objects for `args` and `kwargs` to tasks is "
-                    "deprecated as of pulpcore==3.12. See the traceback below for more info."
+                    "deprecated as of pulpcore==3.12."
                 ).format(obj=obj, type=type(obj))
             )
             return None


### PR DESCRIPTION
fixes #8723
https://pulp.plan.io/issues/8723