### PR TITLE
Fixes deletion of UploadChunk when Upload deletes

### DIFF
--- a/CHANGES/7316.bugfix
+++ b/CHANGES/7316.bugfix
@@ -1,0 +1,1 @@
+Fixed cleanup of UploadChunks when their corresponding Upload is deleted.


### PR DESCRIPTION
According to the Django docs, the `on_delete=models.CASCADE` option does
not call Model.delete(), but it does call the Model.post_delete() signal
handler.

This replaces the `UploadChunk.delete()` with an
`UploadChunk.post_delete()` signal handler which correctly handles
the `UploadChunk.file` file deletion.

closes #7316

