### PR TITLE
Fixes ability to specify custom headers on a Remote

### DIFF
--- a/CHANGES/8689.bugfix
+++ b/CHANGES/8689.bugfix
@@ -1,0 +1,1 @@
+Fixed ability to specify custom headers on a Remote.

--- a/pulpcore/tests/functional/api/using_plugin/test_crud_repos.py
+++ b/pulpcore/tests/functional/api/using_plugin/test_crud_repos.py
@@ -346,3 +346,14 @@ class CRUDRemoteTestCase(unittest.TestCase):
         # verify the delete
         with self.assertRaises(ApiException):
             self.remotes_api.read(self.remote.pulp_href)
+
+    def test_headers(self):
+        # Test that headers value must be a list of dicts
+        data = {"headers": {"Connection": "keep-alive"}}
+        with self.assertRaises(ApiException):
+            self.remotes_api.partial_update(self.remote.pulp_href, data)
+        data = {"headers": [1, 2, 3]}
+        with self.assertRaises(ApiException):
+            self.remotes_api.partial_update(self.remote.pulp_href, data)
+        data = {"headers": [{"Connection": "keep-alive"}]}
+        self.remotes_api.partial_update(self.remote.pulp_href, data)

--- a/pulpcore/tests/functional/api/using_plugin/test_repo_versions.py
+++ b/pulpcore/tests/functional/api/using_plugin/test_repo_versions.py
@@ -133,6 +133,7 @@ class AddRemoveContentTestCase(unittest.TestCase):
         * The ``content_removed_summary`` attribute is correct.
         """
         body = gen_file_remote()
+        body.update({"headers": [{"Connection": "keep-alive"}]})
         self.remote.update(self.client.post(FILE_REMOTE_PATH, body))
         sync(self.cfg, self.remote, self.repo)
         repo = self.client.get(self.repo["pulp_href"])

--- a/pulpcore/tests/unit/download/test_factory.py
+++ b/pulpcore/tests/unit/download/test_factory.py
@@ -1,0 +1,33 @@
+from django.test import TestCase
+
+from pulpcore.download.factory import DownloaderFactory, user_agent
+from pulpcore.plugin.models import Remote
+
+
+class DownloaderFactoryHeadersTestCase(TestCase):
+    def test_user_agent_header(self):
+        remote = Remote.objects.create(url="http://example.org/", name="foo")
+        factory = DownloaderFactory(remote)
+        downloader = factory.build(remote.url)
+        default_user_agent = user_agent()
+        self.assertEqual(downloader.session.headers["User-Agent"], default_user_agent)
+        remote.delete()
+
+    def test_custom_user_agent_header(self):
+        remote = Remote.objects.create(
+            url="http://example.org/", headers=[{"User-Agent": "foo"}], name="foo"
+        )
+        factory = DownloaderFactory(remote)
+        downloader = factory.build(remote.url)
+        default_user_agent = user_agent()
+        expected_user_agent = f"{default_user_agent}, foo"
+        self.assertEqual(downloader.session.headers["User-Agent"], expected_user_agent)
+        remote.delete()
+
+    def test_custom_headers(self):
+        remote = Remote.objects.create(
+            url="http://example.org/", headers=[{"Connection": "keep-alive"}], name="foo"
+        )
+        factory = DownloaderFactory(remote)
+        downloader = factory.build(remote.url)
+        self.assertEqual(downloader.session.headers["Connection"], "keep-alive")


### PR DESCRIPTION
The Remotes APIs accepts a list of headers to be sent with each request during
sync. However, the headers were not being properly passed to aiohttp. This patch
fixes how the headers are passed to aiohttp.


fixes: #8689
https://pulp.plan.io/issues/8689