### PR TITLE
Removes click as a direct dependency

### DIFF
--- a/CHANGES/8772.misc
+++ b/CHANGES/8772.misc
@@ -1,0 +1,1 @@
+Removed click as a direct dependency since ``pulpcore`` does not directly use it.

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,6 @@ aiohttp~=3.7.4
 aiodns~=3.0.0
 aiofiles==0.6.0
 backoff~=1.10.0
-click~=7.1.2
 Django~=2.2.23  # LTS version, switch only if we have a compelling reason to
 django-currentuser~=0.5.3
 django-filter~=2.4.0


### PR DESCRIPTION
`pulpcore` does not use `click` as a direct dependency, so we should no
longer declare it.

closes #8772

