### PR TITLE
Revert "[noissue]: Update click requirement from ~=7.1.2 to ~=8.0.0"

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ aiohttp~=3.7.4
 aiodns~=3.0.0
 aiofiles==0.7.0
 backoff~=1.10.0
-click~=8.0.0
+click<9.0
 Django~=2.2.23  # LTS version, switch only if we have a compelling reason to
 django-currentuser~=0.5.3
 django-filter~=2.4.0


### PR DESCRIPTION
This reverts commit 935fac880e5f0b70e8cccc75fa22b614da96ef47.

Additionally since pulpcore is compatible with both 7.y and 8.y versions
of click we can just ensure we don't break when click 9.0 comes out.

[noissue]

