### PR TITLE
Fixes autodoc build errors

### DIFF
--- a/CHANGES/8784.doc
+++ b/CHANGES/8784.doc
@@ -1,0 +1,1 @@
+Fixed docs build errors reported by autodoc.

--- a/docs/contributing/platform-api/app/auth.rst
+++ b/docs/contributing/platform-api/app/auth.rst
@@ -1,4 +1,4 @@
 pulp.app.auth
-=================
+=============
 
-.. automodule:: pulpcore.app.auth
+.. automodule:: pulpcore.app.authentication

--- a/docs/contributing/platform-api/app/fields.rst
+++ b/docs/contributing/platform-api/app/fields.rst
@@ -1,6 +1,0 @@
-pulp.app.fields
-===============
-
-All fields documented here should be imported directly from the ``pulp.app.fields`` namespace.
-
-.. automodule:: pulpcore.app.fields

--- a/docs/contributing/platform-api/tasking.rst
+++ b/docs/contributing/platform-api/tasking.rst
@@ -14,20 +14,20 @@ pulp.tasking.constants
 
 .. automodule:: pulpcore.tasking.constants
 
-pulp.tasking.services.manage_workers
+pulp.tasking.manage_workers
 ------------------------------------
 
-.. automodule:: pulpcore.tasking.services.manage_workers
+.. automodule:: pulpcore.tasking.manage_workers
 
-pulp.tasking.services.storage
------------------------------
+pulp.tasking.storage
+--------------------
 
-.. automodule:: pulpcore.tasking.services.storage
+.. automodule:: pulpcore.tasking.storage
 
-pulp.tasking.services.worker_watcher
+pulp.tasking.worker_watcher
 ------------------------------------
 
-.. automodule:: pulpcore.tasking.services.worker_watcher
+.. automodule:: pulpcore.tasking.worker_watcher
 
 pulp.tasking.tasks
 ------------------


### PR DESCRIPTION
Autodoc was failing to find several python modules, but these failures
didn't cause formal docs build errors. In cases where code was moved,
this PR fixes the paths to resolve the error. In cases where code was
removed, it removes those autodoc entries.

closes #8784

