### PR TITLE
Use Redis to cache responses from content app

### DIFF
--- a/CHANGES/8805.feature
+++ b/CHANGES/8805.feature
@@ -1,0 +1,1 @@
+Content app responses are now smartly cached in Redis.

--- a/docs/configuration/settings.rst
+++ b/docs/configuration/settings.rst
@@ -189,6 +189,33 @@ CONTENT_APP_TTL
    Defaults to ``30`` seconds.
 
 
+.. _pulp-cache:
+
+CACHE_ENABLED
+^^^^^^^^^^^^^^^^^^
+
+   .. note:: This feature is provided as a tech-preview
+
+   Store cached responses from the content app into Redis. This setting improves the performance
+   of the content app under heavy load for similar requests. Defaults to ``True``.
+
+   .. note::
+     The entire response is not stored in the cache. Only the location of the file needed to
+     recreate the response is stored. This reduces database queries and allows for many
+     responses to be stored inside the cache.
+
+CACHE_SETTINGS
+^^^^^^^^^^^^^
+
+   Dictionary with tunable settings for the cache:
+
+   * ``EXPIRES_TTL`` - Number of seconds entries should stay in the cache before expiring.
+
+   .. note::
+     Set to ``None`` to have entries not expire.
+     Content app responses are always invalidated when the backing distribution is updated.
+
+
 .. _worker-ttl:
 
 WORKER_TTL

--- a/pulpcore/app/settings.py
+++ b/pulpcore/app/settings.py
@@ -239,6 +239,12 @@ USE_NEW_WORKER_TYPE = True
 
 PROFILE_STAGES_API = False
 
+# https://docs.pulpproject.org/pulpcore/configuration/settings.html#pulp-cache
+CACHE_ENABLED = True
+CACHE_SETTINGS = {
+    "EXPIRES_TTL": 86400,
+}
+
 SPECTACULAR_SETTINGS = {
     "SERVE_URLCONF": ROOT_URLCONF,
     "DEFAULT_GENERATOR_CLASS": "pulpcore.openapi.PulpSchemaGenerator",

--- a/pulpcore/cache/__init__.py
+++ b/pulpcore/cache/__init__.py
@@ -1,0 +1,1 @@
+from .cache import Cache, AsyncCache, ContentCache, CacheKeys  # noqa

--- a/pulpcore/cache/cache.py
+++ b/pulpcore/cache/cache.py
@@ -1,0 +1,234 @@
+import enum
+import json
+
+from aiohttp.web import FileResponse, Response, HTTPSuccessful, Request
+from aiohttp.web_exceptions import HTTPFound
+
+from pulpcore.app.settings import settings
+from pulpcore.tasking.connection import get_redis_connection, get_async_redis_connection
+
+DEFAULT_EXPIRES_TTL = settings.CACHE_SETTINGS["EXPIRES_TTL"]
+
+
+class CacheKeys(enum.Enum):
+    """Available keys to construct the index key for cache entry."""
+
+    path = "path"
+    host = "host"
+    method = "method"
+
+
+class Cache:
+    """Base class for Pulp's cache"""
+
+    default_base_key = "PULP_CACHE"
+    default_expires_ttl = DEFAULT_EXPIRES_TTL
+
+    def __init__(self):
+        """Creates synchronous cache instance"""
+        self.redis = get_redis_connection()
+
+    def get(self, key, base_key=None):
+        """Gets cached entry of key"""
+        base_key = base_key or self.default_base_key
+        if key is None:
+            return self.redis.hgetall(base_key)
+        return self.redis.hget(base_key, key)
+
+    def set(self, key, value, expires=None, base_key=None):
+        """Sets the cached entry at key"""
+        base_key = base_key or self.default_base_key
+        ret = self.redis.hset(base_key, key, value)
+        if expires:
+            self.redis.expire(base_key, expires)
+        return ret
+
+    def exists(self, key=None, base_key=None):
+        """Checks if cached entries exist"""
+        base_key = base_key or self.default_base_key
+        if key:
+            return self.redis.hexists(base_key, key)
+        else:
+            if isinstance(base_key, str):
+                base_key = [base_key]
+            return self.redis.exists(*base_key)
+
+    def delete(self, key=None, base_key=None):
+        """
+        Deletes the cached entry at base_key: key
+
+        If only base_key is supplied then delete all entries under that base_key
+        key can be a list to delete multiple entries under a base_key
+        base_key can be a list to delete multiple sets of entries
+        key and base_key should not both be lists
+        """
+        base_key = base_key or self.default_base_key
+        if key:
+            return self.redis.hdel(base_key, key)
+        if isinstance(base_key, str):
+            base_key = [base_key]
+        return self.redis.delete(*base_key)
+
+
+class AsyncCache:
+    """Base class for asynchronous Pulp Cache"""
+
+    default_base_key = "PULP_CACHE"
+    default_expires_ttl = DEFAULT_EXPIRES_TTL
+
+    def __init__(self):
+        """Creates asynchronous cache instance"""
+        self.redis = get_async_redis_connection()
+
+    async def get(self, key, base_key=None):
+        """Gets cached entry of key"""
+        base_key = base_key or self.default_base_key
+        if key is None:
+            return await self.redis.hgetall(base_key)
+        return await self.redis.hget(base_key, key)
+
+    async def set(self, key, value, expires=None, base_key=None):
+        """Sets the cached entry at key"""
+        base_key = base_key or self.default_base_key
+        ret = await self.redis.hset(base_key, key, value)
+        if expires:
+            await self.redis.expire(base_key, expires)
+        return ret
+
+    async def exists(self, key=None, base_key=None):
+        """Checks if cached entries exist"""
+        base_key = base_key or self.default_base_key
+        if key:
+            return await self.redis.hexists(base_key, key)
+        else:
+            if isinstance(base_key, str):
+                base_key = [base_key]
+            return await self.redis.exists(*base_key)
+
+    async def delete(self, key=None, base_key=None):
+        """
+        Deletes the cached entry at base_key: key
+
+        If only base_key is supplied then delete all entries under that base_key
+        key can be a list to delete multiple entries under a base_key
+        base_key can be a list to delete multiple sets of entries
+        key and base_key should not both be lists
+        """
+        base_key = base_key or self.default_base_key
+        if key:
+            return await self.redis.hdel(base_key, key)
+        if isinstance(base_key, str):
+            base_key = [base_key]
+        return await self.redis.delete(*base_key)
+
+
+class ContentCache(AsyncCache):
+    """Cache object meant to be used for the content app"""
+
+    RESPONSE_TYPES = {
+        "FileResponse": FileResponse,
+        "Response": Response,
+        "Redirect": HTTPFound,
+    }
+
+    def __init__(self, base_key=None, expires_ttl=None, keys=None, auth=None):
+        """
+        Initiates a cache instance to be used for dealing with an aiohttp server
+
+        Args:
+            base_key: a string to group entries under, defaults to DEFAULT_BASE_KEY,
+                      can be a callable taking the request and cache instance as arguments
+            expires_ttl: length in seconds entries should live in the cache, EXPIRES_TTL is default
+            keys: a list of CacheKeys to use for key creation upon entry placement, path is default
+            auth: a callable to check authorization of the request; takes the request, cache
+                  instance, and base_key as arguments.
+        """
+        super().__init__()
+        self.default_base_key = base_key or self.default_base_key
+        self.keys = keys or (CacheKeys.path,)
+        self.default_expires_ttl = expires_ttl or self.default_expires_ttl
+        self.auth = auth
+
+    def __call__(self, func):
+        """Decorator magic call to make the handler cached"""
+        if not settings.CACHE_ENABLED:
+            return func
+
+        async def cached_function(*args):
+            request = self.get_request_from_args(args)
+            bk = self.default_base_key
+            if callable(self.default_base_key):
+                bk = await self.default_base_key(request, self)
+            if self.auth:
+                await self.auth(request, self, bk)
+            key = self.make_key(request)
+            # Check cache
+            response = await self.make_response(key, bk)
+            if response is None:
+                # Cache miss, create new entry
+                response = await self.make_entry(key, bk, func, args, self.default_expires_ttl)
+            return response
+
+        return cached_function
+
+    def get_request_from_args(self, args):
+        """Finds the request object from list of args"""
+        for arg in args:
+            if isinstance(arg, Request):
+                return arg
+
+    async def make_response(self, key, base_key):
+        """Tries to find the cached entry and turn it into a proper response"""
+        entry = await self.get(key, base_key)
+        if not entry:
+            return None
+        entry = json.loads(entry)
+        response_type = entry.pop("type", None)
+        if not response_type or response_type not in self.RESPONSE_TYPES:
+            # Bad entry, delete from cache
+            self.delete(key, base_key)
+            return None
+        response = self.RESPONSE_TYPES[response_type](**entry)
+        response.headers.update({"X-PULP-CACHE": "HIT"})
+        return response
+
+    async def make_entry(self, key, base_key, handler, args, expires=86400):
+        """Gets the response for the request and try to turn it into a cacheable entry"""
+        try:
+            response = await handler(*args)
+        except (HTTPSuccessful, HTTPFound) as e:
+            response = e
+
+        entry = {"headers": dict(response.headers), "status": response.status}
+        response.headers.update({"X-PULP-CACHE": "MISS"})
+        if isinstance(response, FileResponse):
+            entry["path"] = str(response._path)
+            entry["type"] = "FileResponse"
+        elif isinstance(response, (Response, HTTPSuccessful)):
+            body = response.body
+            entry["text"] = getattr(body, "_value", body).decode("utf-8")
+            entry["type"] = "Response"
+        elif isinstance(response, HTTPFound):
+            entry["location"] = str(response.location)
+            entry["type"] = "Redirect"
+        else:
+            # We don't cache StreamResponses or errors
+            return response
+
+        # TODO look into smaller format, maybe some compression on the text
+        await self.set(key, json.dumps(entry), expires, base_key=base_key)
+        return response
+
+    def make_key(self, request):
+        """Makes the key based off the request"""
+        # Might potentially have to make this async if keys require async data from request
+        all_keys = {
+            CacheKeys.path: request.match_info["path"],
+            CacheKeys.method: request.method,
+            CacheKeys.host: request.url.host,
+        }
+        key = ":".join(all_keys[k] for k in self.keys)
+        return key
+
+
+# TODO Add Cache object for non async redis connection/ aka Django requests

--- a/pulpcore/tasking/connection.py
+++ b/pulpcore/tasking/connection.py
@@ -1,8 +1,10 @@
+from aioredis import Redis as aRedis
 from rq.cli.helpers import get_redis_from_config
 
 from pulpcore.app.settings import settings
 
 _conn = None
+_a_conn = None
 
 
 def get_redis_connection():
@@ -12,3 +14,12 @@ def get_redis_connection():
         _conn = get_redis_from_config(settings)
 
     return _conn
+
+
+def get_async_redis_connection():
+    global _a_conn
+
+    if _a_conn is None:
+        _a_conn = get_redis_from_config(settings, aRedis)
+
+    return _a_conn

--- a/pulpcore/tests/functional/api/using_plugin/test_content_cache.py
+++ b/pulpcore/tests/functional/api/using_plugin/test_content_cache.py
@@ -1,0 +1,147 @@
+"""Tests related to content cache."""
+import requests
+import unittest
+from urllib.parse import urljoin
+
+from pulp_smash.pulp3.bindings import monitor_task
+from pulp_smash.pulp3.utils import gen_distribution, gen_repo
+
+from .constants import PULP_CONTENT_BASE_URL
+from pulpcore.tests.functional.api.using_plugin.utils import (
+    gen_file_client,
+    gen_file_remote,
+)
+from pulpcore.client.pulp_file import (
+    ContentFilesApi,
+    RepositoryAddRemoveContent,
+    RepositorySyncURL,
+    RepositoriesFileApi,
+    RemotesFileApi,
+    PublicationsFileApi,
+    FileFilePublication,
+    DistributionsFileApi,
+    PatchedfileFileDistribution,
+)
+from pulpcore.tests.functional.api.using_plugin.utils import (  # noqa:F401
+    set_up_module as setUpModule,
+)
+
+
+class ContentCacheTestCache(unittest.TestCase):
+    """Test content cache"""
+
+    @classmethod
+    def setUpClass(cls):
+        """Sets up class"""
+        client = gen_file_client()
+        cls.cont_api = ContentFilesApi(client)
+        cls.repo_api = RepositoriesFileApi(client)
+        cls.remote_api = RemotesFileApi(client)
+        cls.pub_api = PublicationsFileApi(client)
+        cls.dis_api = DistributionsFileApi(client)
+        cls.repo = cls.repo_api.create(gen_repo(autopublish=True))
+        cls.remote = cls.remote_api.create(gen_file_remote())
+        body = RepositorySyncURL(remote=cls.remote.pulp_href)
+        created = monitor_task(cls.repo_api.sync(cls.repo.pulp_href, body).task).created_resources
+        cls.repo = cls.repo_api.read(cls.repo.pulp_href)
+        cls.pub1 = cls.pub_api.read(created[1])
+        body = FileFilePublication(repository=cls.repo.pulp_href)
+        cls.pub2 = cls.pub_api.read(
+            monitor_task(cls.pub_api.create(body).task).created_resources[0]
+        )
+        cls.pub3 = []
+        response = cls.dis_api.create(gen_distribution(repository=cls.repo.pulp_href))
+        cls.distro = cls.dis_api.read(monitor_task(response.task).created_resources[0])
+        cls.distro2 = []
+        cls.url = urljoin(PULP_CONTENT_BASE_URL, f"{cls.distro.base_path}/")
+
+    @classmethod
+    def tearDownClass(cls):
+        """Tears the class down"""
+        cls.remote_api.delete(cls.remote.pulp_href)
+        cls.dis_api.delete(cls.distro.pulp_href)
+
+    def test_01_basic_cache_access(self):
+        """Checks responses are cached for content"""
+        files = ["", "", "PULP_MANIFEST", "PULP_MANIFEST", "1.iso", "1.iso"]
+        for i, file in enumerate(files):
+            self.assertEqual((200, "HIT" if i % 2 == 1 else "MISS"), self.check_cache(file), file)
+
+    def test_02_remove_repository_invalidates(self):
+        """Checks removing repository from distribution invalidates the cache"""
+        body = PatchedfileFileDistribution(repository="")
+        monitor_task(self.dis_api.partial_update(self.distro.pulp_href, body).task)
+        files = ["", "PULP_MANIFEST", "1.iso"]
+        for i, file in enumerate(files):
+            self.assertEqual((404, None), self.check_cache(file))
+
+    def test_03_restore_repository(self):
+        """Checks that responses are cacheable after repository is added back"""
+        body = PatchedfileFileDistribution(repository=self.repo.pulp_href)
+        monitor_task(self.dis_api.partial_update(self.distro.pulp_href, body).task)
+        files = ["", "", "PULP_MANIFEST", "PULP_MANIFEST", "1.iso", "1.iso"]
+        for i, file in enumerate(files):
+            self.assertEqual((200, "HIT" if i % 2 == 1 else "MISS"), self.check_cache(file), file)
+
+    def test_04_multiple_distributions(self):
+        """Add a new distribution and check that its responses are cached separately"""
+        response = self.dis_api.create(gen_distribution(repository=self.repo.pulp_href))
+        self.distro2.append(self.dis_api.read(monitor_task(response.task).created_resources[0]))
+        url = urljoin(PULP_CONTENT_BASE_URL, f"{self.distro2[0].base_path}/")
+        files = ["", "", "PULP_MANIFEST", "PULP_MANIFEST", "1.iso", "1.iso"]
+        for i, file in enumerate(files):
+            self.assertEqual((200, "HIT" if i % 2 == 1 else "MISS"), self.check_cache(file, url))
+
+    def test_05_invalidate_multiple_distributions(self):
+        """Test that updating a repository pointed by multiple distributions invalidates all"""
+        url = urljoin(PULP_CONTENT_BASE_URL, f"{self.distro2[0].base_path}/")
+        cfile = self.cont_api.list(
+            relative_path="1.iso", repository_version=self.repo.latest_version_href
+        ).results[0]
+        body = RepositoryAddRemoveContent(remove_content_units=[cfile.pulp_href])
+        response = monitor_task(self.repo_api.modify(self.repo.pulp_href, body).task)
+        self.pub3.append(self.pub_api.read(response.created_resources[1]))
+        files = ["", "", "PULP_MANIFEST", "PULP_MANIFEST", "2.iso", "2.iso"]
+        for i, file in enumerate(files):
+            self.assertEqual((200, "HIT" if i % 2 == 1 else "MISS"), self.check_cache(file), file)
+            self.assertEqual((200, "HIT" if i % 2 == 1 else "MISS"), self.check_cache(file, url))
+
+    def test_06_delete_distribution_invalidates_one(self):
+        """Tests that deleting one distribution sharing a repository only invalidates its cache"""
+        url = urljoin(PULP_CONTENT_BASE_URL, f"{self.distro2[0].base_path}/")
+        monitor_task(self.dis_api.delete(self.distro2[0].pulp_href).task)
+        files = ["", "PULP_MANIFEST", "2.iso"]
+        for i, file in enumerate(files):
+            self.assertEqual((200, "HIT"), self.check_cache(file), file)
+            self.assertEqual((404, None), self.check_cache(file, url), file)
+
+    def test_07_delete_extra_pub_doesnt_invalidate(self):
+        """Test that deleting a publication not being served doesn't invalidate cache"""
+        self.pub_api.delete(self.pub2.pulp_href)
+        files = ["", "PULP_MANIFEST", "2.iso"]
+        for i, file in enumerate(files):
+            self.assertEqual((200, "HIT"), self.check_cache(file), file)
+
+    def test_08_delete_served_pub_does_invalidate(self):
+        """Test that deleting the serving publication does invalidate the cache"""
+        # Reverts back to serving self.pub1
+        self.pub_api.delete(self.pub3[0].pulp_href)
+        files = ["", "", "PULP_MANIFEST", "PULP_MANIFEST", "2.iso", "2.iso"]
+        for i, file in enumerate(files):
+            self.assertEqual((200, "HIT" if i % 2 == 1 else "MISS"), self.check_cache(file), file)
+
+    def test_09_delete_repo_invalidates(self):
+        """Tests that deleting a repository invalidates the cache"""
+        monitor_task(self.repo_api.delete(self.repo.pulp_href).task)
+        files = ["", "PULP_MANIFEST", "2.iso"]
+        for i, file in enumerate(files):
+            self.assertEqual((404, None), self.check_cache(file), file)
+
+    def check_cache(self, file, url=None):
+        """Helper to check if cache miss or hit"""
+        url = urljoin(url or self.url, file)
+        r = requests.get(url)
+        if r.history:
+            r = r.history[0]
+            return 200 if r.status_code == 302 else r.status_code, r.headers.get("X-PULP-CACHE")
+        return r.status_code, r.headers.get("X-PULP-CACHE")

--- a/pulpcore/tests/unit/test_cache.py
+++ b/pulpcore/tests/unit/test_cache.py
@@ -1,0 +1,93 @@
+from time import sleep
+from django.test import TestCase
+
+from pulpcore.cache import Cache
+
+
+class CacheBasicOperationsTestCase(TestCase):
+    """Tests the basic APIs of the Cache object"""
+
+    def test_01_basic_set_get(self):
+        """Tests setting value, then getting it"""
+        cache = Cache()
+        cache.set("key", "hello")
+        ret = cache.get("key")
+        self.assertEqual(ret, b"hello")
+        cache.set("key", "there")
+        ret = cache.get("key")
+        self.assertEqual(ret, b"there")
+
+    def test_02_basic_exists(self):
+        """Tests that keys already set exist"""
+        cache = Cache()
+        self.assertTrue(cache.exists("key"))
+        self.assertFalse(cache.exists("absent"))
+
+    def test_03_basic_delete(self):
+        """Tests deleting value"""
+        cache = Cache()
+        self.assertTrue(cache.exists("key"))
+        cache.delete("key")
+        ret = cache.get("key")
+        self.assertIsNone(ret)
+
+    def test_04_basic_expires(self):
+        """Tests setting values with expiration times"""
+        cache = Cache()
+        cache.set("key", "hi", expires=5)
+        ret = cache.get("key")
+        self.assertEqual(ret, b"hi")
+        sleep(5)
+        ret = cache.get("key")
+        self.assertIsNone(ret)
+
+    def test_05_group_with_base_key(self):
+        """Tests grouping multiple key-values under one base-key"""
+        cache = Cache()
+        tuples = [
+            ("key1", "hi", "base1"),
+            ("key2", "friends", "base1"),
+            ("key1", "hola", "base2"),
+            ("key2", "amigos", "base2"),
+        ]
+        for key, value, base_key in tuples:
+            cache.set(key, value, base_key=base_key)
+        for key, value, base_key in tuples:
+            self.assertEqual(value.encode(), cache.get(key, base_key=base_key))
+
+        dict1 = {a.encode(): b.encode() for a, b, _ in tuples[:2]}
+        dict2 = {a.encode(): b.encode() for a, b, _ in tuples[2:]}
+        self.assertDictEqual(dict1, cache.get(None, base_key="base1"))
+        self.assertDictEqual(dict2, cache.get(None, base_key="base2"))
+        self.assertTrue(cache.exists(base_key="base1"))
+        self.assertTrue(cache.exists(base_key="base2"))
+        self.assertEqual(2, cache.exists(base_key=["base1", "base2"]))
+
+    def test_06_delete_base_key(self):
+        """Tests deleting multiple key-values under one base-key"""
+        cache = Cache()
+        cache.delete(base_key="base1")
+        self.assertFalse(cache.exists("key1", base_key="base1"))
+        self.assertFalse(cache.exists("key2", base_key="base1"))
+        self.assertFalse(cache.exists(base_key="base1"))
+
+        cache.set("key1", "hi", base_key="base1")
+        self.assertTrue(cache.exists("key1", base_key="base1"))
+        # multi delete
+        cache.delete(base_key=["base1", "base2"])
+        self.assertEqual(0, cache.exists(base_key=["base1", "base2"]))
+
+    def test_07_clear(self):
+        """Tests clearing the cache"""
+        cache = Cache()
+        tuples = [
+            ("key", "hi", None),
+            ("key1", "there", None),
+            ("key", "hey", "base"),
+            ("key1", "now", "base"),
+        ]
+        for key, value, base_key in tuples:
+            cache.set(key, value, base_key=base_key)
+        cache.redis.flushdb()
+        for key, _, base_key in tuples:
+            self.assertFalse(cache.exists(key, base_key=base_key))

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,7 @@ asyncio-throttle~=1.0
 aiohttp~=3.7.4
 aiodns~=3.0.0
 aiofiles==0.7.0
+aioredis~=2.0.0a1
 backoff~=1.10.0
 click<9.0
 Django~=2.2.24  # LTS version, switch only if we have a compelling reason to


### PR DESCRIPTION
fixes: #8805
https://pulp.plan.io/issues/8805

- [x] Clean up/ Re-do the Cache API
- [x] Finish every TODO commented
- [x] Add tests
- [x] Add changelog
- [x] Add docs explaining new cache
- [ ] (Optional) Add decorator for Django views

Still a heavily WIP PR and lots of work to be done, but it does work and pretty nicely too!  I didn't put much thought into the cache api design(except for the fact that I wanted it to be a decorator added to any handler/view function) so it is a bit of a mess and needs refactoring.  ~The one big problem I ran into was that the content app should use async methods when talking to redis, but all of the other Django code requires non-async methods to talk to redis.  This made designing a shared base class non-trivial.~ Another problem is that aiohttp requests/responses are different from Django requests/responses so an all inclusive cache api would be difficult(but not impossible) to create and would probably need to be in separate objects.  

~*Edit* Since this will go onto pulpcore 3.14 which is upgrading to Django 3.2 which has `asgiref` as a dependency, I have solved the async/sync problem using the `async_to_sync` functions.~

Please be sure you have read our documentation on creating PRs:
https://docs.pulpproject.org/contributing/pull-request-walkthrough.html
