### PR TITLE
Consolidates existing auth into top-level section

### DIFF
--- a/CHANGES/8801.doc
+++ b/CHANGES/8801.doc
@@ -1,0 +1,1 @@
+Moved ``Webserver Authentication`` docs under the top-level ``Authentication`` section.

--- a/docs/authentication/basic.rst
+++ b/docs/authentication/basic.rst
@@ -1,7 +1,7 @@
-.. _basic-auth:
+.. _basic-authentication:
 
-Basic Authentication
---------------------
+Basic
+-----
 
 Pulp by default uses `Basic Authentication <https://tools.ietf.org/html/rfc7617>`_ which checks the
 user submitted header against an internal database of users. If the username and password match, the

--- a/docs/authentication/index.rst
+++ b/docs/authentication/index.rst
@@ -6,36 +6,7 @@ Authentication
 .. toctree::
    :maxdepth: 2
 
+   overview
    basic
-
-Overview
---------
-
-By default, Pulp supports Basic and Session authentication. The Basic Authentication checks the
-username and password against the internal users database.
-
-.. note::
-    This authentication is only for the REST API. Client's fetching binary data have their identity
-    verified and authorization checked using a :term:`ContentGuard`.
-
-
-Which URLs Require Authentication?
-----------------------------------
-
-All URLs in the REST API require authentication except the Status API, ``/pulp/api/v3/status/``,
-which is served to unauthenticated users too. This is true regardless of the type of authentication
-you configure.
-
-
-Concepts
---------
-
-Authentication in Pulp is provided by Django Rest Framework and Django together.
-
-Django provides the
-`AUTHENTICATION_BACKENDS <https://docs.djangoproject.com/en/2.2/ref/settings/#std:setting-AUTHENTICATION_BACKENDS>`_
-which defines a set of behaviors to check usernames and passwords against.
-
-Django Rest Framework defines the source usernames and passwords come from with the
-`DEFAULT_AUTHENTICATION_CLASSES <https://www.django-rest-framework.org/api-guide/authentication/#setting-the-authentication-scheme>`_
-setting.
+   webserver
+   other

--- a/docs/authentication/other.rst
+++ b/docs/authentication/other.rst
@@ -1,0 +1,12 @@
+.. _other-authentication:
+
+Other
+-----
+
+Pulp is a Django app and Django Rest Framework (DRF) application, so additional authentication can
+be added as long as it's correctly configured for both Django and Django Rest Frameowork.
+
+See the `Django docs on configuring custom authentication <https://docs.djangoproject.com/en/2.2/
+topics/auth/customizing/#customizing-authentication-in-django>`_ and the `Django Rest Framework docs
+on configuring custom authentication <https://www.django-rest-framework.org/api-guide/authentication
+/#custom-authentication>`_.

--- a/docs/authentication/overview.rst
+++ b/docs/authentication/overview.rst
@@ -1,0 +1,33 @@
+.. _authentication-overview:
+
+Overview
+--------
+
+By default, Pulp supports Basic and Session authentication. The Basic Authentication checks the
+username and password against the internal users database.
+
+.. note::
+    This authentication is only for the REST API. Client's fetching binary data have their identity
+    verified and authorization checked using a :term:`ContentGuard`.
+
+
+Which URLs Require Authentication?
+**********************************
+
+All URLs in the REST API require authentication except the Status API, ``/pulp/api/v3/status/``,
+which is served to unauthenticated users too. This is true regardless of the type of authentication
+you configure.
+
+
+Concepts
+********
+
+Authentication in Pulp is provided by Django Rest Framework and Django together.
+
+Django provides the
+`AUTHENTICATION_BACKENDS <https://docs.djangoproject.com/en/2.2/ref/settings/#std:setting-AUTHENTICATION_BACKENDS>`_
+which defines a set of behaviors to check usernames and passwords against.
+
+Django Rest Framework defines the source usernames and passwords come from with the
+`DEFAULT_AUTHENTICATION_CLASSES <https://www.django-rest-framework.org/api-guide/authentication/#setting-the-authentication-scheme>`_
+setting.

--- a/docs/authentication/webserver.rst
+++ b/docs/authentication/webserver.rst
@@ -1,29 +1,11 @@
-Disabling Checks against Internal User DB
------------------------------------------
+.. _webserver-authentication:
 
-The internal users database is checked using the ``django.contrib.auth.backends.ModelBackend`` from
-Django. To disable checking a username and password against the internal users database, remove the
-``django.contrib.auth.backends.ModelBackend`` from the ``AUTHENTICATION_BACKENDS`` setting in Pulp.
-
-You can do this effectively, for example using a Python settings file::
-
-    AUTHENTICATION_BACKENDS = []
-
-
-Or by defining an environment variable for Dynaconf to use::
-
-    export PULP_AUTHENTICATION_BACKENDS="[]"
-
-
-.. _webserver-auth:
-
-Webserver Authentication
-------------------------
+Webserver
+---------
 
 Pulp can be configured to use authentication provided in the webserver outside of Pulp. This allows
-for integration with ldap for examples, through
-`mod_ldap <https://httpd.apache.org/docs/2.4/mod/mod_ldap.html>`_, or certificate based API access,
-etc.
+for integration with ldap for example, through `mod_ldap <https://httpd.apache.org/docs/2.4/mod/
+mod_ldap.html>`_, or certificate based API access, etc.
 
 Enable external authentication in two steps:
 
@@ -37,7 +19,7 @@ backend for them. To have any name accepted but create the username in the datab
 
 
 2. Specify how to receive the username from the webserver. Do this by specifying to DRF an
-   AUTHENTICATION_CLASS. For example, use the ``PulpRemoteUserAuthentication`` as follows::
+   ``AUTHENTICATION_CLASS``. For example, use the ``PulpRemoteUserAuthentication`` as follows::
 
     REST_FRAMEWORK['DEFAULT_AUTHENTICATION_CLASSES'] = (
         'rest_framework.authentication.SessionAuthentication',
@@ -59,7 +41,7 @@ This removes ``rest_framework.authentication.BasicAuthentication``, but retains
 :ref:`REMOTE_USER_ENVIRON_NAME <remote-user-environ-name>` Pulp setting.
 
 
-.. _webserver-auth-same-webserver:
+.. _webserver-authentication-same-webserver:
 
 Webserver Auth in Same Webserver
 ********************************
@@ -80,7 +62,7 @@ authentication, you likely want to leave :ref:`REMOTE_USER_ENVIRON_NAME <remote-
 unset and configure the webserver to set the ``REMOTE_USER`` WSGI environment variable.
 
 
-.. _webserver-auth-with-reverse-proxy:
+.. _webserver-authentication-with-reverse-proxy:
 
 Webserver Auth with Reverse Proxy
 *********************************
@@ -114,15 +96,3 @@ you to specify another WSGI environment variable to read the authenticated usern
     Configuring this has serious security implications. See the `Django warning at the end of this
     section in their docs <https://docs.djangoproject.com/en/2.2/howto/auth-remote-user/
     #configuration>`_ for more details.
-
-
-Custom Authentication
----------------------
-
-Pulp is a Django app and Django Rest Framework (DRF) application, so additional authentication can
-be added as long as it's correctly configured for both Django and Django Rest Frameowork.
-
-See the `Django docs on configuring custom authentication <https://docs.djangoproject.com/en/2.2/
-topics/auth/customizing/#customizing-authentication-in-django>`_ and the `Django Rest Framework docs
-on configuring custom authentication <https://www.django-rest-framework.org/api-guide/authentication
-/#custom-authentication>`_.

--- a/docs/configuration/settings.rst
+++ b/docs/configuration/settings.rst
@@ -205,7 +205,7 @@ REMOTE_USER_ENVIRON_NAME
 ^^^^^^^^^^^^^^^^^^^^^^^^
 
    The name of the WSGI environment variable to read for :ref:`webserver authentication
-   <webserver-auth>`.
+   <webserver-authentication>`.
 
    .. warning::
 

--- a/docs/installation/instructions.rst
+++ b/docs/installation/instructions.rst
@@ -1,5 +1,5 @@
-Installation Instructions
-=========================
+Instructions
+============
 
 Supported Platforms
 -------------------


### PR DESCRIPTION
This moves all of the authentication into one place and organizes it
into and Overview, Basic, Webserver, and Other sections.

It also deletes the 'disabling auth' docs. Upon testing Django refuses
to start if you follow those docs.

closes #8801

