### PR TITLE
Try a different method of ignoring versions in dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,13 +7,10 @@ updates:
   open-pull-requests-limit: 10
   ignore:
   - dependency-name: django
-    versions:
-    - ">= 2.3, < 2.2"
+    versions: ["3.x"]
   - dependency-name: djangorestframework
-    versions:
-    - ">= 3"
+    versions: ["3.x"]
   - dependency-name: django-guid
-    versions:
-    - ">= 3"
+    versions: ["3.x"]
   commit-message:
     prefix: "[noissue]"


### PR DESCRIPTION
Trying [the method of ignoring versions from the github dependabot docs](https://docs.github.com/en/code-security/supply-chain-security/keeping-your-dependencies-updated-automatically/configuration-options-for-dependency-updates#ignore)
since [the current method doesn't seem to work](https://github.com/pulp/pulpcore/pull/1389).

[noissue]

Please be sure you have read our documentation on creating PRs:
https://docs.pulpproject.org/contributing/pull-request-walkthrough.html
