### PR TITLE
Fixes request schema for `/pulp/api/v3/repair/`

### DIFF
--- a/CHANGES/8869.bugfix
+++ b/CHANGES/8869.bugfix
@@ -1,0 +1,2 @@
+Fixed request schema for ``/pulp/api/v3/repair/``, which did identify any arguments. This also fixes
+the bindings.

--- a/pulpcore/app/views/repair.py
+++ b/pulpcore/app/views/repair.py
@@ -14,6 +14,7 @@ class RepairView(APIView):
             "or corrupted artifacts, and attempts to redownload them."
         ),
         summary="Repair Artifact Storage",
+        request=RepairSerializer,
         responses={202: AsyncOperationResponseSerializer},
     )
     def post(self, request):


### PR DESCRIPTION
Links the RepairSerializer with the view for `/pulp/api/v3/repair/`.
Without this no arguments can be passed in through bindings.

closes #8869

