### PR TITLE
Adds `/pulp/api/v3/orphans/cleanup/`

### DIFF
--- a/.github/workflows/scripts/script.sh
+++ b/.github/workflows/scripts/script.sh
@@ -111,7 +111,6 @@ export PYTHONPATH=$REPO_ROOT${PYTHONPATH:+:${PYTHONPATH}}
 
 
 if [[ "$TEST" == "upgrade" ]]; then
-  git checkout ci_upgrade_test -- pulpcore/tests/
 
   # Handle app label change:
   sed -i "/require_pulp_plugins(/d" pulpcore/tests/functional/utils.py
@@ -160,6 +159,7 @@ if [[ "$TEST" == "upgrade" ]]; then
   cd $REPO_ROOT
 
   # Running post upgrade tests
+  git checkout ci_upgrade_test -- pulpcore/tests/
   pytest -v -r sx --color=yes --pyargs -capture=no pulpcore.tests.upgrade.post
   exit
 fi

--- a/CHANGES/8658.feature
+++ b/CHANGES/8658.feature
@@ -1,0 +1,4 @@
+Added new endpoint ``/pulp/api/v3/orphans/cleanup/``. When called with ``POST`` and no parameters
+it is equivalent to calling ``DELETE /pulp/api/v3/orphans/``. Additionally the optional parameter
+``content_hrefs`` can be specified and must contain a list of content hrefs. When ``content_hrefs``
+is specified, only those content units will be considered to be removed by orphan cleanup.

--- a/pulpcore/app/serializers/__init__.py
+++ b/pulpcore/app/serializers/__init__.py
@@ -57,6 +57,7 @@ from .importer import (  # noqa
     PulpImporterSerializer,
     PulpImportSerializer,
 )
+from .orphans import OrphansCleanupSerializer  # noqa
 from .progress import GroupProgressReportSerializer, ProgressReportSerializer  # noqa
 from .publication import (  # noqa
     ContentGuardSerializer,

--- a/pulpcore/app/serializers/orphans.py
+++ b/pulpcore/app/serializers/orphans.py
@@ -1,0 +1,34 @@
+from gettext import gettext as _
+
+from rest_framework import fields, serializers
+
+from pulpcore.app.models import Content
+from pulpcore.app.serializers import ValidateFieldsMixin
+
+
+class OrphansCleanupSerializer(serializers.Serializer, ValidateFieldsMixin):
+
+    content_hrefs = fields.ListField(
+        required=False,
+        help_text=_("Will delete specified content and associated Artifacts if they are orphans."),
+    )
+
+    def validate_content_hrefs(self, value):
+        """
+        Check that the content_hrefs is not an empty list and contains all valid hrefs.
+        Args:
+            value (list): The list supplied by the user
+        Returns:
+            The list of pks (not hrefs) after validation
+        Raises:
+            ValidationError: If the list is empty or contains invalid hrefs.
+        """
+        if len(value) == 0:
+            raise serializers.ValidationError("Must not be [].")
+        from pulpcore.app.viewsets import NamedModelViewSet
+
+        pks_to_return = []
+        for href in value:
+            pks_to_return.append(NamedModelViewSet.get_resource(href, Content).pk)
+
+        return pks_to_return

--- a/pulpcore/app/tasks/orphan.py
+++ b/pulpcore/app/tasks/orphan.py
@@ -29,11 +29,14 @@ def queryset_iterator(qs, batchsize=2000, gc_collect=True):
             gc.collect()
 
 
-def orphan_cleanup():
+def orphan_cleanup(content_pks=None):
     """
     Delete all orphan Content and Artifact records.
     Go through orphan Content multiple times to remove content from subrepos.
     This task removes Artifact files from the filesystem as well.
+
+    Kwargs:
+        content_pks (list): A list of content pks. If specified, only remove these orphans.
 
     """
     progress_bar = ProgressReport(
@@ -48,6 +51,9 @@ def orphan_cleanup():
         content = Content.objects.filter(version_memberships__isnull=True).exclude(
             pulp_type=PublishedMetadata.get_pulp_type()
         )
+        if content_pks:
+            content = content.filter(pk__in=content_pks)
+
         content_count = content.count()
         if not content_count:
             break

--- a/pulpcore/app/urls.py
+++ b/pulpcore/app/urls.py
@@ -16,7 +16,7 @@ from rest_framework_nested import routers
 
 from pulpcore.app.apps import pulp_plugin_configs
 from pulpcore.app.views import OrphansView, PulpImporterImportCheckView, RepairView, StatusView
-from pulpcore.app.viewsets import ListRepositoryVersionViewSet
+from pulpcore.app.viewsets import ListRepositoryVersionViewSet, OrphansCleanupViewset
 from pulpcore.constants import API_ROOT
 from pulpcore.openapi import PulpSchemaGenerator
 
@@ -123,6 +123,10 @@ root_router = routers.DefaultRouter()
 urlpatterns = [
     url(r"^{api_root}repair/".format(api_root=API_ROOT), RepairView.as_view()),
     url(r"^{api_root}status/".format(api_root=API_ROOT), StatusView.as_view()),
+    url(
+        r"^{api_root}orphans/cleanup/".format(api_root=API_ROOT),
+        OrphansCleanupViewset.as_view({"post": "cleanup"}),
+    ),
     url(r"^{api_root}orphans/".format(api_root=API_ROOT), OrphansView.as_view()),
     url(
         r"^{api_root}repository_versions/".format(api_root=API_ROOT),

--- a/pulpcore/app/viewsets/__init__.py
+++ b/pulpcore/app/viewsets/__init__.py
@@ -35,6 +35,7 @@ from .importer import (  # noqa
     PulpImportViewSet,
     PulpImporterViewSet,
 )
+from .orphans import OrphansCleanupViewset  # noqa
 from .publication import (  # noqa
     ContentGuardFilter,
     ContentGuardViewSet,

--- a/pulpcore/app/viewsets/orphans.py
+++ b/pulpcore/app/viewsets/orphans.py
@@ -1,0 +1,28 @@
+from drf_spectacular.utils import extend_schema
+from rest_framework.viewsets import ViewSet
+
+from pulpcore.app.response import OperationPostponedResponse
+from pulpcore.app.serializers import AsyncOperationResponseSerializer, OrphansCleanupSerializer
+from pulpcore.app.tasks import orphan_cleanup
+from pulpcore.tasking.tasks import dispatch
+
+
+class OrphansCleanupViewset(ViewSet):
+    serializer_class = OrphansCleanupSerializer
+
+    @extend_schema(
+        description="Trigger an asynchronous orphan cleanup operation.",
+        responses={202: AsyncOperationResponseSerializer},
+    )
+    def cleanup(self, request):
+        """
+        Triggers an asynchronous orphan cleanup operation.
+        """
+        serializer = OrphansCleanupSerializer(data=request.data)
+        serializer.is_valid(raise_exception=True)
+
+        content_pks = serializer.validated_data.get("content_hrefs", None)
+
+        task = dispatch(orphan_cleanup, [], kwargs={"content_pks": content_pks})
+
+        return OperationPostponedResponse(task, request)

--- a/pulpcore/tests/functional/api/test_correlation_id.py
+++ b/pulpcore/tests/functional/api/test_correlation_id.py
@@ -4,7 +4,7 @@ import uuid
 from pulp_smash import api, cli, config
 from pulp_smash.pulp3.bindings import monitor_task
 
-from pulpcore.client.pulpcore import ApiClient, OrphansApi, TasksApi
+from pulpcore.client.pulpcore import ApiClient, OrphansCleanupApi, TasksApi
 
 
 class CorrelationIdTestCase(unittest.TestCase):
@@ -23,12 +23,12 @@ class CorrelationIdTestCase(unittest.TestCase):
         )
         cls.cli_client = cli.Client(cls.cfg)
 
-        cls.orphan_api = OrphansApi(cls.client)
+        cls.orphan_cleanup_api = OrphansCleanupApi(cls.client)
         cls.task_api = TasksApi(cls.client)
 
     def test_correlation_id(self):
         """Test that a correlation can be passed as a header and logged."""
-        response, status, headers = self.orphan_api.delete_with_http_info()
+        response, status, headers = self.orphan_cleanup_api.cleanup_with_http_info({})
         monitor_task(response.task)
         task = self.task_api.read(response.task)
         self.assertEqual(headers["Correlation-ID"], self.cid)

--- a/pulpcore/tests/functional/api/test_crd_artifacts.py
+++ b/pulpcore/tests/functional/api/test_crd_artifacts.py
@@ -6,8 +6,8 @@ import unittest
 
 from pulp_smash import api, cli, config, utils
 from pulp_smash.exceptions import CalledProcessError
+from pulp_smash.pulp3.bindings import delete_orphans
 from pulp_smash.pulp3.constants import ARTIFACTS_PATH
-from pulp_smash.pulp3.utils import delete_orphans
 from requests.exceptions import HTTPError
 
 # This import is an exception, we use a file url but we are not actually using
@@ -29,7 +29,7 @@ class ArtifactTestCase(unittest.TestCase):
     def setUpClass(cls):
         """Delete orphans and create class-wide variables."""
         cfg = config.get_config()
-        delete_orphans(cfg)
+        delete_orphans()
         cls.client = api.Client(cfg, api.json_handler)
         cls.file = {"file": utils.http_get(FILE_URL)}
         cls.file_sha256 = hashlib.sha256(cls.file["file"]).hexdigest()

--- a/pulpcore/tests/functional/api/using_plugin/test_content_delivery.py
+++ b/pulpcore/tests/functional/api/using_plugin/test_content_delivery.py
@@ -5,9 +5,9 @@ from random import choice
 from urllib.parse import urljoin
 
 from pulp_smash import api, config, utils
+from pulp_smash.pulp3.bindings import delete_orphans
 from pulp_smash.pulp3.constants import ON_DEMAND_DOWNLOAD_POLICIES
 from pulp_smash.pulp3.utils import (
-    delete_orphans,
     download_content_unit,
     gen_distribution,
     gen_repo,
@@ -53,7 +53,7 @@ class ContentDeliveryTestCase(unittest.TestCase):
         remote is recreated and another sync is triggered.
         """
         cfg = config.get_config()
-        delete_orphans(cfg)
+        delete_orphans()
         client = api.Client(cfg, api.page_handler)
 
         repo = client.post(FILE_REPO_PATH, gen_repo())

--- a/pulpcore/tests/functional/api/using_plugin/test_content_path.py
+++ b/pulpcore/tests/functional/api/using_plugin/test_content_path.py
@@ -2,7 +2,8 @@
 import unittest
 
 from pulp_smash import api, config
-from pulp_smash.pulp3.utils import delete_orphans, gen_remote, gen_repo, sync
+from pulp_smash.pulp3.bindings import delete_orphans
+from pulp_smash.pulp3.utils import gen_remote, gen_repo, sync
 
 from pulpcore.tests.functional.api.using_plugin.constants import (
     FILE_FIXTURE_MANIFEST_URL,
@@ -45,7 +46,7 @@ class SyncPublishContentPathTestCase(unittest.TestCase):
 
         # step 1. delete orphans to assure that no content is present on disk,
         # or database.
-        delete_orphans(cfg)
+        delete_orphans()
 
         remote = client.post(FILE_REMOTE_PATH, gen_remote(FILE_FIXTURE_MANIFEST_URL))
         self.addCleanup(client.delete, remote["pulp_href"])

--- a/pulpcore/tests/functional/api/using_plugin/test_distributions.py
+++ b/pulpcore/tests/functional/api/using_plugin/test_distributions.py
@@ -5,8 +5,8 @@ import unittest
 from urllib.parse import urljoin
 
 from pulp_smash import api, config, utils
+from pulp_smash.pulp3.bindings import delete_orphans
 from pulp_smash.pulp3.utils import (
-    delete_orphans,
     download_content_unit,
     gen_distribution,
     gen_repo,

--- a/pulpcore/tests/functional/api/using_plugin/test_generic_list.py
+++ b/pulpcore/tests/functional/api/using_plugin/test_generic_list.py
@@ -3,8 +3,8 @@ import tempfile
 import unittest
 
 from pulp_smash import config, utils
-from pulp_smash.pulp3.bindings import monitor_task
-from pulp_smash.pulp3.utils import delete_orphans, gen_repo
+from pulp_smash.pulp3.bindings import delete_orphans, monitor_task
+from pulp_smash.pulp3.utils import gen_repo
 
 from pulpcore.tests.functional.api.using_plugin.constants import X509_CA_CERT_FILE_PATH
 from pulpcore.tests.functional.utils import set_up_module as setUpModule  # noqa:F401

--- a/pulpcore/tests/functional/api/using_plugin/test_orphans.py
+++ b/pulpcore/tests/functional/api/using_plugin/test_orphans.py
@@ -7,7 +7,6 @@ from pulp_smash import cli, config, utils
 from pulp_smash.exceptions import CalledProcessError
 from pulp_smash.pulp3.bindings import monitor_task
 from pulp_smash.pulp3.utils import (
-    delete_orphans,
     delete_version,
     gen_repo,
     get_content,
@@ -16,6 +15,7 @@ from pulp_smash.pulp3.utils import (
 
 from pulpcore.tests.functional.api.using_plugin.constants import FILE_CONTENT_NAME
 from pulpcore.client.pulpcore import ArtifactsApi
+from pulpcore.client.pulpcore import OrphansApi, OrphansCleanupApi
 from pulpcore.client.pulpcore.exceptions import ApiException
 from pulpcore.client.pulp_file import (
     ApiClient,
@@ -32,16 +32,12 @@ from pulpcore.tests.functional.api.using_plugin.utils import (  # noqa:F401
 
 
 class DeleteOrphansTestCase(unittest.TestCase):
-    """Test whether orphans files can be clean up.
+    """Test whether orphan files can be cleaned up.
 
     An orphan artifact is an artifact that is not in any content units.
     An orphan content unit is a content unit that is not in any repository
     version.
 
-    This test targets the following issues:
-
-    * `Pulp #3442 <https://pulp.plan.io/issues/3442>`_
-    * `Pulp Smash #914 <https://github.com/pulp/pulp-smash/issues/914>`_
     """
 
     @classmethod
@@ -50,23 +46,12 @@ class DeleteOrphansTestCase(unittest.TestCase):
         cls.cfg = config.get_config()
         cls.api_client = ApiClient(configuration)
         cls.cli_client = cli.Client(cls.cfg)
+        cls.orphans_api = OrphansApi(core_client)
         cls.storage = utils.get_pulp_setting(cls.cli_client, "DEFAULT_FILE_STORAGE")
         cls.media_root = utils.get_pulp_setting(cls.cli_client, "MEDIA_ROOT")
 
     def test_clean_orphan_content_unit(self):
-        """Test whether orphan content units can be clean up.
-
-        Do the following:
-
-        1. Create, and sync a repo.
-        2. Remove a content unit from the repo. This will create a second
-           repository version, and create an orphan content unit.
-        3. Assert that content unit that was removed from the repo and its
-           artifact are present on disk.
-        4. Delete orphans.
-        5. Assert that the orphan content unit was cleaned up, and its artifact
-           is not present on disk.
-        """
+        """Test whether orphaned content units can be cleaned up."""
         repo_api = RepositoriesFileApi(self.api_client)
         remote_api = RemotesFileApi(self.api_client)
 
@@ -105,7 +90,9 @@ class DeleteOrphansTestCase(unittest.TestCase):
         content_units_href = [c["pulp_href"] for c in content_units]
         self.assertIn(content["pulp_href"], content_units_href)
 
-        delete_orphans()
+        orphans_response = self.orphans_api.delete()
+        monitor_task(orphans_response.task)
+
         content_units = file_contents_api.list().to_dict()["results"]
         content_units_href = [c["pulp_href"] for c in content_units]
         self.assertNotIn(content["pulp_href"], content_units_href)
@@ -128,7 +115,8 @@ class DeleteOrphansTestCase(unittest.TestCase):
             cmd = ("ls", os.path.join(self.media_root, artifact.file))
             self.cli_client.run(cmd, sudo=True)
 
-        delete_orphans()
+        orphans_response = self.orphans_api.delete()
+        monitor_task(orphans_response.task)
 
         with self.assertRaises(ApiException):
             artifacts_api.read(artifact.pulp_href)
@@ -136,3 +124,150 @@ class DeleteOrphansTestCase(unittest.TestCase):
         if self.storage == "pulpcore.app.models.storage.FileSystem":
             with self.assertRaises(CalledProcessError):
                 self.cli_client.run(cmd)
+
+
+class OrphansCleanUpTestCase(unittest.TestCase):
+    """Test the orphan cleanup endpoint.
+
+    An orphan artifact is an artifact that is not in any content units.
+    An orphan content unit is a content unit that is not in any repository
+    version.
+
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        """Create class-wide variables."""
+        cls.cfg = config.get_config()
+        cls.api_client = ApiClient(configuration)
+        cls.cli_client = cli.Client(cls.cfg)
+        cls.orphans_cleanup_api = OrphansCleanupApi(core_client)
+        cls.storage = utils.get_pulp_setting(cls.cli_client, "DEFAULT_FILE_STORAGE")
+        cls.media_root = utils.get_pulp_setting(cls.cli_client, "MEDIA_ROOT")
+
+    def test_clean_orphan_content_unit(self):
+        """Test whether orphaned content units can be cleaned up."""
+        repo_api = RepositoriesFileApi(self.api_client)
+        remote_api = RemotesFileApi(self.api_client)
+
+        repo = repo_api.create(gen_repo())
+        self.addCleanup(repo_api.delete, repo.pulp_href)
+
+        body = gen_file_remote()
+        remote = remote_api.create(body)
+        self.addCleanup(remote_api.delete, remote.pulp_href)
+
+        # Sync the repository.
+        self.assertEqual(repo.latest_version_href, f"{repo.pulp_href}versions/0/")
+        repository_sync_data = RepositorySyncURL(remote=remote.pulp_href)
+        sync_response = repo_api.sync(repo.pulp_href, repository_sync_data)
+        monitor_task(sync_response.task)
+        repo = repo_api.read(repo.pulp_href)
+        content = choice(get_content(repo.to_dict())[FILE_CONTENT_NAME])
+
+        # Create an orphan content unit.
+        repo_api.modify(repo.pulp_href, dict(remove_content_units=[content["pulp_href"]]))
+
+        artifacts_api = ArtifactsApi(core_client)
+
+        if self.storage == "pulpcore.app.models.storage.FileSystem":
+            # Verify that the artifact is present on disk.
+            relative_path = artifacts_api.read(content["artifact"]).file
+            artifact_path = os.path.join(self.media_root, relative_path)
+            cmd = ("ls", artifact_path)
+            self.cli_client.run(cmd, sudo=True)
+
+        file_contents_api = ContentFilesApi(self.api_client)
+        # Delete first repo version. The previous removed content unit will be
+        # an orphan.
+        delete_version(repo, get_versions(repo.to_dict())[1]["pulp_href"])
+        content_units = file_contents_api.list().to_dict()["results"]
+        content_units_href = [c["pulp_href"] for c in content_units]
+        self.assertIn(content["pulp_href"], content_units_href)
+
+        orphans_response = self.orphans_cleanup_api.cleanup({})
+        monitor_task(orphans_response.task)
+
+        content_units = file_contents_api.list().to_dict()["results"]
+        content_units_href = [c["pulp_href"] for c in content_units]
+        self.assertNotIn(content["pulp_href"], content_units_href)
+
+        if self.storage == "pulpcore.app.models.storage.FileSystem":
+            # Verify that the artifact was removed from disk.
+            with self.assertRaises(CalledProcessError):
+                self.cli_client.run(cmd)
+
+    def test_clean_orphan_artifact(self):
+        """Test whether orphan artifacts units can be clean up."""
+        repo_api = RepositoriesFileApi(self.api_client)
+        repo = repo_api.create(gen_repo())
+        self.addCleanup(repo_api.delete, repo.pulp_href)
+
+        artifacts_api = ArtifactsApi(core_client)
+        artifact = artifacts_api.create(file=__file__)
+
+        if self.storage == "pulpcore.app.models.storage.FileSystem":
+            cmd = ("ls", os.path.join(self.media_root, artifact.file))
+            self.cli_client.run(cmd, sudo=True)
+
+        orphans_response = self.orphans_cleanup_api.cleanup({})
+        monitor_task(orphans_response.task)
+
+        with self.assertRaises(ApiException):
+            artifacts_api.read(artifact.pulp_href)
+
+        if self.storage == "pulpcore.app.models.storage.FileSystem":
+            with self.assertRaises(CalledProcessError):
+                self.cli_client.run(cmd)
+
+    def test_clean_specific_orphans(self):
+        """Test whether the `content_hrefs` param removes specific orphans but not others"""
+        repo_api = RepositoriesFileApi(self.api_client)
+        remote_api = RemotesFileApi(self.api_client)
+
+        repo = repo_api.create(gen_repo())
+        self.addCleanup(repo_api.delete, repo.pulp_href)
+
+        body = gen_file_remote()
+        remote = remote_api.create(body)
+        self.addCleanup(remote_api.delete, remote.pulp_href)
+
+        # Sync the repository.
+        self.assertEqual(repo.latest_version_href, f"{repo.pulp_href}versions/0/")
+        repository_sync_data = RepositorySyncURL(remote=remote.pulp_href)
+        sync_response = repo_api.sync(repo.pulp_href, repository_sync_data)
+        monitor_task(sync_response.task)
+        repo = repo_api.read(repo.pulp_href)
+
+        # Create two orphaned content units.
+        content_a = get_content(repo.to_dict())[FILE_CONTENT_NAME][0]["pulp_href"]
+        content_b = get_content(repo.to_dict())[FILE_CONTENT_NAME][1]["pulp_href"]
+        content_to_remove = dict(remove_content_units=[content_a, content_b])
+        repo_api.modify(repo.pulp_href, content_to_remove)
+
+        file_contents_api = ContentFilesApi(self.api_client)
+        # Delete first repo version. The previous removed content unit will be an orphan.
+        delete_version(repo, get_versions(repo.to_dict())[1]["pulp_href"])
+        content_units = file_contents_api.list().to_dict()["results"]
+        content_units_href = [c["pulp_href"] for c in content_units]
+        self.assertIn(content_a, content_units_href)
+        self.assertIn(content_b, content_units_href)
+
+        content_hrefs_dict = {"content_hrefs": [content_a]}
+        orphans_response = self.orphans_cleanup_api.cleanup(content_hrefs_dict)
+        monitor_task(orphans_response.task)
+
+        content_units = file_contents_api.list().to_dict()["results"]
+        content_units_href = [c["pulp_href"] for c in content_units]
+        self.assertNotIn(content_a, content_units_href)
+        self.assertIn(content_b, content_units_href)
+
+    def test_clean_specific_orphans_but_no_orphans_specified(self):
+        """Test whether the `content_hrefs` param raises a ValidationError with [] as the value"""
+        content_hrefs_dict = {"content_hrefs": []}
+        self.assertRaises(ApiException, self.orphans_cleanup_api.cleanup, content_hrefs_dict)
+
+    def test_clean_specific_orphans_but_invalid_orphan_specified(self):
+        """Test whether the `content_hrefs` param raises a ValidationError with and invalid href"""
+        content_hrefs_dict = {"content_hrefs": ["/not/a/valid/content/href"]}
+        self.assertRaises(ApiException, self.orphans_cleanup_api.cleanup, content_hrefs_dict)

--- a/pulpcore/tests/functional/api/using_plugin/test_publications.py
+++ b/pulpcore/tests/functional/api/using_plugin/test_publications.py
@@ -1,10 +1,9 @@
 import unittest
 
 from pulp_smash import config
-from pulp_smash.pulp3.bindings import monitor_task
+from pulp_smash.pulp3.bindings import delete_orphans, monitor_task
 
 from pulp_smash.pulp3.utils import (
-    delete_orphans,
     gen_repo,
     get_content,
 )
@@ -40,7 +39,7 @@ class ContentInPublicationViewTestCase(unittest.TestCase):
 
     @classmethod
     def tearDownClass(cls):
-        delete_orphans(cls.cfg)
+        delete_orphans()
 
     def test_all(self):
         """Create two publications and check view filter."""

--- a/pulpcore/tests/functional/api/using_plugin/test_pulpexport.py
+++ b/pulpcore/tests/functional/api/using_plugin/test_pulpexport.py
@@ -7,9 +7,8 @@ the case.
 import unittest
 from pulp_smash import api, cli, config, utils
 from pulp_smash.utils import uuid4
-from pulp_smash.pulp3.bindings import monitor_task
+from pulp_smash.pulp3.bindings import delete_orphans, monitor_task
 from pulp_smash.pulp3.utils import (
-    delete_orphans,
     gen_repo,
 )
 
@@ -105,7 +104,7 @@ class BaseExporterCase(unittest.TestCase):
             cls.remote_api.delete(remote.pulp_href)
         for repo in cls.repos:
             cls.repo_api.delete(repo.pulp_href)
-        delete_orphans(cls.cfg)
+        delete_orphans()
 
     def _create_exporter(self, cleanup=True, use_repos=None):
         """

--- a/pulpcore/tests/functional/api/using_plugin/test_pulpimport.py
+++ b/pulpcore/tests/functional/api/using_plugin/test_pulpimport.py
@@ -9,9 +9,8 @@ import unittest
 
 from pulp_smash import api, cli, config
 from pulp_smash.utils import uuid4, get_pulp_setting
-from pulp_smash.pulp3.bindings import monitor_task, monitor_task_group
+from pulp_smash.pulp3.bindings import delete_orphans, monitor_task, monitor_task_group
 from pulp_smash.pulp3.utils import (
-    delete_orphans,
     gen_repo,
 )
 
@@ -199,7 +198,7 @@ class PulpImportTestCase(unittest.TestCase):
             cls.repo_api.delete(repo.pulp_href)
         delete_exporter(cls.exporter)
         cls._delete_import_check_structures()
-        delete_orphans(cls.cfg)
+        delete_orphans()
 
     def _create_importer(self, name=None, cleanup=True, exported_repos=None):
         """Create an importer."""

--- a/pulpcore/tests/functional/api/using_plugin/test_repair.py
+++ b/pulpcore/tests/functional/api/using_plugin/test_repair.py
@@ -4,9 +4,9 @@ from random import sample
 from urllib.parse import urljoin
 
 from pulp_smash import api, cli, config, utils
+from pulp_smash.pulp3.bindings import delete_orphans
 from pulp_smash.pulp3.constants import BASE_PATH
 from pulp_smash.pulp3.utils import (
-    delete_orphans,
     gen_repo,
     get_content,
     get_versions,

--- a/pulpcore/tests/functional/api/using_plugin/test_repo_versions.py
+++ b/pulpcore/tests/functional/api/using_plugin/test_repo_versions.py
@@ -6,11 +6,10 @@ from urllib.parse import urlsplit
 
 from pulp_smash import api, config, utils
 from pulp_smash.exceptions import TaskReportError
-from pulp_smash.pulp3.bindings import monitor_task
+from pulp_smash.pulp3.bindings import delete_orphans, monitor_task
 from pulp_smash.pulp3.constants import ARTIFACTS_PATH
 from pulp_smash.pulp3.utils import (
     download_content_unit,
-    delete_orphans,
     delete_version,
     gen_repo,
     gen_distribution,
@@ -599,7 +598,7 @@ class CreateRepoBaseVersionTestCase(unittest.TestCase):
     def setUpClass(cls):
         """Create class-wide variables."""
         cls.cfg = config.get_config()
-        delete_orphans(cls.cfg)
+        delete_orphans()
         populate_pulp(cls.cfg, url=FILE_LARGE_FIXTURE_MANIFEST_URL)
         cls.client = api.Client(cls.cfg, api.page_handler)
         cls.content = cls.client.get(FILE_CONTENT_PATH)
@@ -1048,11 +1047,11 @@ class BaseVersionTestCase(unittest.TestCase):
     @classmethod
     def tearDownClass(cls):
         """Clean created resources."""
-        delete_orphans(cls.cfg)
+        delete_orphans()
 
     def test_add_content_with_base_version(self):
         """Test modify repository with base_version"""
-        delete_orphans(self.cfg)
+        delete_orphans()
 
         repo = self.client.post(FILE_REPO_PATH, gen_repo())
         self.addCleanup(self.client.delete, repo["pulp_href"])
@@ -1197,7 +1196,7 @@ class ContentInRepositoryVersionViewTestCase(unittest.TestCase):
 
     @classmethod
     def tearDownClass(cls):
-        delete_orphans(cls.cfg)
+        delete_orphans()
 
     def test_all(self):
         """Sync two repositories and check view filter."""

--- a/pulpcore/tests/functional/api/using_plugin/test_tasking.py
+++ b/pulpcore/tests/functional/api/using_plugin/test_tasking.py
@@ -3,8 +3,9 @@ import unittest
 from urllib.parse import urljoin
 
 from pulp_smash import api, config, utils
+from pulp_smash.pulp3.bindings import delete_orphans
 from pulp_smash.pulp3.constants import TASKS_PATH
-from pulp_smash.pulp3.utils import delete_orphans, gen_remote, gen_repo, get_content_summary, sync
+from pulp_smash.pulp3.utils import gen_remote, gen_repo, get_content_summary, sync
 from requests.exceptions import HTTPError
 
 from pulpcore.tests.functional.api.using_plugin.constants import (
@@ -112,7 +113,7 @@ class CancelTaskTestCase(unittest.TestCase):
     def create_long_task(self):
         """Create a long task. Sync a repository with large files."""
         # to force the download of files.
-        delete_orphans(self.cfg)
+        delete_orphans()
 
         repo = self.client.post(FILE_REPO_PATH, gen_repo())
         self.addCleanup(self.client.delete, repo["pulp_href"])


### PR DESCRIPTION
This adds a new endpoint `/pulp/api/v3/orphans/cleanup/`. When called
with `POST` and no parameters it is equivalent to calling `DELETE
/pulp/api/v3/orphans/`. Additionally the optional parameter
`content_hrefs` can be specified and must contain a list of content
hrefs. When `content_hrefs` is specified, only those content units will
be considered to be removed by orphan cleanup.

closes #8658