### PR TITLE
Adds DistributionFilter

### DIFF
--- a/CHANGES/plugin_api/8480.deprecation
+++ b/CHANGES/plugin_api/8480.deprecation
@@ -1,0 +1,2 @@
+The ``pulpcore.plugin.viewsets.NewDistributionFilter`` is deprecated and will be removed from a
+future release. Instead use ``pulpcore.plugin.viewsets.DistributionFilter``.

--- a/CHANGES/plugin_api/8480.feature
+++ b/CHANGES/plugin_api/8480.feature
@@ -1,0 +1,2 @@
+Adds the ``pulpcore.plugin.viewsets.DistributionFilter``. This should be used instead of
+``pulpcore.plugin.viewsets.NewDistributionFilter``.

--- a/pulpcore/app/viewsets/__init__.py
+++ b/pulpcore/app/viewsets/__init__.py
@@ -38,6 +38,7 @@ from .importer import (  # noqa
 from .publication import (  # noqa
     ContentGuardFilter,
     ContentGuardViewSet,
+    DistributionFilter,
     DistributionViewSet,
     ListContentGuardViewSet,
     ListPublicationViewSet,

--- a/pulpcore/app/viewsets/publication.py
+++ b/pulpcore/app/viewsets/publication.py
@@ -5,6 +5,7 @@ from django_filters.rest_framework import DjangoFilterBackend, filters
 from rest_framework import mixins, serializers
 from rest_framework.filters import OrderingFilter
 
+from pulpcore.app.loggers import deprecation_logger
 from pulpcore.app.models import (
     ContentGuard,
     Distribution,
@@ -129,7 +130,7 @@ class ContentGuardViewSet(
     """
 
 
-class NewDistributionFilter(BaseFilterSet):
+class DistributionFilter(BaseFilterSet):
     # e.g.
     # /?name=foo
     # /?name__in=foo,bar
@@ -145,6 +146,15 @@ class NewDistributionFilter(BaseFilterSet):
             "name": NAME_FILTER_OPTIONS,
             "base_path": ["exact", "contains", "icontains", "in"],
         }
+
+
+class NewDistributionFilter(DistributionFilter):
+    def __init__(self, *args, **kwargs):
+        deprecation_logger.warning(
+            "The NewDistributionFilter object is deprecated and will be removed in version 3.15. "
+            "Use DistributionFilter instead."
+        )
+        return super().__init__(*args, **kwargs)
 
 
 class DistributionViewSet(
@@ -164,7 +174,7 @@ class DistributionViewSet(
     endpoint_name = "distributions"
     queryset = Distribution.objects.all()
     serializer_class = DistributionSerializer
-    filterset_class = NewDistributionFilter
+    filterset_class = DistributionFilter
 
     def async_reserved_resources(self, instance):
         """Return resource that locks all Distributions."""

--- a/pulpcore/plugin/viewsets/__init__.py
+++ b/pulpcore/plugin/viewsets/__init__.py
@@ -9,6 +9,7 @@ from pulpcore.app.viewsets import (  # noqa
     ContentGuardFilter,
     ContentGuardViewSet,
     ContentViewSet,
+    DistributionFilter,
     DistributionViewSet,
     ExportViewSet,
     ExporterViewSet,


### PR DESCRIPTION
This add `pulpcore.plugin.viewsets.DistributionFilter` to replace
`pulpcore.plugin.viewsets.NewDistributionFilter`. The
`pulpcore.plugin.viewsets.NewDistributionFilter` is now deprecated and
will emit warnings if used.

closes #8480

