### PR TITLE
Extend retry logic to cover more types of errors

### DIFF
--- a/CHANGES/8867.bugfix
+++ b/CHANGES/8867.bugfix
@@ -1,0 +1,1 @@
+Retry downloads on ``ClientConnectorSSLError``, which appears to be spuriously returned by some CDNs.

--- a/CHANGES/8881.feature
+++ b/CHANGES/8881.feature
@@ -1,0 +1,1 @@
+Downloads from remote sources will now be retried on more kinds of errors, such as HTTP 500 or socket errors.

--- a/CHANGES/plugin_api/8881.deprecation
+++ b/CHANGES/plugin_api/8881.deprecation
@@ -1,0 +1,1 @@
+Plugin writers who create custom downloaders by subclassing ``HttpDownloader`` no longer need to wrap the ``_run()`` method with a ``backoff`` decorator. Consequntly the ``http_giveup`` handler the sake of the ``backoff`` decorator is no longer needed and has been deprecated. It is likely be removed in pulpcore 3.15.

--- a/CHANGES/plugin_api/8881.feature
+++ b/CHANGES/plugin_api/8881.feature
@@ -1,0 +1,1 @@
+Added a field ``DEFAULT_MAX_RETRIES`` to the ``Remote`` base class - plugin writers can override the default number of retries attempted when file downloads failed for each type of remote. The default value is 3.

--- a/pulpcore/app/migrations/0066_download_concurrency_and_retry_changes.py
+++ b/pulpcore/app/migrations/0066_download_concurrency_and_retry_changes.py
@@ -16,4 +16,9 @@ class Migration(migrations.Migration):
             name='download_concurrency',
             field=models.PositiveIntegerField(null=True, validators=[django.core.validators.MinValueValidator(1, 'Download concurrency must be at least 1')]),
         ),
+        migrations.AddField(
+            model_name='remote',
+            name='max_retries',
+            field=models.PositiveIntegerField(null=True),
+        ),
     ]

--- a/pulpcore/app/models/repository.py
+++ b/pulpcore/app/models/repository.py
@@ -257,6 +257,7 @@ class Remote(MasterModel):
     STREAMED = "streamed"
 
     DEFAULT_DOWNLOAD_CONCURRENCY = 10
+    DEFAULT_MAX_RETRIES = 3
 
     POLICY_CHOICES = (
         (IMMEDIATE, "When syncing, download all metadata and content now."),
@@ -293,6 +294,7 @@ class Remote(MasterModel):
     download_concurrency = models.PositiveIntegerField(
         null=True, validators=[MinValueValidator(1, "Download concurrency must be at least 1")]
     )
+    max_retries = models.PositiveIntegerField(null=True)
     policy = models.TextField(choices=POLICY_CHOICES, default=IMMEDIATE)
 
     total_timeout = models.FloatField(

--- a/pulpcore/app/serializers/repository.py
+++ b/pulpcore/app/serializers/repository.py
@@ -144,6 +144,14 @@ class RemoteSerializer(ModelSerializer):
         required=False,
         min_value=1,
     )
+    max_retries = serializers.IntegerField(
+        help_text=(
+            "Maximum number of retry attempts after a download failure. If not set then the "
+            "default value (3) will be used."
+        ),
+        required=False,
+        allow_null=True,
+    )
     policy = serializers.ChoiceField(
         help_text="The policy to use when downloading content.",
         choices=((models.Remote.IMMEDIATE, "When syncing, download all metadata and content now.")),
@@ -263,6 +271,7 @@ class RemoteSerializer(ModelSerializer):
             "pulp_labels",
             "pulp_last_updated",
             "download_concurrency",
+            "max_retries",
             "policy",
             "total_timeout",
             "connect_timeout",

--- a/pulpcore/download/factory.py
+++ b/pulpcore/download/factory.py
@@ -160,6 +160,12 @@ class DownloaderFactory:
             is configured with the remote settings.
         """
         kwargs["semaphore"] = self._semaphore
+        kwargs["max_retries"] = (
+            kwargs.get("max_retries")
+            or self._remote.max_retries
+            or self._remote.DEFAULT_MAX_RETRIES
+        )
+
         scheme = urlparse(url).scheme.lower()
         try:
             builder = self._handler_map[scheme]

--- a/pulpcore/download/http.py
+++ b/pulpcore/download/http.py
@@ -13,23 +13,45 @@ logging.getLogger("backoff").addHandler(logging.StreamHandler())
 
 
 def http_giveup(exc):
+    """Deprecated."""
+    from pulpcore.app.loggers import deprecation_logger
+
+    deprecation_logger.warning(
+        "http_giveup() is no longer necessary and has been deprecated. "
+        "It will be removed in pulpcore 3.15."
+    )
+    return http_giveup_handler(exc)
+
+
+def http_giveup_handler(exc):
     """
     Inspect a raised exception and determine if we should give up.
 
-    Do not give up when the status code is one of the following:
+    Do not give up when the error is one of the following:
 
-        429 - Too Many Requests
-        502 - Bad Gateway
-        503 - Service Unavailable
-        504 - Gateway Timeout
+        HTTP 429 - Too Many Requests
+        HTTP 5xx - Server errors
+        Socket timeout
+        TCP disconnect
+        Client SSL Error
+
+    Based on the AWS and Google Cloud guidelines:
+        https://docs.aws.amazon.com/general/latest/gr/api-retries.html
+        https://cloud.google.com/storage/docs/retry-strategy
 
     Args:
-        exc (aiohttp.ClientResponseException): The exception to inspect
+        exc (Exception): The exception to inspect
 
     Returns:
         True if the download should give up, False otherwise
     """
-    return exc.code not in [429, 502, 503, 504]
+    if isinstance(exc, aiohttp.ClientResponseError):
+        server_error = 500 <= exc.code < 600
+        too_many_requests = exc.code == 429
+        return not server_error and not too_many_requests
+
+    # any other type of error (pre-filtered by the backoff decorator) shouldn't be fatal
+    return False
 
 
 class HttpDownloader(BaseDownloader):
@@ -121,6 +143,7 @@ class HttpDownloader(BaseDownloader):
         headers_ready_callback=None,
         headers=None,
         throttler=None,
+        max_retries=None,
         **kwargs,
     ):
         """
@@ -138,6 +161,7 @@ class HttpDownloader(BaseDownloader):
                 as its values. e.g. `{'Transfer-Encoding': 'chunked'}`
             headers (dict): Headers to be submitted with the request.
             throttler (asyncio_throttle.Throttler): Throttler for asyncio.
+            max_retries (int): The maximum number of times to retry a download upon failure.
             kwargs (dict): This accepts the parameters of
                 :class:`~pulpcore.plugin.download.BaseDownloader`.
         """
@@ -154,6 +178,7 @@ class HttpDownloader(BaseDownloader):
         self.proxy_auth = proxy_auth
         self.headers_ready_callback = headers_ready_callback
         self.download_throttler = throttler
+        self.max_retries = max_retries
         super().__init__(url, **kwargs)
 
     def raise_for_status(self, response):
@@ -194,16 +219,51 @@ class HttpDownloader(BaseDownloader):
             headers=response.headers,
         )
 
-    @backoff.on_exception(
-        backoff.expo, aiohttp.ClientResponseError, max_tries=10, giveup=http_giveup
-    )
+    async def run(self, extra_data=None):
+        """
+        Run the downloader with concurrency restriction and retry logic.
+
+        This method acquires `self.semaphore` before calling the actual download implementation
+        contained in `_run()`. This ensures that the semaphore stays acquired even as the `backoff`
+        wrapper around `_run()`, handles backoff-and-retry logic.
+
+        Args:
+            extra_data (dict): Extra data passed to the downloader.
+
+        Returns:
+            :class:`~pulpcore.plugin.download.DownloadResult` from `_run()`.
+
+        """
+        retryable_errors = (
+            aiohttp.ClientConnectorSSLError,
+            aiohttp.ClientConnectorError,
+            aiohttp.ClientOSError,
+            aiohttp.ClientPayloadError,
+            aiohttp.ClientResponseError,
+            aiohttp.ServerDisconnectedError,
+            TimeoutError,
+        )
+
+        async with self.semaphore:
+
+            @backoff.on_exception(
+                backoff.expo,
+                retryable_errors,
+                max_tries=self.max_retries + 1,
+                giveup=http_giveup_handler,
+            )
+            async def download_wrapper():
+                return await self._run(extra_data=extra_data)
+
+            return await download_wrapper()
+
     async def _run(self, extra_data=None):
         """
         Download, validate, and compute digests on the `url`. This is a coroutine.
 
-        This method is decorated with a backoff-and-retry behavior to retry some errors.
-        It retries with exponential backoff 10 times before allowing a final exception to
-        be raised.
+        This method is externally wrapped with backoff-and-retry behavior for some errors.
+        It retries with exponential backoff some number of times before allowing a final
+        exception to be raised.
 
         This method provides the same return object type and documented in
         :meth:`~pulpcore.plugin.download.BaseDownloader._run`.


### PR DESCRIPTION
Extend retry logic to cover all HTTP 5xx errors as well as some types of connection errors, and make the number of retries configurable by the user and plugin writer.

closes: #8881
https://pulp.plan.io/issues/8881
closes: #8867
https://pulp.plan.io/issues/8867