### PR TITLE
Removes the versions_containing_content method

### DIFF
--- a/CHANGES/plugin_api/8480.feature
+++ b/CHANGES/plugin_api/8480.feature
@@ -1,2 +1,2 @@
-Adds the ``pulpcore.plugin.viewsets.DistributionFilter``. This should be used instead of
+Added the ``pulpcore.plugin.viewsets.DistributionFilter``. This should be used instead of
 ``pulpcore.plugin.viewsets.NewDistributionFilter``.

--- a/CHANGES/plugin_api/8729.removal
+++ b/CHANGES/plugin_api/8729.removal
@@ -1,0 +1,3 @@
+Removed the ``versions_containing_content`` method from the
+`pulpcore.plugin.models.RepositoryVersion`` object. Instead use
+``RepositoryVersion.objects.with_content()``.

--- a/pulpcore/app/models/repository.py
+++ b/pulpcore/app/models/repository.py
@@ -19,7 +19,6 @@ from pulpcore.app.util import batch_qs, get_view_name_for_model
 from pulpcore.constants import ALL_KNOWN_CONTENT_CHECKSUMS
 from pulpcore.download.factory import DownloaderFactory
 from pulpcore.exceptions import ResourceImmutableError
-from pulpcore.app.loggers import deprecation_logger
 
 from .base import MasterModel, BaseModel
 from .content import Artifact, Content
@@ -532,36 +531,6 @@ class RepositoryVersion(BaseModel):
         unique_together = ("repository", "number")
         get_latest_by = "number"
         ordering = ("number",)
-
-    @classmethod
-    def versions_containing_content(cls, content):
-        """
-        Returns a query of repository versions containing the provided content units.
-
-        Args:
-            content (django.db.models.QuerySet): query of content
-
-        Returns:
-            django.db.models.QuerySet: Repository versions which contains content.
-        """
-        deprecation_logger(
-            "This method is deprecated and will be removed in version 3.14. "
-            "Use RepositoryVersion.objects.with_content() instead."
-        )
-        query = models.Q(pk__in=[])
-        repo_content = RepositoryContent.objects.filter(content__pk__in=content)
-
-        for rc in repo_content.iterator():
-            filter = models.Q(
-                repository__pk=rc.repository.pk,
-                number__gte=rc.version_added.number,
-            )
-            if rc.version_removed:
-                filter &= models.Q(number__lt=rc.version_removed.number)
-
-            query |= filter
-
-        return cls.objects.filter(query)
 
     def _content_relationships(self):
         """

--- a/pulpcore/tasking/tasks.py
+++ b/pulpcore/tasking/tasks.py
@@ -178,7 +178,7 @@ class NonJSONWarningEncoder(json.JSONEncoder):
         try:
             return json.JSONEncoder.default(self, obj)
         except TypeError:
-            deprecation_logger.warn(
+            deprecation_logger.warning(
                 _(
                     "The argument {obj} is of type {type}, which is not JSON serializable. The use "
                     "of non JSON serializable objects for `args` and `kwargs` to tasks is "


### PR DESCRIPTION
This remotes the deprecated `versions_containing_content` method from
`RepositoryVersion`.

closes #8729

