### PR TITLE
[noissue]  github issue was pulp/pulpproject.org#362

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,3 @@
-![Pulp CI](https://github.com/pulp/pulpcore/workflows/Pulp%20CI/badge.svg)
-[![PyPI](https://img.shields.io/pypi/pyversions/pulpcore.svg)](https://pypi.python.org/pypi/pulpcore)
-
 
 **Acquire, Organize, and Distribute Software**
 


### PR DESCRIPTION
remove misleading badges.
Can be re-instated if somebody likes to make them reflect tags/branches.
See also: https://github.com/pulp/community/discussions/26
