### PR TITLE
Close a race condition with ReservedResource

### DIFF
--- a/CHANGES/8708.bugfix
+++ b/CHANGES/8708.bugfix
@@ -1,0 +1,3 @@
+Add an update row lock on in task dispatching for ``ReservedResource`` to prevent a race where an
+object was deleted that was supposed to be reused. This prevents a condition where tasks ended up in
+waiting state forever.

--- a/pulpcore/tasking/tasks.py
+++ b/pulpcore/tasking/tasks.py
@@ -139,7 +139,7 @@ def _queue_reserved_task(func, inner_task_id, resources, inner_args, inner_kwarg
 
                 # Attempt to lock all resources by their urls. Must be atomic to prevent deadlocks.
                 for resource in resources:
-                    if worker.reservations.filter(resource=resource).exists():
+                    if worker.reservations.select_for_update().filter(resource=resource).exists():
                         reservation = worker.reservations.get(resource=resource)
                     else:
                         reservation = ReservedResource.objects.create(


### PR DESCRIPTION
During a small window between checking it's existance and looking up the
ReservedResource, this object may be deleted in another thread.
This condition will lead to task remaining in waiting state forever.

fixes #8708
https://pulp.plan.io/issues/8708