### PR TITLE
Close a race condition with ReservedResource

### DIFF
--- a/.github/workflows/scripts/before_install.sh
+++ b/.github/workflows/scripts/before_install.sh
@@ -117,7 +117,7 @@ cd ..
 
 
 
-git clone --depth=1 https://github.com/pulp/pulp_file.git --branch master
+git clone --depth=1 https://github.com/pulp/pulp_file.git --branch 1.7
 if [ -n "$PULP_FILE_PR_NUMBER" ]; then
   cd pulp_file
   git fetch --depth=1 origin pull/$PULP_FILE_PR_NUMBER/head:$PULP_FILE_PR_NUMBER

--- a/.github/workflows/scripts/install.sh
+++ b/.github/workflows/scripts/install.sh
@@ -36,7 +36,7 @@ TAG=ci_build
 if [ -e $REPO_ROOT/../pulp_file ]; then
   PULP_FILE=./pulp_file
 else
-  PULP_FILE=git+https://github.com/pulp/pulp_file.git@master
+  PULP_FILE=git+https://github.com/pulp/pulp_file.git@1.7
 fi
 
 if [ -e $REPO_ROOT/../pulp-certguard ]; then

--- a/CHANGES/8909.bugfix
+++ b/CHANGES/8909.bugfix
@@ -1,0 +1,4 @@
+Add an update row lock on in task dispatching for ``ReservedResource`` to prevent a race where an
+object was deleted that was supposed to be reused. This prevents a condition where tasks ended up in
+waiting state forever.
+(backported from #8708)

--- a/pulpcore/tasking/tasks.py
+++ b/pulpcore/tasking/tasks.py
@@ -140,7 +140,7 @@ def _queue_reserved_task(func, inner_task_id, resources, inner_args, inner_kwarg
 
                 # Attempt to lock all resources by their urls. Must be atomic to prevent deadlocks.
                 for resource in resources:
-                    if worker.reservations.filter(resource=resource).exists():
+                    if worker.reservations.select_for_update().filter(resource=resource).exists():
                         reservation = worker.reservations.get(resource=resource)
                     else:
                         reservation = ReservedResource.objects.create(

--- a/template_config.yml
+++ b/template_config.yml
@@ -2,7 +2,7 @@
 # were not present before running plugin-template have been added with their default values.
 
 additional_repos:
-- branch: master
+- branch: 1.7
   name: pulp_file
 - branch: master
   name: pulp-certguard


### PR DESCRIPTION
During a small window between checking it's existance and looking up the
ReservedResource, this object may be deleted in another thread.
This condition will lead to task remaining in waiting state forever.

backports #8708
https://pulp.plan.io/issues/8708

fixes #8909

(cherry picked from commit 18978d85d510d50b10990f509fae5a6a07d30f67)