### PR TITLE
Close a race condition with ReservedResource

### DIFF
--- a/.github/workflows/scripts/before_install.sh
+++ b/.github/workflows/scripts/before_install.sh
@@ -100,7 +100,7 @@ cd ..
   pip install --upgrade --force-reinstall ./pulp-smash
 
 
-git clone --depth=1 https://github.com/pulp/pulp_file.git --branch master
+git clone --depth=1 https://github.com/pulp/pulp_file.git --branch 1.6
 if [ -n "$PULP_FILE_PR_NUMBER" ]; then
   cd pulp_file
   git fetch --depth=1 origin pull/$PULP_FILE_PR_NUMBER/head:$PULP_FILE_PR_NUMBER
@@ -108,7 +108,7 @@ if [ -n "$PULP_FILE_PR_NUMBER" ]; then
   cd ..
 fi
 
-git clone --depth=1 https://github.com/pulp/pulp-certguard.git --branch master
+git clone --depth=1 https://github.com/pulp/pulp-certguard.git --branch 1.1
 if [ -n "$PULP_CERTGUARD_PR_NUMBER" ]; then
   cd pulp-certguard
   git fetch --depth=1 origin pull/$PULP_CERTGUARD_PR_NUMBER/head:$PULP_CERTGUARD_PR_NUMBER

--- a/.github/workflows/scripts/install.sh
+++ b/.github/workflows/scripts/install.sh
@@ -34,13 +34,13 @@ TAG=ci_build
 if [ -e $REPO_ROOT/../pulp_file ]; then
   PULP_FILE=./pulp_file
 else
-  PULP_FILE=git+https://github.com/pulp/pulp_file.git@master
+  PULP_FILE=git+https://github.com/pulp/pulp_file.git@1.6
 fi
 
 if [ -e $REPO_ROOT/../pulp-certguard ]; then
   PULP_CERTGUARD=./pulp-certguard
 else
-  PULP_CERTGUARD=git+https://github.com/pulp/pulp-certguard.git@master
+  PULP_CERTGUARD=git+https://github.com/pulp/pulp-certguard.git@1.1
 fi
 cat >> vars/main.yaml << VARSYAML
 image:

--- a/CHANGES/8908.bugfix
+++ b/CHANGES/8908.bugfix
@@ -1,0 +1,4 @@
+Add an update row lock on in task dispatching for ``ReservedResource`` to prevent a race where an
+object was deleted that was supposed to be reused. This prevents a condition where tasks ended up in
+waiting state forever.
+(backported from #8708)

--- a/pulpcore/app/models/task.py
+++ b/pulpcore/app/models/task.py
@@ -306,7 +306,7 @@ class Worker(BaseModel):
         """
         with transaction.atomic():
             for resource in resource_urls:
-                if self.reservations.filter(resource=resource).exists():
+                if self.reservations.select_for_update().filter(resource=resource).exists():
                     reservation = self.reservations.get(resource=resource)
                 else:
                     reservation = ReservedResource.objects.create(worker=self, resource=resource)

--- a/pulpcore/openapi/__init__.py
+++ b/pulpcore/openapi/__init__.py
@@ -358,7 +358,7 @@ class PulpSchemaGenerator(SchemaGenerator):
         return path
 
     def parse(self, request, public):
-        """ Iterate endpoints generating per method path operations. """
+        """Iterate endpoints generating per method path operations."""
         result = {}
         self._initialise_endpoints()
 
@@ -432,7 +432,7 @@ class PulpSchemaGenerator(SchemaGenerator):
         return result
 
     def get_schema(self, request=None, public=False):
-        """ Generate a OpenAPI schema. """
+        """Generate a OpenAPI schema."""
         reset_generator_stats()
         result = build_root_object(
             paths=self.parse(request, public),

--- a/template_config.yml
+++ b/template_config.yml
@@ -2,9 +2,9 @@
 # were not present before running plugin-template have been added with their default values.
 
 additional_plugins:
-- branch: master
+- branch: 1.6
   name: pulp_file
-- branch: master
+- branch: 1.1
   name: pulp-certguard
 black: true
 check_commit_message: true


### PR DESCRIPTION
During a small window between checking it's existance and looking up the
ReservedResource, this object may be deleted in another thread.
This condition will lead to task remaining in waiting state forever.

backports #8708
https://pulp.plan.io/issues/8708

fixes #8908

(cherry picked from commit 18978d85d510d50b10990f509fae5a6a07d30f67)