### PR TITLE
Add logging_cid filter to task list view

### DIFF
--- a/CHANGES/8891.feature
+++ b/CHANGES/8891.feature
@@ -1,0 +1,1 @@
+Add a correlation id filter to the task list endpoint.

--- a/pulpcore/app/viewsets/task.py
+++ b/pulpcore/app/viewsets/task.py
@@ -32,6 +32,7 @@ class TaskFilter(BaseFilterSet):
     state = filters.ChoiceFilter(choices=TASK_CHOICES)
     worker = HyperlinkRelatedFilter()
     name = filters.CharFilter()
+    logging_cid = filters.CharFilter()
     started_at = IsoDateTimeFilter(field_name="started_at")
     finished_at = IsoDateTimeFilter(field_name="finished_at")
     parent_task = HyperlinkRelatedFilter()
@@ -43,9 +44,10 @@ class TaskFilter(BaseFilterSet):
     class Meta:
         model = Task
         fields = {
-            "name": ["contains"],
             "state": ["exact", "in"],
             "worker": ["exact", "in"],
+            "name": ["contains"],
+            "logging_cid": ["exact", "contains"],
             "started_at": DATETIME_FILTER_OPTIONS,
             "finished_at": DATETIME_FILTER_OPTIONS,
             "parent_task": ["exact"],


### PR DESCRIPTION
fixes #8891
https://pulp.plan.io/issues/8891

This should help to find "all the tasks that were triggered by xxx frontend api call".