### PR TITLE
Fall back to on_demand if artifact download fails

### DIFF
--- a/CHANGES/8873.feature
+++ b/CHANGES/8873.feature
@@ -1,0 +1,1 @@
+Files which are unable to be downloaded will fall back to "on_demand" and log a warning rather than causing a sync to fail.


### PR DESCRIPTION
closes: #8873
https://pulp.plan.io/issues/8873

This needs some discussion.  See the issue: Pulp 2 handles content download failures (referring to non-retriable ones like 403 forbidden, 404 not found) by skipping over downloading the content.  Pulp 3 does not do so.

Should we, or should we close this issue?  And if we should, then should we have strict and non-strict mode?

I agree with Justin here but I'm pretty sure we've seen repositories with missing packages before.
```

<jsherrill> gotcha
<jsherrill> yeah it seems rare that a paricular package you'd get a 403, but the rest of the repo is fine
```