### PR TITLE
Fix bad default value

### DIFF
--- a/pulpcore/download/http.py
+++ b/pulpcore/download/http.py
@@ -143,7 +143,7 @@ class HttpDownloader(BaseDownloader):
         headers_ready_callback=None,
         headers=None,
         throttler=None,
-        max_retries=None,
+        max_retries=0,
         **kwargs,
     ):
         """


### PR DESCRIPTION
The default value isn't used by normal code due to downloader factory,
but RPM plugin unit tests construct the downloader manually and expect it to not be null.

[noissue]
