### PR TITLE
Fix OpenAPI schema tag generation

### DIFF
--- a/CHANGES/8868.bugfix
+++ b/CHANGES/8868.bugfix
@@ -1,0 +1,9 @@
+Fixed OpenAPI schema tag generation for resources that are nested more than 2 levels.
+
+This change is most evident in client libraries generated from the OpenAPI schema.
+
+Prior to this change, the API client for a resource located at
+`/api/v3/pulp/exporters/core/pulp/<uuid>/exports/` was named `ExportersCoreExportsApi`.
+
+After this change, the API client for a resource located at
+`/api/v3/pulp/exporters/core/pulp/<uuid>/exports/` is named `ExportersPulpExportsApi`.

--- a/CHANGES/plugin_api/8868.bugfix
+++ b/CHANGES/plugin_api/8868.bugfix
@@ -1,0 +1,9 @@
+Fixed OpenAPI schema tag generation for resources that are nested more than 2 levels.
+
+This change is most evident in client libraries generated from the OpenAPI schema.
+
+Prior to this change, the API client for a resource located at
+`/api/v3/pulp/exporters/core/pulp/<uuid>/exports/` was named `ExportersCoreExportsApi`.
+
+After this change, the API client for a resource located at
+`/api/v3/pulp/exporters/core/pulp/<uuid>/exports/` is named `ExportersPulpExportsApi`.

--- a/pulpcore/openapi/__init__.py
+++ b/pulpcore/openapi/__init__.py
@@ -95,7 +95,7 @@ class PulpAutoSchema(AutoSchema):
         operation_keys = [i.title() for i in operation_keys]
         tags = operation_keys
         if len(operation_keys) > 2:
-            del operation_keys[-2]
+            del operation_keys[1]
         if len(operation_keys) > 1:
             operation_keys[0] = "{key}:".format(key=operation_keys[0])
         tags = [" ".join(operation_keys)]

--- a/pulpcore/tests/functional/api/using_plugin/test_pulpexport.py
+++ b/pulpcore/tests/functional/api/using_plugin/test_pulpexport.py
@@ -23,7 +23,7 @@ from pulpcore.tests.functional.api.using_plugin.utils import (
 from pulpcore.client.pulpcore import (
     ApiClient as CoreApiClient,
     ExportersPulpApi,
-    ExportersCoreExportsApi,
+    ExportersPulpExportsApi,
 )
 
 from pulpcore.client.pulpcore.exceptions import ApiException
@@ -94,7 +94,7 @@ class BaseExporterCase(unittest.TestCase):
         cls.versions_api = RepositoriesFileVersionsApi(cls.file_client)
         cls.remote_api = RemotesFileApi(cls.file_client)
         cls.exporter_api = ExportersPulpApi(cls.core_client)
-        cls.exports_api = ExportersCoreExportsApi(cls.core_client)
+        cls.exports_api = ExportersPulpExportsApi(cls.core_client)
 
         (cls.repos, cls.remotes) = cls._setup_repositories()
 

--- a/pulpcore/tests/functional/api/using_plugin/test_pulpimport.py
+++ b/pulpcore/tests/functional/api/using_plugin/test_pulpimport.py
@@ -24,10 +24,10 @@ from pulpcore.tests.functional.api.using_plugin.utils import (
 
 from pulpcore.client.pulpcore import (
     ApiClient as CoreApiClient,
-    ExportersCoreExportsApi,
+    ExportersPulpExportsApi,
     ExportersPulpApi,
-    ImportersCoreImportCheckApi,
-    ImportersCoreImportsApi,
+    ImportersPulpImportCheckApi,
+    ImportersPulpImportsApi,
     ImportersPulpApi,
 )
 
@@ -160,11 +160,11 @@ class PulpImportTestCase(unittest.TestCase):
         cls.versions_api = RepositoriesFileVersionsApi(cls.file_client)
         cls.content_api = ContentFilesApi(cls.file_client)
         cls.exporter_api = ExportersPulpApi(cls.core_client)
-        cls.exports_api = ExportersCoreExportsApi(cls.core_client)
+        cls.exports_api = ExportersPulpExportsApi(cls.core_client)
         cls.importer_api = ImportersPulpApi(cls.core_client)
-        cls.imports_api = ImportersCoreImportsApi(cls.core_client)
+        cls.imports_api = ImportersPulpImportsApi(cls.core_client)
 
-        cls.import_check_api = ImportersCoreImportCheckApi(cls.core_client)
+        cls.import_check_api = ImportersPulpImportCheckApi(cls.core_client)
 
         (cls.import_repos, cls.export_repos, cls.remotes) = cls._setup_repositories()
         cls.exporter = cls._create_exporter()


### PR DESCRIPTION
The tag generation code was deleting the second element from the end instead of deleting the
second element in the list of operation keys. This worked for operations that had 3 elements
in the operations keys list, however, anything longer produced wrong operation tags.

fixes: #8868
https://pulp.plan.io/issues/8868