### PR TITLE
Deprecated `DELETE /pulp/api/v3/orphans/`

### DIFF
--- a/CHANGES/8876.deprecation
+++ b/CHANGES/8876.deprecation
@@ -1,0 +1,2 @@
+Deprecated the ``DELETE /pulp/api/v3/orphans/`` call. Instead use the
+``POST /pulp/api/v3/orphans/cleanup/`` call.

--- a/pulpcore/app/views/orphans.py
+++ b/pulpcore/app/views/orphans.py
@@ -1,6 +1,7 @@
 from drf_spectacular.utils import extend_schema
 from rest_framework.views import APIView
 
+from pulpcore.app.loggers import deprecation_logger
 from pulpcore.app.response import OperationPostponedResponse
 from pulpcore.app.serializers import AsyncOperationResponseSerializer
 from pulpcore.app.tasks import orphan_cleanup
@@ -9,8 +10,9 @@ from pulpcore.tasking.tasks import dispatch
 
 class OrphansView(APIView):
     @extend_schema(
-        description="Trigger an asynchronous task that deletes all"
-        "orphaned content and artifacts.",
+        description="DEPRECATED! Trigger an asynchronous task that deletes all "
+        "orphaned content and artifacts. Use the `POST /pulp/api/v3/orphans/cleanup/` call "
+        "instead.",
         summary="Delete orphans",
         responses={202: AsyncOperationResponseSerializer},
     )
@@ -18,6 +20,11 @@ class OrphansView(APIView):
         """
         Cleans up all the Content and Artifact orphans in the system
         """
+        deprecation_logger.warning(
+            "The `DELETE /pulp/api/v3/orphans/` call is deprecated. Use"
+            "`POST /pulp/api/v3/orphans/cleanup/` instead."
+        )
+
         task = dispatch(orphan_cleanup, [])
 
         return OperationPostponedResponse(task, request)


### PR DESCRIPTION
When calling this endpoint now, a deprecation warning is logged
recommending users instead use the `POST /pulp/api/v3/orphans/cleanup/`
call.

closes #8876

