### PR TITLE
Add stronger user orientation to docs

### DIFF
--- a/CHANGES/8946.doc
+++ b/CHANGES/8946.doc
@@ -1,0 +1,1 @@
+Updated the docs.pulpproject.org to provide some immediate direction for better user orientation. 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,8 +1,28 @@
 Pulp Documentation
 ==================
 
-This documentation is for `pulpcore`, which is used with plugins to fetch, upload, and organize
-arbitrary content types.
+This is the main landing page for documentation related to Pulp.
+
+The documentation itself is broken into sub categories that provide more granular information and
+workflows.
+
+`pulpcore` handles some parts of common content management workflows, including high performance
+downloading, task queuing with scalable workers, and management of content within versioned
+repositories.
+
+If you are looking for a very high-level overview of Pulp's features, check out `features page at
+pulpproject.org <https://pulpproject.org/features/>`_
+
+If you want an overview of the main concepts and terminology of Pulp, see :doc:`general concepts and
+ terminology<concepts>`
+
+If you want to understand the core workflows, see  :doc:`Workflows<workflows/index>`
+
+If you want to look at the considerations and requirements for installing Pulp, see
+ :ref:`installation`. If you want to evaluate Pulp quickly, try `Pulp in One
+ Container <https://pulpproject.org/pulp-in-one-container/>`_
+
+If you're looking for documentation specific to a content type, see :doc:`List of Plugins<plugins/index>`
 
 Anyone interested in writing a plugin should reference the :ref:`Plugin API`.
 
@@ -35,24 +55,6 @@ Source code
   * `pulpcore <https://github.com/pulp/pulpcore/>`_
   * `plugin repositories <https://pulpproject.org/content-plugins/>`_
 
-
-How to Navigate the pulpcore and plugin docs
---------------------------------------------
-
-Plugin Documentation
-^^^^^^^^^^^^^^^^^^^^
-
-If you are a new user who is evaluating Pulp it is recommended that you skim the documentation for
-the plugins that add the content types you are interested in. Links to these docs can be found in
-our `list of plugins <https://docs.pulpproject.org/pulpcore/plugins/index.html#plugins>`_
-
-Pulpcore Documentation
-^^^^^^^^^^^^^^^^^^^^^^
-
-`pulpcore` handles some parts of common content management workflows, including high performance
-downloading, task queuing with scalable workers, and management of content within versioned
-repositories. Information about :ref:`installation`, :ref:`deployment`, and :doc:`general concepts
-and terminology<concepts>` are all covered by the ``pulpcore`` documentation.
 
 
 Table of Contents


### PR DESCRIPTION
fixes #8946

Problem: people don't scroll. The "How to Navigate the pulpcore and plugin docs" section, I think, should be up front and centre when a user lands. We have a lot of docs, but knowing how to navigate them seems to be a challenge. 

Any/all feedback welcome. 

Please be sure you have read our documentation on creating PRs:
https://docs.pulpproject.org/contributing/pull-request-walkthrough.html
