### PR TITLE
Shields coroutine that is saving Artifact and Content

### DIFF
--- a/CHANGES/8980.bugfix
+++ b/CHANGES/8980.bugfix
@@ -1,0 +1,2 @@
+Fixed bug where artifacts and content were not always saved in Pulp with each
+on_demand request serviced by content app.

--- a/pulpcore/content/handler.py
+++ b/pulpcore/content/handler.py
@@ -784,7 +784,7 @@ class Handler:
             def save_artifact_blocking():
                 self._save_artifact(download_result, remote_artifact)
 
-            await loop.run_in_executor(None, save_artifact_blocking)
+            await asyncio.shield(loop.run_in_executor(None, save_artifact_blocking))
         await response.write_eof()
 
         if response.status == 404:


### PR DESCRIPTION
After the client receives the last chunk of the response, it closes the connection
with the content app. This causes all scheduled coroutines to be cancelled. If the
the thread that is performing the Artifact/Content save has not finished running,
the Content is never saved.

This patch ensures that the Artifact and the Content are fully saved to the
database after being streamed to the user.


fixes: #8980
https://pulp.plan.io/issues/8980