### PR TITLE
Improve the help text for the remote timeout options

### DIFF
--- a/pulpcore/app/serializers/repository.py
+++ b/pulpcore/app/serializers/repository.py
@@ -161,25 +161,37 @@ class RemoteSerializer(ModelSerializer):
     total_timeout = serializers.FloatField(
         allow_null=True,
         required=False,
-        help_text="aiohttp.ClientTimeout.total (q.v.) for download-connections.",
+        help_text=(
+            "aiohttp.ClientTimeout.total (q.v.) for download-connections. The default is null, "
+            "which will cause the default from the aiohttp library to be used."
+        ),
         min_value=0.0,
     )
     connect_timeout = serializers.FloatField(
         allow_null=True,
         required=False,
-        help_text="aiohttp.ClientTimeout.connect (q.v.) for download-connections.",
+        help_text=(
+            "aiohttp.ClientTimeout.connect (q.v.) for download-connections. The default is null, "
+            "which will cause the default from the aiohttp library to be used."
+        ),
         min_value=0.0,
     )
     sock_connect_timeout = serializers.FloatField(
         allow_null=True,
         required=False,
-        help_text="aiohttp.ClientTimeout.sock_connect (q.v.) for download-connections.",
+        help_text=(
+            "aiohttp.ClientTimeout.sock_connect (q.v.) for download-connections. The default is "
+            "null, which will cause the default from the aiohttp library to be used."
+        ),
         min_value=0.0,
     )
     sock_read_timeout = serializers.FloatField(
         allow_null=True,
         required=False,
-        help_text="aiohttp.ClientTimeout.sock_read (q.v.) for download-connections.",
+        help_text=(
+            "aiohttp.ClientTimeout.sock_read (q.v.) for download-connections. The default is "
+            "null, which will cause the default from the aiohttp library to be used."
+        ),
         min_value=0.0,
     )
     headers = serializers.ListField(


### PR DESCRIPTION
[noissue]

Adds an additional hint on how to look for the default values and by
extension what one might plausibly change the value to.

This is kind of implied already by the `(q.v.)` abbreviation, but I think there might be the odd user who is helped by it, and I don't think slightly longer help strings in the API docs ever really hurt. Any thoughts?

If there is agreement that this is an improvement I can create an issue to go with it, if desired.