### PR TITLE
Removes `NewDistributionFilter`

### DIFF
--- a/CHANGES/plugin_api/8479.removal
+++ b/CHANGES/plugin_api/8479.removal
@@ -1,0 +1,2 @@
+Removed the ``pulpcore.plugin.viewsets.NewDistributionFilter``. Instead use
+``pulpcore.plugin.viewsets.DistributionFilter``.

--- a/pulpcore/app/viewsets/__init__.py
+++ b/pulpcore/app/viewsets/__init__.py
@@ -43,7 +43,6 @@ from .publication import (  # noqa
     DistributionViewSet,
     ListContentGuardViewSet,
     ListPublicationViewSet,
-    NewDistributionFilter,
     PublicationFilter,
     PublicationViewSet,
 )

--- a/pulpcore/app/viewsets/publication.py
+++ b/pulpcore/app/viewsets/publication.py
@@ -5,7 +5,6 @@ from django_filters.rest_framework import DjangoFilterBackend, filters
 from rest_framework import mixins, serializers
 from rest_framework.filters import OrderingFilter
 
-from pulpcore.app.loggers import deprecation_logger
 from pulpcore.app.models import (
     ContentGuard,
     Distribution,
@@ -146,15 +145,6 @@ class DistributionFilter(BaseFilterSet):
             "name": NAME_FILTER_OPTIONS,
             "base_path": ["exact", "contains", "icontains", "in"],
         }
-
-
-class NewDistributionFilter(DistributionFilter):
-    def __init__(self, *args, **kwargs):
-        deprecation_logger.warning(
-            "The NewDistributionFilter object is deprecated and will be removed in version 3.15. "
-            "Use DistributionFilter instead."
-        )
-        return super().__init__(*args, **kwargs)
 
 
 class DistributionViewSet(

--- a/pulpcore/plugin/viewsets/__init__.py
+++ b/pulpcore/plugin/viewsets/__init__.py
@@ -18,7 +18,6 @@ from pulpcore.app.viewsets import (  # noqa
     ImporterViewSet,
     NamedModelViewSet,
     NAME_FILTER_OPTIONS,
-    NewDistributionFilter,
     PublicationFilter,
     PublicationViewSet,
     ReadOnlyContentViewSet,


### PR DESCRIPTION
Removes the `pulpcore.plugin.viewsets.NewDistributionFilter`. Instead
use `pulpcore.plugin.viewsets.DistributionFilter`.

The final step is a long plan!

closes #8479

