### PR TITLE
Removes ambiguity from OpenAPI schema for Exports.

### DIFF
--- a/.ci/assets/bindings/test_bindings.rb
+++ b/.ci/assets/bindings/test_bindings.rb
@@ -28,6 +28,9 @@ end
 @fileremotes_api = PulpFileClient::RemotesFileApi.new
 @tasks_api = PulpcoreClient::TasksApi.new
 @uploads_api = PulpcoreClient::UploadsApi.new
+@exporters_api = PulpcoreClient::ExportersPulpApi.new
+@exports_api = PulpcoreClient::ExportersPulpExportsApi.new
+
 
 
 def monitor_task(task_href)
@@ -119,6 +122,16 @@ sync_response = @filerepositories_api.sync(file_repository.pulp_href, repository
 created_resources = monitor_task(sync_response.task)
 
 repository_version_1 = @repoversions_api.read(created_resources[0])
+
+# Create an exporter
+exporter = @exporters_api.create({name: 'foo48', path: '/tmp/foo', repositories:[file_repository.pulp_href]})
+
+# Create an export
+export_response = @exports_api.create(exporter.pulp_href, versions: [repository_version_1.pulp_href])
+created_resources = monitor_task(export_response.task)
+
+# List exports
+exports = @exports_api.list(exporter.pulp_href)
 
 # Create an artifact from a local file
 file_path = File.join(ENV['GITHUB_WORKSPACE'], '.ci/assets/bindings/test_bindings.rb')

--- a/CHANGES/9008.bugfix
+++ b/CHANGES/9008.bugfix
@@ -1,0 +1,1 @@
+Removed ambiguity from the OpenAPI schema for Exports. The exported_resources are now a list of URI strings.

--- a/pulpcore/app/serializers/__init__.py
+++ b/pulpcore/app/serializers/__init__.py
@@ -11,6 +11,7 @@ from .base import (  # noqa
     NestedIdentityField,
     NestedRelatedField,
     RelatedField,
+    RelatedResourceField,
     ValidateFieldsMixin,
     validate_unknown_fields,
 )

--- a/pulpcore/app/serializers/task.py
+++ b/pulpcore/app/serializers/task.py
@@ -9,32 +9,13 @@ from pulpcore.app.serializers import (
     ModelSerializer,
     ProgressReportSerializer,
     RelatedField,
+    RelatedResourceField,
     TaskGroupStatusCountField,
 )
 from pulpcore.constants import TASK_STATES
-from pulpcore.app.util import get_viewset_for_model, get_request_without_query_params
 
 
-class CreatedResourceSerializer(RelatedField):
-    def to_representation(self, data):
-        # If the content object was deleted
-        if data.content_object is None:
-            return None
-        try:
-            if not data.content_object.complete:
-                return None
-        except AttributeError:
-            pass
-
-        # query parameters can be ignored because we are looking just for 'pulp_href'; still,
-        # we need to use the request object due to contextual references required by some
-        # serializers
-        request = get_request_without_query_params(self.context)
-
-        viewset = get_viewset_for_model(data.content_object)
-        serializer = viewset.serializer_class(data.content_object, context={"request": request})
-        return serializer.data.get("pulp_href")
-
+class CreatedResourceSerializer(RelatedResourceField):
     class Meta:
         model = models.CreatedResource
         fields = []


### PR DESCRIPTION
This patch clearly defines the exported_resources as a list of URI strings. The implementation for
the ExportedResourceSerializer is shared with CreatedResource serializer. They now both inherit from
a new RelatedResourceField.

fixes: #9008
https://pulp.plan.io/issues/9008