### PR TITLE
Validate absolute pathnames in remotes' URLs

### DIFF
--- a/CHANGES/9080.bugfix
+++ b/CHANGES/9080.bugfix
@@ -1,0 +1,1 @@
+Fixed improper validation of remotes' URLs.


### PR DESCRIPTION
Before this change, it was not possible to determine why did the synchronization fail when a user provided a seemingly valid URL. This commit also adds more relevant information to the error message.

Having set `ALLOWED_EXPORT_PATHS` to `["/tmp", "/home/vagrant/test"]`, the following error messages are shown:

```
$ pulp file remote create --name test --url file://error/vagrant/test/centos-7/PULP_MANIFEST
Error: {"url":["The path 'error/vagrant/test/centos-7/PULP_MANIFEST' needs to be an absolute pathname."]}

$ pulp file remote create --name test --url file:///error/vagrant/test/centos-7/PULP_MANIFEST
Error: {"url":["The path '/error/vagrant/test/centos-7/PULP_MANIFEST' is not in allowed import paths"]}
```

closes #9080