### PR TITLE
Reduce the cache entry expiration TTL

### DIFF
--- a/CHANGES/8996.misc
+++ b/CHANGES/8996.misc
@@ -1,0 +1,1 @@
+Reduced the default expiration TTL of entries in the Pulp content app cache.

--- a/docs/configuration/settings.rst
+++ b/docs/configuration/settings.rst
@@ -211,6 +211,8 @@ CACHE_SETTINGS
 
    * ``EXPIRES_TTL`` - Number of seconds entries should stay in the cache before expiring.
 
+   Defaults to ``600`` seconds.
+
    .. note::
      Set to ``None`` to have entries not expire.
      Content app responses are always invalidated when the backing distribution is updated.

--- a/pulpcore/app/settings.py
+++ b/pulpcore/app/settings.py
@@ -242,7 +242,7 @@ PROFILE_STAGES_API = False
 # https://docs.pulpproject.org/pulpcore/configuration/settings.html#pulp-cache
 CACHE_ENABLED = True
 CACHE_SETTINGS = {
-    "EXPIRES_TTL": 86400,
+    "EXPIRES_TTL": 600,  # 10 minutes
 }
 
 SPECTACULAR_SETTINGS = {


### PR DESCRIPTION
If Redis goes down then its persisted data can get out of sync with
Pulp, because cache invalidation events cannot occur. We should mitigate
the impact by letting cache entries expire after a shorter period of
time.

closes: #8996
https://pulp.plan.io/issues/8996
