### PR TITLE
Use proxy auth from the Remote config.

### DIFF
--- a/CHANGES/9024.bugfix
+++ b/CHANGES/9024.bugfix
@@ -1,0 +1,1 @@
+Use proxy auth from Remote config to download content from a remote repository.

--- a/pulpcore/download/http.py
+++ b/pulpcore/download/http.py
@@ -273,7 +273,9 @@ class HttpDownloader(BaseDownloader):
         """
         if self.download_throttler:
             await self.download_throttler.acquire()
-        async with self.session.get(self.url, proxy=self.proxy, auth=self.auth) as response:
+        async with self.session.get(
+            self.url, proxy=self.proxy, proxy_auth=self.proxy_auth, auth=self.auth
+        ) as response:
             self.raise_for_status(response)
             to_return = await self._handle_response(response)
             await response.release()


### PR DESCRIPTION
fixes: #9024
https://pulp.plan.io/issues/9024
