### PR TITLE
Conditionally include Redis connection information

### DIFF
--- a/CHANGES/9070.bugfix
+++ b/CHANGES/9070.bugfix
@@ -1,0 +1,2 @@
+Set Redis connection information in status to null unless it's used. Redis is
+needed for RQ tasking or content caching.

--- a/pulpcore/app/serializers/status.py
+++ b/pulpcore/app/serializers/status.py
@@ -74,6 +74,9 @@ class StatusSerializer(serializers.Serializer):
         help_text=_("Database connection information")
     )
 
-    redis_connection = RedisConnectionSerializer(help_text=_("Redis connection information"))
+    redis_connection = RedisConnectionSerializer(
+        required=False,
+        help_text=_("Redis connection information"),
+    )
 
     storage = StorageSerializer(required=False, help_text=_("Storage information"))

--- a/pulpcore/app/views/status.py
+++ b/pulpcore/app/views/status.py
@@ -57,7 +57,11 @@ class StatusView(APIView):
         for app in pulp_plugin_configs():
             versions.append({"component": app.label, "version": app.version})
 
-        redis_status = {"connected": self._get_redis_conn_status()}
+        if settings.CACHE_ENABLED or not settings.USE_NEW_WORKER_TYPE:
+            redis_status = {"connected": self._get_redis_conn_status()}
+        else:
+            redis_status = None
+
         db_status = {"connected": self._get_db_conn_status()}
 
         try:

--- a/pulpcore/tests/functional/api/test_status.py
+++ b/pulpcore/tests/functional/api/test_status.py
@@ -1,6 +1,7 @@
 """Test the status page."""
 import unittest
 
+from django.test import override_settings
 from jsonschema import validate
 from pulp_smash import api, cli, config, utils
 from pulp_smash.pulp3.constants import STATUS_PATH
@@ -91,6 +92,7 @@ class StatusTestCase(unittest.TestCase):
         """
         validate(status, self.status_response)
         self.assertTrue(status["database_connection"]["connected"])
+        self.assertIsNotNone(status["redis_connection"])
         self.assertTrue(status["redis_connection"]["connected"])
         self.assertNotEqual(status["online_workers"], [])
         self.assertNotEqual(status["versions"], [])
@@ -98,3 +100,12 @@ class StatusTestCase(unittest.TestCase):
             self.assertIsNotNone(status["storage"])
         else:
             self.assertIsNone(status["storage"])
+
+    @override_settings(CACHE_ENABLED=False, USE_NEW_WORKER_TYPE=True)
+    def verify_get_response_without_redis(self, status):
+        """Verify the response to an HTTP GET call when Redis is not used.
+
+        Verify that redis_connection is null
+        """
+        validate(status, self.status_response)
+        self.assertIsNone(status["redis_connection"])


### PR DESCRIPTION
Redis is only used when cache is enabled or RQ tasking is used. In other cases, the connection is not needed. We've changed the Foreman installer to [only install Redis if needed](https://github.com/theforeman/puppet-pulpcore/commit/7a5543b1a47de8d76a1cad1fb76e12db7bbf8e45), just to stop wasting resources. However, this leads to warnings.

This PR changes the status view to only include Redis if it's used.

Right now there are no tests since I first want to discuss if this is even the right direction. That's also why this PR is a draft.

https://pulp.plan.io/issues/9070