### PR TITLE
3.14.2 backports

### DIFF
--- a/CHANGES/9057.bugfix
+++ b/CHANGES/9057.bugfix
@@ -1,0 +1,4 @@
+Fixed bug where content app would not respond to ``Range`` HTTP Header in requests when
+``remote.policy`` was either ``on_demand`` or ``streamed``. For example this request is used by
+Anaconda clients.
+(backported from #8865)

--- a/CHANGES/9058.bugfix
+++ b/CHANGES/9058.bugfix
@@ -1,0 +1,2 @@
+Fixed a bug that caused a serializer to ignore form data for ``pulp_labels``.
+(backported from #8954)

--- a/CHANGES/9059.bugfix
+++ b/CHANGES/9059.bugfix
@@ -1,0 +1,2 @@
+Fixed the behavior of setting "repository" on a distribution for publication-based plugins.
+(backported from #9039)

--- a/CHANGES/9068.bugfix
+++ b/CHANGES/9068.bugfix
@@ -1,0 +1,2 @@
+Use proxy auth from Remote config to download content from a remote repository.
+(backported from #9024)

--- a/pulpcore/app/serializers/fields.py
+++ b/pulpcore/app/serializers/fields.py
@@ -377,8 +377,8 @@ class TaskGroupStatusCountField(serializers.IntegerField, serializers.ReadOnlyFi
         return instance.tasks.filter(state=self.state).count()
 
 
-class LabelsField(serializers.DictField):
-    """Serializer field for pulp_labels."""
+class LabelsField(serializers.JSONField):
+    """A serializer field for pulp_labels."""
 
     def to_representation(self, labels):
         """
@@ -397,14 +397,16 @@ class LabelsField(serializers.DictField):
         Ensures that data conforms to key/value dict.
 
         Args:
-            data (dict): A dictionary that maps label key to label value
+            data (str or dict): A dictionary which maps a label key to a label value
 
         Returns:
             A validated data dict for labels mapping keys to values
 
         Raises:
-            rest_framework.serializers.ValidationError: if data is invalid (eg not a dict)
+            rest_framework.serializers.ValidationError: if data is invalid (e.g., not a dict)
         """
+        data = super().to_internal_value(data)
+
         if not isinstance(data, dict):
             raise serializers.ValidationError(_("Data must be supplied as a key/value hash."))
         for key, value in data.items():

--- a/pulpcore/download/http.py
+++ b/pulpcore/download/http.py
@@ -273,7 +273,9 @@ class HttpDownloader(BaseDownloader):
         """
         if self.download_throttler:
             await self.download_throttler.acquire()
-        async with self.session.get(self.url, proxy=self.proxy, auth=self.auth) as response:
+        async with self.session.get(
+            self.url, proxy=self.proxy, proxy_auth=self.proxy_auth, auth=self.auth
+        ) as response:
             self.raise_for_status(response)
             to_return = await self._handle_response(response)
             await response.release()

--- a/pulpcore/tests/functional/api/using_plugin/test_distributions.py
+++ b/pulpcore/tests/functional/api/using_plugin/test_distributions.py
@@ -4,10 +4,11 @@ import hashlib
 import unittest
 from urllib.parse import urljoin
 
-from pulp_smash import api, config, utils
+from pulp_smash import api, cli, config, utils
 from pulp_smash.pulp3.bindings import delete_orphans
 from pulp_smash.pulp3.utils import (
     download_content_unit,
+    download_content_unit_return_requests_response,
     gen_distribution,
     gen_repo,
     get_content,
@@ -329,24 +330,113 @@ class ContentServePublicationDistributionTestCase(unittest.TestCase):
         self.setup_download_test("immediate")
         self.do_test_content_served()
 
-    @unittest.skip("https://pulp.plan.io/issues/8865")
-    def test_content_served_on_demand_with_range_request(self):
-        """Assert that on_demand content can be properly downloaded with range requests."""
-        self.setup_download_test("on_demand")
-        self.do_range_request_download_test()
+    def test_content_served_streamed(self):
+        """Assert that streamed content can be properly downloaded."""
+        self.setup_download_test("streamed")
+        self.do_test_content_served()
 
-    def test_content_served_immediate_with_range_request(self):
+    def test_content_served_immediate_with_range_request_inside_one_chunk(self):
         """Assert that downloaded content can be properly downloaded with range requests."""
-        self.setup_download_test("immediate")
-        self.do_range_request_download_test()
+        self.setup_download_test(
+            "immediate", url="https://fixtures.pulpproject.org/file-chunked/PULP_MANIFEST"
+        )
+        range_headers = {"Range": "bytes=1048586-1049586"}
+        num_bytes = 1001
+        self.do_range_request_download_test(range_headers, num_bytes)
 
-    def setup_download_test(self, policy):
+    def test_content_served_immediate_with_range_request_over_three_chunks(self):
+        """Assert that downloaded content can be properly downloaded with range requests."""
+        self.setup_download_test(
+            "immediate", url="https://fixtures.pulpproject.org/file-chunked/PULP_MANIFEST"
+        )
+        range_headers = {"Range": "bytes=1048176-2248576"}
+        num_bytes = 1200401
+        self.do_range_request_download_test(range_headers, num_bytes)
+
+    def test_content_served_on_demand_with_range_request_over_three_chunks(self):
+        """Assert that on_demand content can be properly downloaded with range requests."""
+        self.setup_download_test(
+            "on_demand", url="https://fixtures.pulpproject.org/file-chunked/PULP_MANIFEST"
+        )
+        range_headers = {"Range": "bytes=1048176-2248576"}
+        num_bytes = 1200401
+        self.do_range_request_download_test(range_headers, num_bytes)
+
+    def test_content_served_streamed_with_range_request_over_three_chunks(self):
+        """Assert that streamed content can be properly downloaded with range requests."""
+        self.setup_download_test(
+            "streamed", url="https://fixtures.pulpproject.org/file-chunked/PULP_MANIFEST"
+        )
+        range_headers = {"Range": "bytes=1048176-2248576"}
+        num_bytes = 1200401
+        self.do_range_request_download_test(range_headers, num_bytes)
+
+    def test_content_served_immediate_with_multiple_different_range_requests(self):
+        """Assert that multiple requests with different Range header values work as expected."""
+        self.setup_download_test(
+            "immediate", url="https://fixtures.pulpproject.org/file-chunked/PULP_MANIFEST"
+        )
+        range_headers = {"Range": "bytes=1048176-2248576"}
+        num_bytes = 1200401
+        self.do_range_request_download_test(range_headers, num_bytes)
+        range_headers = {"Range": "bytes=2042176-3248576"}
+        num_bytes = 1206401
+        self.do_range_request_download_test(range_headers, num_bytes)
+
+    def test_content_served_immediate_with_range_request_invalid_start_value(self):
+        """Assert that range requests with a negative start value errors as expected."""
+        cfg = config.get_config()
+        cli_client = cli.Client(cfg)
+        storage = utils.get_pulp_setting(cli_client, "DEFAULT_FILE_STORAGE")
+        if storage != "pulpcore.app.models.storage.FileSystem":
+            self.skipTest("The S3 test API project doesn't handle invalid Range values correctly")
+        self.setup_download_test(
+            "immediate", url="https://fixtures.pulpproject.org/file-chunked/PULP_MANIFEST"
+        )
+
+        self.assertRaises(
+            HTTPError,
+            download_content_unit_return_requests_response,
+            self.cfg,
+            self.distribution.to_dict(),
+            "1.iso",
+            headers={"Range": "bytes=-1-11"},
+        )
+
+    def test_content_served_immediate_with_range_request_too_large_end_value(self):
+        """Assert that a range request with a end value that is larger than the data works still."""
+        self.setup_download_test(
+            "immediate", url="https://fixtures.pulpproject.org/file-chunked/PULP_MANIFEST"
+        )
+        range_headers = {"Range": "bytes=10485260-10485960"}
+        num_bytes = 500
+        self.do_range_request_download_test(range_headers, num_bytes)
+
+    def test_content_served_immediate_with_range_request_start_value_larger_than_content(self):
+        """Assert that a range request with a start value larger than the content errors."""
+        self.setup_download_test(
+            "immediate", url="https://fixtures.pulpproject.org/file-chunked/PULP_MANIFEST"
+        )
+        self.assertRaises(
+            HTTPError,
+            download_content_unit_return_requests_response,
+            self.cfg,
+            self.distribution.to_dict(),
+            "1.iso",
+            headers={"Range": "bytes=10485860-10485870"},
+        )
+
+    def setup_download_test(self, policy, url=None):
         # Create a repository
         self.repo = self.repo_api.create(gen_repo())
         self.addCleanup(self.repo_api.delete, self.repo.pulp_href)
 
         # Create a remote
-        self.remote = self.remote_api.create(gen_file_remote(policy=policy))
+        remote_options = {"policy": policy}
+        if url:
+            remote_options["url"] = url
+
+        self.remote = self.remote_api.create(gen_file_remote(**remote_options))
         self.addCleanup(self.remote_api.delete, self.remote.pulp_href)
 
         # Sync the repository.
@@ -388,19 +478,26 @@ class ContentServePublicationDistributionTestCase(unittest.TestCase):
 
         self.assertEqual(len(pulp_manifest), FILE_FIXTURE_COUNT, pulp_manifest)
 
-    def do_range_request_download_test(self):
+    def do_range_request_download_test(self, range_header, expected_bytes):
         file_path = "1.iso"
 
-        headers = {"Range": "bytes=0-9"}  # first 10 bytes
-        NUM_BYTES = 10
-
-        req1 = download_content_unit(
-            self.cfg, self.distribution.to_dict(), file_path, headers=headers
+        req1_reponse = download_content_unit_return_requests_response(
+            self.cfg, self.distribution.to_dict(), file_path, headers=range_header
         )
-        req2 = download_content_unit(
-            self.cfg, self.distribution.to_dict(), file_path, headers=headers
+        req2_response = download_content_unit_return_requests_response(
+            self.cfg, self.distribution.to_dict(), file_path, headers=range_header
         )
 
-        self.assertEqual(NUM_BYTES, len(req1))
-        self.assertEqual(NUM_BYTES, len(req2))
-        self.assertEqual(req1, req2)
+        self.assertEqual(expected_bytes, len(req1_reponse.content))
+        self.assertEqual(expected_bytes, len(req2_response.content))
+        self.assertEqual(req1_reponse.content, req2_response.content)
+
+        self.assertEqual(req1_reponse.status_code, 206)
+        self.assertEqual(req1_reponse.status_code, req2_response.status_code)
+
+        self.assertEqual(str(expected_bytes), req1_reponse.headers["Content-Length"])
+        self.assertEqual(str(expected_bytes), req2_response.headers["Content-Length"])
+
+        self.assertEqual(
+            req1_reponse.headers["Content-Range"], req2_response.headers["Content-Range"]
+        )


### PR DESCRIPTION
- Use proxy auth from the Remote config.
- Make auto-distribute feature more intuitive
- Replace DictField with JSONField
- Adds Range header support to content app

Please be sure you have read our documentation on creating PRs:
https://docs.pulpproject.org/contributing/pull-request-walkthrough.html
