### PR TITLE
Fixed non-gracefully shutting down workers

### DIFF
--- a/CHANGES/8986.bugfix
+++ b/CHANGES/8986.bugfix
@@ -1,0 +1,1 @@
+Fixed signal handling to properly kill a task when double ctrl-c is used to shut down a worker fast.

--- a/pulpcore/tasking/pulpcore_worker.py
+++ b/pulpcore/tasking/pulpcore_worker.py
@@ -236,6 +236,12 @@ class NewPulpWorker:
 
 
 def child_signal_handler(sig, frame):
+    # Reset signal handlers to default
+    # If you kill the process a second time it's not graceful anymore.
+    signal.signal(signal.SIGINT, signal.SIG_DFL)
+    signal.signal(signal.SIGTERM, signal.SIG_DFL)
+    signal.signal(signal.SIGUSR1, signal.SIG_DFL)
+
     if sig == signal.SIGUSR1:
         sys.exit()
 


### PR DESCRIPTION
When hitting ctrl-c twice, workers should also kill their supervised
tasks. And shut them down.

fixes #8986
https://pulp.plan.io/issues/8986