### PR TITLE
Fixed non-gracefully shutting down workers

### DIFF
--- a/CHANGES/9086.bugfix
+++ b/CHANGES/9086.bugfix
@@ -1,0 +1,2 @@
+Fixed signal handling to properly kill a task when double ctrl-c is used to shut down a worker fast.
+(backported from #8986)

--- a/pulpcore/tasking/pulpcore_worker.py
+++ b/pulpcore/tasking/pulpcore_worker.py
@@ -234,6 +234,12 @@ class NewPulpWorker:
 
 
 def child_signal_handler(sig, frame):
+    # Reset signal handlers to default
+    # If you kill the process a second time it's not graceful anymore.
+    signal.signal(signal.SIGINT, signal.SIG_DFL)
+    signal.signal(signal.SIGTERM, signal.SIG_DFL)
+    signal.signal(signal.SIGUSR1, signal.SIG_DFL)
+
     if sig == signal.SIGUSR1:
         sys.exit()
 


### PR DESCRIPTION
When hitting ctrl-c twice, workers should also kill their supervised
tasks. And shut them down.

backports #8986
https://pulp.plan.io/issues/8986

fixes #9086

(cherry picked from commit 80d7d6d8e24c26d6eb0ff13ce29ed8c764cf2341)