### PR TITLE
Change content app's working directory dynamically

### DIFF
--- a/CHANGES/9000.bugfix
+++ b/CHANGES/9000.bugfix
@@ -1,0 +1,1 @@
+Fixed a bug where on-demand downloads would fill up ``/var/run/`` by not deleting downloaded files.

--- a/pulpcore/content/__init__.py
+++ b/pulpcore/content/__init__.py
@@ -55,6 +55,8 @@ async def _heartbeat():
 
 
 async def server(*args, **kwargs):
+    os.chdir(settings.WORKING_DIRECTORY)
+
     asyncio.ensure_future(_heartbeat())
     for pulp_plugin in pulp_plugin_configs():
         if pulp_plugin.name != "pulpcore.app":

--- a/pulpcore/content/handler.py
+++ b/pulpcore/content/handler.py
@@ -720,6 +720,12 @@ class Handler:
                         **download_result.artifact_attributes, file=download_result.path
                     )
                     artifact.save()
+                else:
+                    # The file needs to be unlinked because it was not used to create an artifact.
+                    # The artifact must have already been saved while servicing another request for
+                    # the same artifact.
+                    os.unlink(download_result.path)
+
             update_content_artifact = True
             if content_artifact._state.adding:
                 # This is the first time pull-through content was requested.


### PR DESCRIPTION
As of this commit, content app is no longer storing temporary files in the /var/run/ directory. The temporary files were created during on-demand downloading and were not removed until, e.g., restarting pulp services.

closes #9000
