### PR TITLE
Fix dependabot error

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,6 +5,5 @@ updates:
   schedule:
     interval: daily
   open-pull-requests-limit: 10
-  ignore:
   commit-message:
     prefix: "[noissue]"


### PR DESCRIPTION
```
The property '#/updates/0/ignore' of type null did not match the following type: array
```
