### PR TITLE
Removes `http_giveup` method from plugin API

### DIFF
--- a/CHANGES/plugin_api/8913.removal
+++ b/CHANGES/plugin_api/8913.removal
@@ -1,0 +1,5 @@
+The ``pulpcore.plugin.download.http_giveup`` method has been removed from the plugin API. Plugins
+used to have to use this to wrap the ``_run`` method defined on subclasses of ``HttpDownloader``,
+but starting with pulpcore 3.14 the backoff is implemented directly in the ``HttpDownloader.run()``
+method which subclasses do not override. Due to ``pulpcore`` implementing it, it is no longer needed
+or available for plugins to use.

--- a/pulpcore/download/__init__.py
+++ b/pulpcore/download/__init__.py
@@ -1,4 +1,4 @@
 from .base import BaseDownloader, DownloadResult  # noqa
 from .factory import DownloaderFactory  # noqa
 from .file import FileDownloader  # noqa
-from .http import http_giveup, HttpDownloader  # noqa
+from .http import HttpDownloader  # noqa

--- a/pulpcore/download/http.py
+++ b/pulpcore/download/http.py
@@ -12,17 +12,6 @@ log = logging.getLogger(__name__)
 logging.getLogger("backoff").addHandler(logging.StreamHandler())
 
 
-def http_giveup(exc):
-    """Deprecated."""
-    from pulpcore.app.loggers import deprecation_logger
-
-    deprecation_logger.warning(
-        "http_giveup() is no longer necessary and has been deprecated. "
-        "It will be removed in pulpcore 3.15."
-    )
-    return http_giveup_handler(exc)
-
-
 def http_giveup_handler(exc):
     """
     Inspect a raised exception and determine if we should give up.

--- a/pulpcore/plugin/download/__init__.py
+++ b/pulpcore/plugin/download/__init__.py
@@ -3,6 +3,5 @@ from pulpcore.download import (  # noqa
     DownloadResult,
     DownloaderFactory,
     FileDownloader,
-    http_giveup,
     HttpDownloader,
 )


### PR DESCRIPTION
This is no longer needed in the plugin API because, starting with
`pulpcore==3.14` the `HttpDownloader.run()` method uses it directly so
plugins no longer have to use it on their `_run()` subclass definitions.

closes #8913
