### PR TITLE
Prevent tasks being assigned to missing workers

### DIFF
--- a/CHANGES/9116.bugfix
+++ b/CHANGES/9116.bugfix
@@ -1,0 +1,2 @@
+Fixed a bug, where new tasks were assigned to dead workers.
+(backported from #8779)

--- a/pulpcore/tasking/worker.py
+++ b/pulpcore/tasking/worker.py
@@ -22,6 +22,7 @@ from pulpcore.app import settings  # noqa: E402: module level not at top of file
 from pulpcore.app.settings import WORKER_TTL  # noqa: E402: module level not at top of file
 
 from pulpcore.app.models import Task  # noqa: E402: module level not at top of file
+from pulpcore.constants import TASK_STATES  # noqa: E402: module level not at top of file
 
 from pulpcore.tasking.constants import (  # noqa: E402: module level not at top of file
     TASKING_CONSTANTS,
@@ -105,6 +106,8 @@ class PulpWorker(Worker):
         except Task.DoesNotExist:
             pass
         else:
+            if task.state != TASK_STATES.WAITING:
+                return
             task.set_running()
             user = get_users_with_perms(task).first()
             _set_current_user(user)


### PR DESCRIPTION
backports #8779

fixes #9116

(cherry picked from commit 0cfaa8e7433b7cd272631a6f51b9f4a7b10224a7)
