### PR TITLE
Prevent tasks being assigned to missing workers

### DIFF
--- a/CHANGES/9118.bugfix
+++ b/CHANGES/9118.bugfix
@@ -1,0 +1,2 @@
+Fixed a bug, where new tasks were assigned to dead workers.
+(backported from #8779)

--- a/pulpcore/tasking/worker.py
+++ b/pulpcore/tasking/worker.py
@@ -20,6 +20,7 @@ from django_currentuser.middleware import (  # noqa: E402: module level not at t
 )
 
 from pulpcore.app.models import Task  # noqa: E402: module level not at top of file
+from pulpcore.constants import TASK_STATES  # noqa: E402: module level not at top of file
 
 from pulpcore.tasking.constants import (  # noqa: E402: module level not at top of file
     TASKING_CONSTANTS,
@@ -97,6 +98,8 @@ class PulpWorker(Worker):
         except Task.DoesNotExist:
             pass
         else:
+            if task.state != TASK_STATES.WAITING:
+                return
             task.set_running()
             user = get_users_with_perms(task).first()
             _set_current_user(user)

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,7 @@ aiohttp
 aiodns
 aiofiles
 backoff
+click<8
 Django~=2.2.16  # LTS version, switch only if we have a compelling reason to
 django-currentuser~=0.5.1
 django-filter~=2.3.0


### PR DESCRIPTION
backports #8779

fixes #9118

(cherry picked from commit 0cfaa8e7433b7cd272631a6f51b9f4a7b10224a7)