### PR TITLE
Loosen the constraints around what can be in a new-repository-version.

### DIFF
--- a/CHANGES/8133.bugfix
+++ b/CHANGES/8133.bugfix
@@ -1,0 +1,1 @@
+In stages-pipeline and new-version sanity-checks, added full error-info on path-problems.

--- a/CHANGES/plugin_api/8133.bugfix
+++ b/CHANGES/plugin_api/8133.bugfix
@@ -1,0 +1,4 @@
+Added kwarg to RemoteArtifactSaver init to allow enabling handling of rare error edge-case.
+
+`fix_mismatched_remote_artifacts=True` enables workaround for a failure-scenario that
+(so far) is only encountered by pulp_rpm. Current behavior is the default.

--- a/pulpcore/app/models/publication.py
+++ b/pulpcore/app/models/publication.py
@@ -184,7 +184,14 @@ class Publication(MasterModel):
             exc_tb (types.TracebackType): (optional) stack trace.
         """
         if exc_val:
-            self.delete()
+            # If an exception got us here, the Publication we were trying to create is
+            # Bad, and we should delete the attempt. HOWEVER - some exceptions happen before we
+            # even get that far. In those cases, calling delete() results in a new not-very-useful
+            # exception being raised and reported to the user, rather than the actual problem.
+            try:
+                self.delete()
+            except Exception:
+                raise exc_val.with_traceback(exc_tb)
         else:
             try:
                 self.finalize_new_publication()

--- a/pulpcore/plugin/repo_version_utils.py
+++ b/pulpcore/plugin/repo_version_utils.py
@@ -119,11 +119,10 @@ def validate_version_paths(version):
     paths = ContentArtifact.objects.filter(content__pk__in=version.content).values_list(
         "relative_path", flat=True
     )
-
     try:
         validate_file_paths(paths)
     except ValueError as e:
-        raise ValueError(_("Cannot create repository version. {err}.").format(err=e))
+        raise ValueError(_("Repository version errors : {err}").format(err=e))
 
 
 def validate_repo_version(version):

--- a/pulpcore/tests/unit/test_files.py
+++ b/pulpcore/tests/unit/test_files.py
@@ -19,7 +19,9 @@ class TestValidateFilePaths(TestCase):
         Test for two duplicate paths.
         """
         paths = ["a/b", "PULP_MANIFEST", "PULP_MANIFEST"]
-        with self.assertRaisesRegex(ValueError, "Path is duplicated: PULP_MANIFEST"):
+        with self.assertRaisesRegex(
+            ValueError, "Path errors found. Paths are duplicated: PULP_MANIFEST"
+        ):
             validate_file_paths(paths)
 
     def test_overlaps(self):


### PR DESCRIPTION
There are RPM repositories "in the wild" that violate Pulp's assumptions
about what is 'legal' in an incoming repository version. This commit
changes some fatal errors into log-warnings, along with some heuristics
around how to get a 'reasonable' repository in the face of suboptimal
data.

It also handles an exception during repo-version-failure-cleanup that
could result in losing error info.

fixes #8133
[nocoverage]