### PR TITLE
Fixed a bug with logging on task cancel

### DIFF
--- a/pulpcore/tasking/pulpcore_worker.py
+++ b/pulpcore/tasking/pulpcore_worker.py
@@ -213,7 +213,7 @@ class NewPulpWorker:
                         )
                     ):
                         connection.connection.notifies.clear()
-                        _logger.info(_("Received signal to cancel current task."), task.pk)
+                        _logger.info(_("Received signal to cancel current task %s."), task.pk)
                         os.kill(task_process.pid, signal.SIGUSR1)
                         break
                 if task_process.sentinel in r:


### PR DESCRIPTION
This was introduced in 794a8799.

[noissue]

^ Before anyone asks: I believe, this does not need a changelog (or issue), because i found that bug in a nightly build and it has never been in a release. So there is no benefit in telling there even _was_ a bug.