### PR TITLE
Adds deprecation of old tasking system

### DIFF
--- a/CHANGES/9159.deprecation
+++ b/CHANGES/9159.deprecation
@@ -1,0 +1,3 @@
+The traditional tasking system (formerly the default in ``pulpcore<=3.13`) is deprecated and will be
+removed in ``pulpcore==3.16``. If you are using the ``USE_NEW_WORKER_TYPE=False`` that will no
+longer give you the traditional tasking system starting with ``pulpcore==3.16``.

--- a/pulpcore/tasking/tasks.py
+++ b/pulpcore/tasking/tasks.py
@@ -302,6 +302,12 @@ def dispatch(func, resources, args=None, kwargs=None, task_group=None):
             cursor.execute("NOTIFY pulp_worker_wakeup")
         return task
     else:
+        deprecation_logger.warning(
+            _(
+                "You are using the traditional tasking system which will be removed in pulpcore "
+                "3.16 along with the `USE_NEW_WORKER_TYPE` setting."
+            )
+        )
         RQ_job_id = _enqueue_with_reservation(
             func, resources=resources, args=args, kwargs=kwargs, task_group=task_group
         )


### PR DESCRIPTION
This commit deprecates the old style tasking system in preparation for
it to be removed with pulpcore==3.16.

closes #9159
