### PR TITLE
Removes workaround in RemoteArtifactSaver

### DIFF
--- a/CHANGES/9171.misc
+++ b/CHANGES/9171.misc
@@ -1,0 +1,1 @@
+Removed a workaround in RemoteArtifactSaver that was needed prior to Django 3.2.

--- a/pulpcore/plugin/stages/artifact_stages.py
+++ b/pulpcore/plugin/stages/artifact_stages.py
@@ -287,12 +287,6 @@ class RemoteArtifactSaver(Stage):
         """
         remotes_present = set()
         for d_content in batch:
-            # If the attribute is set in a previous batch on the very first item in this batch, the
-            # rest of the items in this batch will not get the attribute set during prefetch.
-            # https://code.djangoproject.com/ticket/32089
-            if hasattr(d_content.content, "_remote_artifact_saver_cas"):
-                delattr(d_content.content, "_remote_artifact_saver_cas")
-
             for d_artifact in d_content.d_artifacts:
                 if d_artifact.remote:
                     remotes_present.add(d_artifact.remote)


### PR DESCRIPTION
Django 3.2 contains a fix for the bug that required a workaround.
https://code.djangoproject.com/ticket/32089

closes: #9171
https://pulp.plan.io/issues/9171
