### PR TITLE
`AccessPolicyFromDB` is now used by default

### DIFF
--- a/CHANGES/8974.bugfix
+++ b/CHANGES/8974.bugfix
@@ -1,0 +1,2 @@
+Fixed inability for users to disable RBAC at the settings level by changing the
+``DEFAULT_PERMISSION_CLASSES`` like any user configuring a DRF project expects to.

--- a/CHANGES/plugin_api/8974.feature
+++ b/CHANGES/plugin_api/8974.feature
@@ -1,0 +1,4 @@
+The settings file switched ``DEFAULT_PERMISSION_CLASSES`` to use ``AccessPolicyFromDB`` instead of
+``IsAdminUser`` with a fallback to a behavior of ``IsAdminUser``. With this feature plugin writers
+no longer need to declare ``permission_classes`` on their Views or Viewsets to use
+``AccessPolicyFromDB``.

--- a/docs/plugins/plugin-writer/concepts/rbac/access_policy.rst
+++ b/docs/plugins/plugin-writer/concepts/rbac/access_policy.rst
@@ -205,16 +205,21 @@ generally causes them to pass any permission check even without explicit permiss
 Viewset Enforcement
 -------------------
 
-Protecting a viewset with your saved AccessPolicy is done by declaring a ``permission_classes``
-class attribute on your ViewSet that points to ``pulpcore.plugin.access_policy.AccessPolicyFromDB``.
+Pulp configures the ``DEFAULT_PERMISSION_CLASSES`` in the settings file to use
+``pulpcore.plugin.access_policy.AccessPolicyFromDB`` by default. This ensures that by defining a
+``DEFAULT_ACCESS_POLICY`` on your Viewset, Pulp will automatically save it to the database at
+migration-time, and your Viewset will be protected without additional effort.
 
-For example, here is the FileRemoteViewSet which enables authorization enforcement as follows:
+This strategy allows users to completely customize or disable the DRF Permission checks Pulp uses
+like any typical DRF project would.
+
+Also like a typical DRF project, individual Viewsets or views can also be customized to use a
+different Permission check by declaring the ``permission_classes`` check. For example, here is the
+``StatusView`` which disables permission checks entirely as follows:
 
 .. code-block:: python
 
-    from pulpcore.plugin.access_policy import AccessPolicyFromDB
-
-    class FileRemoteViewSet(NamedModelViewSet):
+    class StatusView(APIView):
         ...
-        permission_classes = (AccessPolicyFromDB,)
+        permission_classes = tuple()
         ...

--- a/docs/plugins/plugin-writer/concepts/rbac/overview.rst
+++ b/docs/plugins/plugin-writer/concepts/rbac/overview.rst
@@ -45,15 +45,16 @@ To add authorization for a given resource, e.g. ``FileRemote``, you'll need to:
 2. Define the default permissions created for new objects using the ``permissions_assignment``
    attribute of the new Access Policy for the resource. See the
    :ref:`adding_automatic_permissions_for_new_objects` documentation for more information on that.
-3. Ship that Access Policy as the class attribute ``DEFAULT_ACCESS_POLICY`` of a ``NamedModelViewSet``.
-   This will contain both the ``statements`` and ``permissions_assignment`` attributes. See the
-   :ref:`shipping_default_access_policy` documentation for more information on this.
+3. Ship that Access Policy as the class attribute ``DEFAULT_ACCESS_POLICY`` of a
+   ``NamedModelViewSet``. This will contain both the ``statements`` and ``permissions_assignment``
+   attributes. See the :ref:`shipping_default_access_policy` documentation for more information on
+   this.
 
 **Enforce the Policy:**
 
-1. Define the ``permission_classes`` attribute on your Viewset referring to your subclass of
-   ``pulpcore.plugin.access_policy.AccessPolicyFromDB``. See the :ref:`viewset_enforcement` docs for
-   more information on this.
+1. ``pulpcore.plugin.access_policy.AccessPolicyFromDB`` is configured as the default permission
+   class, so by specifying a ``DEFAULT_ACCESS_POLICY`` it will automatically be enforced. See the
+   :ref:`viewset_enforcement` docs for more information on this.
 
 **Add QuerySet Scoping:**
 

--- a/pulpcore/app/settings.py
+++ b/pulpcore/app/settings.py
@@ -144,7 +144,7 @@ REST_FRAMEWORK = {
     "DEFAULT_FILTER_BACKENDS": ("django_filters.rest_framework.DjangoFilterBackend",),
     "DEFAULT_PAGINATION_CLASS": "rest_framework.pagination.LimitOffsetPagination",
     "PAGE_SIZE": 100,
-    "DEFAULT_PERMISSION_CLASSES": ("rest_framework.permissions.IsAdminUser",),
+    "DEFAULT_PERMISSION_CLASSES": ("pulpcore.plugin.access_policy.AccessPolicyFromDB",),
     "DEFAULT_AUTHENTICATION_CLASSES": (
         "rest_framework.authentication.SessionAuthentication",
         "rest_framework.authentication.BasicAuthentication",

--- a/pulpcore/app/viewsets/task.py
+++ b/pulpcore/app/viewsets/task.py
@@ -7,7 +7,6 @@ from rest_framework.filters import OrderingFilter
 from rest_framework.response import Response
 from rest_framework.serializers import ValidationError
 
-from pulpcore.app.access_policy import AccessPolicyFromDB
 from pulpcore.app.models import Task, TaskGroup, Worker
 from pulpcore.app.serializers import (
     MinimalTaskSerializer,
@@ -68,7 +67,6 @@ class TaskViewSet(
     minimal_serializer_class = MinimalTaskSerializer
     filter_backends = (OrderingFilter, DjangoFilterBackend)
     ordering = "-pulp_created"
-    permission_classes = (AccessPolicyFromDB,)
     queryset_filtering_required_permission = "core.view_task"
 
     DEFAULT_ACCESS_POLICY = {

--- a/pulpcore/app/viewsets/user.py
+++ b/pulpcore/app/viewsets/user.py
@@ -14,7 +14,6 @@ from rest_framework.filters import OrderingFilter
 from rest_framework.response import Response
 from rest_framework.serializers import ValidationError
 
-from pulpcore.app.access_policy import AccessPolicyFromDB
 from pulpcore.app.viewsets import BaseFilterSet, NamedModelViewSet
 from pulpcore.app.serializers.user import (
     GroupSerializer,
@@ -107,7 +106,6 @@ class GroupViewSet(
     serializer_class = GroupSerializer
     queryset = Group.objects.all()
     ordering = ("name",)
-    permission_classes = (AccessPolicyFromDB,)
     queryset_filtering_required_permission = "auth.view_group"
 
     DEFAULT_ACCESS_POLICY = {
@@ -375,7 +373,6 @@ class GroupUserViewSet(NamedModelViewSet):
     parent_lookup_kwargs = {"group_pk": "groups__pk"}
     serializer_class = GroupUserSerializer
     queryset = User.objects.all()
-    permission_classes = (AccessPolicyFromDB,)
 
     DEFAULT_ACCESS_POLICY = {
         "statements": [


### PR DESCRIPTION
The `AccessPolicyFromDB` object is now declared by default in the
settings file, and it provides a fallback behavior to the `IsAdmin`
functionality that was there before.

closes #8974

