### PR TITLE
Fix unnecessary database connections when saving ProgressReports

### DIFF
--- a/CHANGES/9129.bugfix
+++ b/CHANGES/9129.bugfix
@@ -1,0 +1,1 @@
+Fixed ProgressReport's ``.save()`` creating a new database connection everytime it was called from async code


### PR DESCRIPTION
fixes: #9129

Should I also modify the `GroupProgressReport`'s `.update()` function to have the same behavior?