### PR TITLE
Add touch to QuerySets of artifacts or content

### DIFF
--- a/CHANGES/plugin_api/9234.feature
+++ b/CHANGES/plugin_api/9234.feature
@@ -1,0 +1,1 @@
+Added ``touch`` to Artifact and Content query sets for bulk operation.


### PR DESCRIPTION
fixes TBA

This was just a random thought i had when writing these lines: https://github.com/pulp/pulp_container/blob/d25b01d4fb8aed1b264a9dcfc91461fe92d630b8/pulp_container/app/viewsets.py#L748

Not sure if it really helps there, also it's really kind of late for 3.14. If you like this i can do the issue dance for it.