### PR TITLE
Move files to artifact storage from WORKING_DIRECTORY.

### DIFF
--- a/CHANGES/9146.bugfix
+++ b/CHANGES/9146.bugfix
@@ -1,0 +1,2 @@
+Move files to artifact storage only when they originate from WORKING_DIRECTORY.
+Copy files from all other sources. 

--- a/pulpcore/app/checks.py
+++ b/pulpcore/app/checks.py
@@ -21,20 +21,20 @@ def storage_paths(app_configs, **kwargs):
             )
 
         try:
-            upload_temp_dir_dev = Path(settings.FILE_UPLOAD_TEMP_DIR).stat().st_dev
+            working_dir_dev = Path(settings.WORKING_DIRECTORY).stat().st_dev
         except OSError:
-            upload_temp_dir_dev = None
+            working_dir_dev = None
             warnings.append(
                 CheckWarning(
-                    "Your FILE_UPLOAD_TEMP_DIR setting points to a path that does not exist.",
+                    "Your WORKING_DIRECTORY setting points to a path that does not exist.",
                     id="pulpcore.W002",
                 )
             )
 
-        if media_root_dev and media_root_dev != upload_temp_dir_dev:
+        if media_root_dev and media_root_dev != working_dir_dev:
             warnings.append(
                 CheckWarning(
-                    "MEDIA_ROOT and FILE_UPLOAD_TEMP_DIR are on different filesystems. "
+                    "MEDIA_ROOT and WORKING_DIRECTORY are on different filesystems. "
                     "It is highly recommended that these live on the same filesystem",
                     id="pulpcore.W003",
                 )

--- a/pulpcore/app/models/storage.py
+++ b/pulpcore/app/models/storage.py
@@ -11,9 +11,10 @@ class FileSystem(FileSystemStorage):
     """
     Django's FileSystemStorage with modified _save() and get_available_name behaviors
 
-    The _save() will check if the file is saved in DEPLOY_ROOT first. If it is, a move is used. This
-    will move all files created by the Downloaders and uploaded files from the user. If it is saved
-    in-memory or outside of DEPLOY_ROOT, the data is written/copied in chunks to the new location.
+    The _save() will check if the file is saved in WORKING_DIRECTORY first. If it is, a move is
+    used. This will move all files created by the Downloaders and uploaded files from the user. If
+    it is saved in-memory or outside of WORKING_DIRECTORY, the data is written/copied in chunks to
+    the new location.
     """
 
     def get_available_name(self, name, max_length=None):
@@ -63,7 +64,7 @@ class FileSystem(FileSystemStorage):
 
         try:
             if hasattr(content, "temporary_file_path") and content.temporary_file_path().startswith(
-                str(settings.DEPLOY_ROOT)
+                str(settings.WORKING_DIRECTORY)
             ):
                 file_move_safe(content.temporary_file_path(), full_path)
             else:

--- a/pulpcore/app/settings.py
+++ b/pulpcore/app/settings.py
@@ -46,8 +46,9 @@ STATIC_ROOT = DEPLOY_ROOT / STATIC_URL.strip("/")
 
 DEFAULT_FILE_STORAGE = "pulpcore.app.models.storage.FileSystem"
 
-FILE_UPLOAD_TEMP_DIR = DEPLOY_ROOT / "tmp"
-WORKING_DIRECTORY = FILE_UPLOAD_TEMP_DIR
+WORKING_DIRECTORY = DEPLOY_ROOT / "tmp"
+FILE_UPLOAD_TEMP_DIR = WORKING_DIRECTORY
+
 CHUNKED_UPLOAD_DIR = "upload"
 
 # List of upload handler classes to be applied in order.


### PR DESCRIPTION
Copy files from all other sources. Since users are able to change the
WORKING_DIRECTORY settings, this patch also ensures that we check that
the WORKING_DIRECTORY and MEDIA_ROOT are on the same device. Django's
FILE_UPLOAD_TEMP_DIR is now set to the value of WORKING_DIRECTORY.

fixes: #9146
https://pulp.plan.io/issues/9146/