### PR TITLE
Properly update present ContentAtifacts after immediate sync

### DIFF
--- a/CHANGES/9101.bugfix
+++ b/CHANGES/9101.bugfix
@@ -1,0 +1,1 @@
+Artifacts are now being properly updated for Content after switching from 'on_demand' to 'immediate'.

--- a/pulpcore/tests/functional/api/using_plugin/test_reclaim_disk_space.py
+++ b/pulpcore/tests/functional/api/using_plugin/test_reclaim_disk_space.py
@@ -1,8 +1,6 @@
 """Tests that perform actions over reclaim disk space."""
-import unittest
-
 from pulp_smash import config
-from pulp_smash.pulp3.bindings import monitor_task
+from pulp_smash.pulp3.bindings import monitor_task, PulpTestCase
 from pulp_smash.pulp3.utils import (
     gen_repo,
     get_content,
@@ -30,7 +28,7 @@ from pulpcore.tests.functional.api.using_plugin.utils import (
 from pulpcore.tests.functional.utils import core_client
 
 
-class ReclaimSpaceTestCase(unittest.TestCase):
+class ReclaimSpaceTestCase(PulpTestCase):
     """
     Test whether repository content can be reclaimed.
     Subsequently, confirm that artifact is correctly re-downloaded in sync
@@ -53,10 +51,11 @@ class ReclaimSpaceTestCase(unittest.TestCase):
         orphans_response = cls.orphans_api.cleanup({"orphan_protection_time": 0})
         monitor_task(orphans_response.task)
 
-    @classmethod
-    def tearDownClass(cls):
+    def tearDown(self):
         """Clean created resources."""
-        orphans_response = cls.orphans_api.cleanup({"orphan_protection_time": 0})
+        # Runs any delete tasks and waits for them to complete
+        self.doCleanups()
+        orphans_response = self.orphans_api.cleanup({"orphan_protection_time": 0})
         monitor_task(orphans_response.task)
 
     def test_reclaim_immediate_content(self):

--- a/pulpcore/tests/functional/api/using_plugin/test_sync.py
+++ b/pulpcore/tests/functional/api/using_plugin/test_sync.py
@@ -1,0 +1,73 @@
+from pulp_smash.pulp3.bindings import delete_orphans, monitor_task, PulpTestCase
+from pulp_smash.pulp3.utils import gen_repo
+
+from pulpcore.tests.functional.api.using_plugin.utils import (
+    gen_file_client,
+    gen_file_remote,
+)
+from pulpcore.client.pulp_file import (
+    ContentFilesApi,
+    RepositorySyncURL,
+    RepositoriesFileApi,
+    RemotesFileApi,
+)
+from pulpcore.tests.functional.api.using_plugin.utils import (  # noqa:F401
+    set_up_module as setUpModule,
+)
+
+
+class MultiplePolicySyncTestCase(PulpTestCase):
+    """
+    This test ensures that content artifacts are properly updated when syncing multiple
+    times with different policies, specifically from 'on_demand' to 'immediate'
+
+    This test targets the following issue:
+    * `Pulp #9101 <https://pulp.plan.io/issues/9101>`_
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        """Clean out Pulp before testing."""
+        delete_orphans()
+        client = gen_file_client()
+        cls.cont_api = ContentFilesApi(client)
+        cls.repo_api = RepositoriesFileApi(client)
+        cls.remote_api = RemotesFileApi(client)
+
+    def tearDown(self):
+        """Clean up Pulp after testing."""
+        self.doCleanups()
+        delete_orphans()
+
+    def test_ondemand_to_immediate_sync(self):
+        """Checks that content artifacts are updated following on-demand -> immediate sync."""
+        # Ensure that no content is present
+        content_response = self.cont_api.list(limit=1)
+        if content_response.count > 0:
+            self.skipTest("Please remove all file content before running this test")
+
+        # Create and sync repo w/ on_demand policy
+        repo = self.repo_api.create(gen_repo())
+        remote = self.remote_api.create(gen_file_remote(policy="on_demand"))
+        body = RepositorySyncURL(remote=remote.pulp_href)
+        monitor_task(self.repo_api.sync(repo.pulp_href, body).task)
+        self.addCleanup(self.repo_api.delete, repo.pulp_href)
+        self.addCleanup(self.remote_api.delete, remote.pulp_href)
+
+        # Check content is present, but no artifacts are there
+        content_response = self.cont_api.list()
+        self.assertEqual(content_response.count, 3)
+        for content in content_response.results:
+            self.assertEqual(content.artifact, None)
+
+        # Sync again w/ immediate policy
+        remote = self.remote_api.create(gen_file_remote())
+        body = RepositorySyncURL(remote=remote.pulp_href)
+        monitor_task(self.repo_api.sync(repo.pulp_href, body).task)
+        self.addCleanup(self.remote_api.delete, remote.pulp_href)
+
+        # Check content is still present, but artifacts are now there
+        content_response = self.cont_api.list()
+        self.assertEqual(content_response.count, 3)
+        for content in content_response.results:
+            self.assertNotEqual(content.artifact, None)


### PR DESCRIPTION
fixes: #9101

This needs to be backported to 3.14 by Tuesday for Satellite, but it contains changes to the sync pipeline that need to be updated for the 3.15 async changes here: https://github.com/pulp/pulpcore/pull/1553. 

Please be sure you have read our documentation on creating PRs:
https://docs.pulpproject.org/contributing/pull-request-walkthrough.html
