### PR TITLE
Reset a db connection in content app distribution matching code

### DIFF
--- a/CHANGES/9275.bugfix
+++ b/CHANGES/9275.bugfix
@@ -1,0 +1,1 @@
+Fixed another occurence of the HTTP 500 error and `connection already closed` in the logs while accessing content.

--- a/pulpcore/content/handler.py
+++ b/pulpcore/content/handler.py
@@ -246,6 +246,8 @@ class Handler:
         Raises:
             PathNotResolved: when not matched.
         """
+        cls._reset_db_connection()
+
         base_paths = cls._base_paths(path)
         if cls.distribution_model is None:
             try:


### PR DESCRIPTION
It's a workaround for yet another `connection already closed` issue.
closes #9275
https://pulp.plan.io/issues/9275

https://pulp.plan.io/issues/9276 is filed to investigate that issue more.

