### PR TITLE
Ensure that the Stages API uses a single connection to the DB.

### DIFF
--- a/CHANGES/9129.bugfix
+++ b/CHANGES/9129.bugfix
@@ -1,0 +1,1 @@
+Made all database queries run serially using a single connection to the database.

--- a/CHANGES/plugin_api/9129.deprecation
+++ b/CHANGES/plugin_api/9129.deprecation
@@ -1,0 +1,2 @@
+ContentSaver._pre_save() and ContentSaver._post_save() hooks are no longer coroutines. They should
+be implemented as syncronous functions.

--- a/CHANGES/plugin_api/9129.feature
+++ b/CHANGES/plugin_api/9129.feature
@@ -1,0 +1,5 @@
+`pulpcore.plugin.models.ProgressReport` now has async interfaces: asave(), aincrease_by(),
+aincrement(), __aenter__(), _aexit__(). Plugins should switch to the async interfaces in their
+Stages.
+`pulpcore.plugin.sync.sync_to_async_iterator` is a utility method to synchronize the database
+queries generated when a QuerySet is iterated.

--- a/pulpcore/app/migrations/0010_pulp_fields.py
+++ b/pulpcore/app/migrations/0010_pulp_fields.py
@@ -450,7 +450,7 @@ class Migration(migrations.Migration):
         migrations.AlterField(
             model_name='progressreport',
             name='task',
-            field=models.ForeignKey(default=pulpcore.app.models.task.Task.current, on_delete=django.db.models.deletion.CASCADE, related_name='progress_reports', to='core.Task', to_field='pulp_id'),
+            field=models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, related_name='progress_reports', to='core.Task', to_field='pulp_id'),
         ),
         migrations.AlterField(
             model_name='publication',

--- a/pulpcore/plugin/sync.py
+++ b/pulpcore/plugin/sync.py
@@ -1,0 +1,32 @@
+from asgiref.sync import sync_to_async
+
+
+iter_async = sync_to_async(iter)
+
+
+@sync_to_async
+def next_async(it):
+    try:
+        return next(it)
+    except StopIteration:
+        raise StopAsyncIteration
+
+
+async def sync_to_async_iterable(sync_iterable):
+    """
+    Utility method which runs each iteration of a synchronous iterable in a threadpool. It also
+    sets a threadlocal inside the thread so calls to AsyncToSync can escape it. The implementation
+    relies on `asgiref.sync.sync_to_async`.  thread_sensitive parameter for sync_to_async defaults
+    to True. This code will run in the same thread as any outer code. This is needed for
+    underlying Python code that is not threadsafe (for example, code which handles database
+    connections).
+
+    Args:
+        sync_iterable (iter): A synchronous iterable such as a QuerySet.
+    """
+    sync_iterator = await iter_async(sync_iterable)
+    while True:
+        try:
+            yield await next_async(sync_iterator)
+        except StopAsyncIteration:
+            return

--- a/pulpcore/tests/unit/stages/test_artifactdownloader.py
+++ b/pulpcore/tests/unit/stages/test_artifactdownloader.py
@@ -111,11 +111,11 @@ class TestArtifactDownloader(asynctest.ClockedTestCase):
             The done count of the ProgressReport.
         """
         with mock.patch("pulpcore.plugin.stages.artifact_stages.ProgressReport") as pb:
-            pb.return_value.__enter__.return_value.done = 0
+            pb.return_value.__aenter__.return_value.done = 0
             ad = ArtifactDownloader(max_concurrent_content=max_concurrent_content)
             ad._connect(self.in_q, self.out_q)
             await ad()
-        return pb.return_value.__enter__.return_value.done
+        return pb.return_value.__aenter__.return_value.done
 
     def assertQueued(self, num):
         self.assertEqual(self.in_q.qsize(), num)


### PR DESCRIPTION
Django 3.2 opens up a new connection to the DB for each coroutine that accesses the DB. All ORM
interactions need to be wrapped in 'asgiref.sync.sync_to_async' in order to ensure that all DB
querries are executed using a single connection in a serial manner. This patch also provides
utility function `pulpcore.plugin.sync.sync_to_async_iterable` built on top of `sync_to_async`.
This functions is needed to operate on QuerySet objects and other synchronous iterables.

ProgressReport is enhanced with async interfaces: asave(), aincrease_by(), aincrement(),
__aenter__(), __aexit__(). Plugins should switch to the async interfaces in their Stages.

This patch also ensures that all transactions in the Stages API are run synchronously. This
requires deprecating the ContentStage._pre_save() and _post_save() coroutines in favor of
synchronous interfaces with the same name.

Each task that uses async code to access the DB now creates 2 connections to the DB. One to
communicate on the main thread and another connection for everything that accesses the DB
from coroutines such as the Stages API.

fixes: #9129

Please be sure you have read our documentation on creating PRs:
https://docs.pulpproject.org/contributing/pull-request-walkthrough.html
