### PR TITLE
Backport: Stop using blake2s to calulate lock identifiers

### DIFF
--- a/CHANGES/9288.bugfix
+++ b/CHANGES/9288.bugfix
@@ -1,0 +1,2 @@
+Stop using insecure hash function blake2s for calculating 64 bit lock identifier from uuid.
+(backported from #9249)

--- a/pulpcore/tasking/util.py
+++ b/pulpcore/tasking/util.py
@@ -1,6 +1,5 @@
 import logging
 import time
-from hashlib import blake2s
 from gettext import gettext as _
 
 from django.conf import settings
@@ -140,8 +139,3 @@ def get_current_worker():
             return worker
 
     return None
-
-
-def _hash_to_u64(value):
-    _digest = blake2s(value.encode(), digest_size=8).digest()
-    return int.from_bytes(_digest, byteorder="big", signed=True)


### PR DESCRIPTION
Instead perform a simple xor on the first and second half of the task
uuid.

backports #9249

fixes #9288

(cherry picked from commit 1d77e5cdf4d03b7edff34f4fc3b60a2f70df3e88)