### PR TITLE
Return 201 for RBAC content guard assign/remove endpoints

### DIFF
--- a/CHANGES/9323.bugfix
+++ b/CHANGES/9323.bugfix
@@ -1,0 +1,2 @@
+``RBACContentGuard`` assign/remove permission endpoints now properly return 201 instead of 200
+(backported from #9314)

--- a/pulpcore/app/viewsets/publication.py
+++ b/pulpcore/app/viewsets/publication.py
@@ -200,7 +200,7 @@ class RBACContentGuardViewSet(ContentGuardViewSet):
         ],
     }
 
-    @extend_schema(summary="Add download permission", responses={200: RBACContentGuardSerializer})
+    @extend_schema(summary="Add download permission", responses={201: RBACContentGuardSerializer})
     @action(methods=["post"], detail=True, serializer_class=RBACContentGuardPermissionSerializer)
     def assign_permission(self, request, pk):
         """Give users and groups the `download` permission"""
@@ -210,10 +210,10 @@ class RBACContentGuardViewSet(ContentGuardViewSet):
         guard.add_can_download(users=names.data["usernames"], groups=names.data["groupnames"])
         self.serializer_class = RBACContentGuardSerializer
         serializer = self.get_serializer(guard)
-        return Response(serializer.data)
+        return Response(serializer.data, status=201)
 
     @extend_schema(
-        summary="Remove download permission", responses={200: RBACContentGuardSerializer}
+        summary="Remove download permission", responses={201: RBACContentGuardSerializer}
     )
     @action(methods=["post"], detail=True, serializer_class=RBACContentGuardPermissionSerializer)
     def remove_permission(self, request, pk):
@@ -224,7 +224,7 @@ class RBACContentGuardViewSet(ContentGuardViewSet):
         guard.remove_can_download(users=names.data["usernames"], groups=names.data["groupnames"])
         self.serializer_class = RBACContentGuardSerializer
         serializer = self.get_serializer(guard)
-        return Response(serializer.data)
+        return Response(serializer.data, status=201)
 
 
 class DistributionFilter(BaseFilterSet):


### PR DESCRIPTION
backports: #9314

fixes #9323

(cherry picked from commit dc8c2357f96ee7d2d1ce8e32e7fe3febc127106c)

Please be sure you have read our documentation on creating PRs:
https://docs.pulpproject.org/contributing/pull-request-walkthrough.html
