### PR TITLE
Don't send Content-Encoding header with streamed responses

### DIFF
--- a/CHANGES/9213.bugfix
+++ b/CHANGES/9213.bugfix
@@ -1,0 +1,2 @@
+Fixed a bug where ``pulpcore-content`` decompressed data while incorrectly advertising to clients
+it was still compressed via the ``Content-Encoding: gzip`` header.

--- a/pulpcore/content/handler.py
+++ b/pulpcore/content/handler.py
@@ -101,6 +101,7 @@ class Handler:
 
     hop_by_hop_headers = [
         "connection",
+        "content-encoding",
         "keep-alive",
         "public",
         "proxy-authenticate",


### PR DESCRIPTION
aiohttp automatically enflates gzipped responses. Pulp clients always receive
uncompressed responses when requesting on_demand content.

fixes: #9213