### PR TITLE
backports worker not starting on openshift

### DIFF
--- a/CHANGES/9325.bugfix
+++ b/CHANGES/9325.bugfix
@@ -1,0 +1,3 @@
+Fixed a bug where ``pulpcore-content`` decompressed data while incorrectly advertising to clients
+it was still compressed via the ``Content-Encoding: gzip`` header.
+(backported from #9213)

--- a/CHANGES/9339.bugfix
+++ b/CHANGES/9339.bugfix
@@ -1,0 +1,3 @@
+Fixed bug where some Openshift environments could not start workers due to a strange Python runtime
+import issue.
+(backported from #9338)

--- a/pulpcore/content/handler.py
+++ b/pulpcore/content/handler.py
@@ -101,6 +101,7 @@ class Handler:
 
     hop_by_hop_headers = [
         "connection",
+        "content-encoding",
         "keep-alive",
         "public",
         "proxy-authenticate",

--- a/pulpcore/tasking/entrypoint.py
+++ b/pulpcore/tasking/entrypoint.py
@@ -14,6 +14,7 @@ os.environ.setdefault("DJANGO_ALLOW_ASYNC_UNSAFE", "true")
 django.setup()
 
 from django.conf import settings  # noqa: E402: module level not at top of file
+from pulpcore.tasking.pulpcore_worker import NewPulpWorker  # noqa: E402: module level not at top
 
 
 _logger = logging.getLogger(__name__)
@@ -40,8 +41,6 @@ def worker(resource_manager, pid):
             )
             select.select([], [], [])
         _logger.info("Starting distributed type worker")
-        from pulpcore.tasking.pulpcore_worker import NewPulpWorker
-
         NewPulpWorker().run_forever()
     else:
         _logger.info("Starting rq type worker")


### PR DESCRIPTION
For some strange reason some Openshift environments do not like the
runtime import the worker entrypoint used. Moving it to the top where it
belongs anyway resolves the problem.

backports #9338

fixes #9339

(cherry picked from commit 022d2e390729401e157201edea84da14c77b49db)
