### PR TITLE
Disable DJANGO_ALLOW_ASYNC_UNSAFE for tasking system

### DIFF
--- a/CHANGES/9353.misc
+++ b/CHANGES/9353.misc
@@ -1,0 +1,1 @@
+Disabled DJANGO_ALLOW_ASYNC_UNSAFE for tasking system and fixed some issues that were uncovered in doing so.

--- a/pulpcore/plugin/stages/artifact_stages.py
+++ b/pulpcore/plugin/stages/artifact_stages.py
@@ -15,7 +15,7 @@ from .api import Stage
 log = logging.getLogger(__name__)
 
 
-def _check_for_forbidden_checksume_type(artifact):
+def _check_for_forbidden_checksum_type(artifact):
     """Check if content doesn't have forbidden checksum type.
 
     If contains forbidden checksum type it will raise ValueError,
@@ -74,7 +74,7 @@ class QueryExistingArtifacts(Stage):
                 for d_artifact in d_content.d_artifacts:
                     if d_artifact.artifact._state.adding:
                         if not d_artifact.deferred_download:
-                            _check_for_forbidden_checksume_type(d_artifact.artifact)
+                            _check_for_forbidden_checksum_type(d_artifact.artifact)
                         for digest_type in Artifact.COMMON_DIGEST_FIELDS:
                             digest_value = getattr(d_artifact.artifact, digest_type)
                             if digest_value:
@@ -87,7 +87,7 @@ class QueryExistingArtifacts(Stage):
             # swap it out with the existing one.
             for digest_type, digests in artifact_digests_by_type.items():
                 query_params = {"{attr}__in".format(attr=digest_type): digests}
-                existing_artifacts_qs = Artifact.objects.filter(**query_params).only(digest_type)
+                existing_artifacts_qs = Artifact.objects.filter(**query_params)
                 existing_artifacts = sync_to_async_iterable(existing_artifacts_qs)
                 await sync_to_async(existing_artifacts_qs.touch)()
                 for d_content in batch:

--- a/pulpcore/tasking/entrypoint.py
+++ b/pulpcore/tasking/entrypoint.py
@@ -8,9 +8,6 @@ import django
 from pulpcore.app.loggers import deprecation_logger
 
 os.environ.setdefault("DJANGO_SETTINGS_MODULE", "pulpcore.app.settings")
-# Until Django supports async ORM natively this is the best we can do given these parts of Pulp
-# run in coroutines. We try to ensure it is safe by never passing ORM data between co-routines.
-os.environ.setdefault("DJANGO_ALLOW_ASYNC_UNSAFE", "true")
 
 django.setup()
 


### PR DESCRIPTION
This should no longer be necessary after all the work done to reduce db connections - and if we do encounter issues, we'd be better off trying to address them.

[noissue]