### PR TITLE
Adds machinery to return task groups from viewsets

### DIFF
--- a/CHANGES/plugin_api/9380.feature
+++ b/CHANGES/plugin_api/9380.feature
@@ -1,0 +1,4 @@
+Added ``pulpcore.plugin.viewset.TaskGroupResponse`` which can be used to return a reference to a
+task group created in a viewset. Added ``pulpcore.plugin.serializers.TaskGroupResponseSerializer``
+which can be used to indicate the serializer response format of viewsets that will use
+``TaskGroupResponse`` similar to how ``AsyncOperationResponseSerializer`` is used.

--- a/pulpcore/app/response.py
+++ b/pulpcore/app/response.py
@@ -24,3 +24,26 @@ class OperationPostponedResponse(Response):
         """
         resp = {"task": reverse("tasks-detail", args=[task.pk], request=None)}
         super().__init__(data=resp, status=202)
+
+
+class TaskGroupResponse(Response):
+    """
+    An HTTP response class for returning 202 and a task group.
+
+    This response object should be used by views that create a task group and dispatch one or more
+    tasks for that group. When JSON is requested, the response will look like the following::
+
+        {
+            "task_group": "/pulp/api/v3/task-groups/735633bc-eb41-4737-b436-c7c6914f34b1/"
+        }
+    """
+
+    def __init__(self, task_group, request):
+        """
+        Args:
+            task_group (pulpcore.plugin.models.TaskGroup): A
+                :class:`~pulpcore.plugin.models.TaskGroup` object used to generate the response.
+            request (rest_framework.request.Request): Request used to generate the pulp_href urls
+        """
+        resp = {"task_group": reverse("task-groups-detail", args=[task_group.pk], request=None)}
+        super().__init__(data=resp, status=202)

--- a/pulpcore/app/serializers/__init__.py
+++ b/pulpcore/app/serializers/__init__.py
@@ -12,6 +12,7 @@ from .base import (  # noqa
     NestedRelatedField,
     RelatedField,
     RelatedResourceField,
+    TaskGroupResponseSerializer,
     ValidateFieldsMixin,
     validate_unknown_fields,
 )

--- a/pulpcore/app/serializers/base.py
+++ b/pulpcore/app/serializers/base.py
@@ -13,7 +13,7 @@ from rest_framework_nested.relations import (
     NestedHyperlinkedRelatedField,
 )
 
-from pulpcore.app.models import Label, Task
+from pulpcore.app.models import Label, Task, TaskGroup
 from pulpcore.app.util import (
     get_view_name_for_model,
     get_viewset_for_model,
@@ -364,5 +364,19 @@ class AsyncOperationResponseSerializer(serializers.Serializer):
         help_text=_("The href of the task."),
         queryset=Task.objects,
         view_name="tasks-detail",
+        allow_null=False,
+    )
+
+
+class TaskGroupResponseSerializer(serializers.Serializer):
+    """
+    Serializer for asynchronous operations that return a task group.
+    """
+
+    task_group = RelatedField(
+        required=True,
+        help_text=_("The href of the task group."),
+        queryset=TaskGroup.objects,
+        view_name="task-groups-detail",
         allow_null=False,
     )

--- a/pulpcore/plugin/serializers/__init__.py
+++ b/pulpcore/plugin/serializers/__init__.py
@@ -27,6 +27,7 @@ from pulpcore.app.serializers import (  # noqa
     RepositoryVersionRelatedField,
     SingleArtifactContentSerializer,
     SingleContentArtifactField,
+    TaskGroupResponseSerializer,
     ValidateFieldsMixin,
     validate_unknown_fields,
 )

--- a/pulpcore/plugin/viewsets/__init__.py
+++ b/pulpcore/plugin/viewsets/__init__.py
@@ -1,5 +1,5 @@
 # Allow plugin viewsets to return 202s
-from pulpcore.app.response import OperationPostponedResponse  # noqa
+from pulpcore.app.response import OperationPostponedResponse, TaskGroupResponse  # noqa
 
 # Import Viewsets in platform that are potentially useful to plugin writers
 from pulpcore.app.viewsets import (  # noqa


### PR DESCRIPTION
Adds a ``TaskGroupResponse`` and corresponding
``TaskGroupResponseSerializer`` allowing viewsets to return a task group
back to users directly.

closes #9380

