### PR TITLE
Fixed update call for the ACS so paths are not silenty removed when o…

### DIFF
--- a/CHANGES/9376.bugfix
+++ b/CHANGES/9376.bugfix
@@ -1,0 +1,1 @@
+Fixed update call for the ACS so paths are not silenty removed when other fields are being updated.

--- a/pulpcore/app/serializers/acs.py
+++ b/pulpcore/app/serializers/acs.py
@@ -85,9 +85,12 @@ class AlternateContentSourceSerializer(ModelSerializer):
                 alternate_content_source=acs.pk
             )
         }
-        to_remove = existing_paths - set(paths)
-        to_add = set(paths) - existing_paths
-
+        if paths is None:
+            to_remove = set()
+            to_add = set()
+        else:
+            to_remove = existing_paths - set(paths)
+            to_add = set(paths) - existing_paths
         if to_remove:
             models.AlternateContentSourcePath.objects.filter(path__in=to_remove).delete()
         if to_add:
@@ -115,7 +118,7 @@ class AlternateContentSourceSerializer(ModelSerializer):
         """Update an Alternate Content Source."""
         instance.name = validated_data.get("name", instance.name)
         instance.remote = validated_data.get("remote", instance.remote)
-        paths = validated_data.pop("paths", [])
+        paths = validated_data.get("paths")
         with transaction.atomic():
             self._update_paths(instance, paths)
             instance.save()

--- a/pulpcore/tests/functional/api/using_plugin/test_acs.py
+++ b/pulpcore/tests/functional/api/using_plugin/test_acs.py
@@ -83,6 +83,8 @@ class AlternateContentSourceTestCase(unittest.TestCase):
         acs = self.file_acs_api.read(acs.pulp_href)
 
         self.assertEqual(acs.name, new_name)
+        # assert paths were not silently removed during name update
+        self.assertEqual(acs.paths, self.paths)
 
         # partial update name
         new_name = "new_acs"


### PR DESCRIPTION
…ther fields are being updated.

closes #9376

Please be sure you have read our documentation on creating PRs:
https://docs.pulpproject.org/contributing/pull-request-walkthrough.html
