### PR TITLE
Rename TaskGroupResponse to TaskGroupOperationResponse

### DIFF
--- a/CHANGES/plugin_api/9425.removal
+++ b/CHANGES/plugin_api/9425.removal
@@ -1,0 +1,3 @@
+Renamed ``TaskGroupResponse`` to ``TaskGroupOperationResponse`` and ``TaskGroupResponseSerializer``
+to ``TaskGroupOperationResponseSerializer`` in order to avoid conflicts with responses from task
+groups endpoints.

--- a/pulpcore/app/response.py
+++ b/pulpcore/app/response.py
@@ -26,7 +26,7 @@ class OperationPostponedResponse(Response):
         super().__init__(data=resp, status=202)
 
 
-class TaskGroupResponse(Response):
+class TaskGroupOperationResponse(Response):
     """
     An HTTP response class for returning 202 and a task group.
 

--- a/pulpcore/app/serializers/__init__.py
+++ b/pulpcore/app/serializers/__init__.py
@@ -12,7 +12,7 @@ from .base import (  # noqa
     NestedRelatedField,
     RelatedField,
     RelatedResourceField,
-    TaskGroupResponseSerializer,
+    TaskGroupOperationResponseSerializer,
     ValidateFieldsMixin,
     validate_unknown_fields,
 )

--- a/pulpcore/app/serializers/base.py
+++ b/pulpcore/app/serializers/base.py
@@ -368,7 +368,7 @@ class AsyncOperationResponseSerializer(serializers.Serializer):
     )
 
 
-class TaskGroupResponseSerializer(serializers.Serializer):
+class TaskGroupOperationResponseSerializer(serializers.Serializer):
     """
     Serializer for asynchronous operations that return a task group.
     """

--- a/pulpcore/plugin/serializers/__init__.py
+++ b/pulpcore/plugin/serializers/__init__.py
@@ -27,7 +27,7 @@ from pulpcore.app.serializers import (  # noqa
     RepositoryVersionRelatedField,
     SingleArtifactContentSerializer,
     SingleContentArtifactField,
-    TaskGroupResponseSerializer,
+    TaskGroupOperationResponseSerializer,
     ValidateFieldsMixin,
     validate_unknown_fields,
 )

--- a/pulpcore/plugin/viewsets/__init__.py
+++ b/pulpcore/plugin/viewsets/__init__.py
@@ -1,5 +1,5 @@
 # Allow plugin viewsets to return 202s
-from pulpcore.app.response import OperationPostponedResponse, TaskGroupResponse  # noqa
+from pulpcore.app.response import OperationPostponedResponse, TaskGroupOperationResponse  # noqa
 
 # Import Viewsets in platform that are potentially useful to plugin writers
 from pulpcore.app.viewsets import (  # noqa


### PR DESCRIPTION
fixes #9425

Please be sure you have read our documentation on creating PRs:
https://docs.pulpproject.org/contributing/pull-request-walkthrough.html
