### PR TITLE
Document Azure storage needs to set MEDIA_ROOT

### DIFF
--- a/CHANGES/9428.doc
+++ b/CHANGES/9428.doc
@@ -1,0 +1,1 @@
+Document Azure storage needs to set ``MEDIA_ROOT``

--- a/docs/installation/storage.rst
+++ b/docs/installation/storage.rst
@@ -90,7 +90,8 @@ Configuring Pulp to use Azure Blob storage
       pip install django-storages[azure]
 
 2. Depending on which method you use to install or configure Pulp, you must set ``DEFAULT_FILE_STORAGE`` to ``storages.backends.azure_storage.AzureStorage`` in Pulp Settings. For example, if you use the `Pulp installer <https://docs.pulpproject.org/pulp_installer/quickstart/>`_, the ``default_file_storage`` is part of the ``pulp_settings`` Ansible variables you can define in your Ansible playbook.
-3. In the same way, configure the following parameters::
+3. Set the ``MEDIA_ROOT`` configuration option. This will be the path in your container that Pulp will use. If you want Pulp to create its folders in the top level of the container, an empty string is acceptable.
+4. In the same way, configure the following parameters::
 
       AZURE_ACCOUNT_NAME = 'Storage account name'
       AZURE_CONTAINER = 'Container name (as created within the blob service of your storage account)'
@@ -98,6 +99,7 @@ Configuring Pulp to use Azure Blob storage
       AZURE_URL_EXPIRATION_SECS = 60
       AZURE_OVERWRITE_FILES = 'True'
       AZURE_LOCATION = 'the folder within the container where your pulp objects will be stored'
+      MEDIA_ROOT = ''
 
   For a comprehensive overview of all possible options for the Azure Blob storage backend see the `django-storages[azure] documents
   <https://django-storages.readthedocs.io/en/latest/backends/azure.html>`_.


### PR DESCRIPTION
I've started a PoC for testing azure storage: https://github.com/pulp/pulp_ansible/pull/649
and found this issue
```
(pulp) [vagrant@pulp3-source-fedora34 pulp_ansible]$ nc 127.0.0.1 4444
> /home/vagrant/devel/pulpcore/pulpcore/app/tasks/importer.py(403)pulp_import()
-> if not default_storage.exists(dest):
(Pdb) dest
'/var/lib/pulp/media/artifact/36/0548ba80e3dce478b7915ca89a5613dc80c650a55b96f5491012a8297e12ac'
(Pdb) default_storage.exists(dest)
*** django.core.exceptions.SuspiciousOperation: Attempted access to '/var/lib/pulp/media/artifact/36/0548ba80e3dce478b7915ca89a5613dc80c650a55b96f5491012a8297e12ac' denied.
(Pdb) default_storage.list_all()
['pulp3/artifact/36/0548ba80e3dce478b7915ca89a5613dc80c650a55b96f5491012a8297e12ac', 'pulp3/artifact/4e/042680c4cf9c54296e22e388e6058c469d9a09348523122d44165c2f2d61a8', 'pulp3/artifact/5a/9413fe085b128933884be1fb3f5094ac257e2383a0e869ce17b3c15624ae16', 'pulp3/artifact/6c/a52bdcb651b80b9655805bd44baf6e56c6b6de88210e1b412334be1278e4a5', 'pulp3/artifact/c1/05d0816dcfd2a4fa969ba063acdddf0fa43719fea8c556b2c70e96d60f84f2', 'pulp3/artifact/c1/e05337c06b438780bca6173925bc2f94904eb8cafb5595e2c7de2082009cb6', 'pulp3/pulp3/artifact/36/0548ba80e3dce478b7915ca89a5613dc80c650a55b96f5491012a8297e12ac', 'pulp3/pulp3/artifact/4e/042680c4cf9c54296e22e388e6058c469d9a09348523122d44165c2f2d61a8', 'pulp3/pulp3/artifact/5a/9413fe085b128933884be1fb3f5094ac257e2383a0e869ce17b3c15624ae16', 'pulp3/pulp3/artifact/6c/a52bdcb651b80b9655805bd44baf6e56c6b6de88210e1b412334be1278e4a5', 'pulp3/pulp3/artifact/c1/05d0816dcfd2a4fa969ba063acdddf0fa43719fea8c556b2c70e96d60f84f2', 'pulp3/pulp3/artifact/c1/e05337c06b438780bca6173925bc2f94904eb8cafb5595e2c7de2082009cb6', 'pulp3/tmp/files/95/597048-d7e4-4268-9d6d-96a4d22d365d']
(Pdb) dest = os.path.join(settings.AZURE_LOCATION, base_path)
(Pdb) default_storage.exists(dest)
True
(Pdb) dest
'pulp3/artifact/36/0548ba80e3dce478b7915ca89a5613dc80c650a55b96f5491012a8297e12ac'                                         
```