### PR TITLE
Fix occasional deadlocks when doing multiple similar syncs concurrently.

### DIFF
--- a/CHANGES/8750.bugfix
+++ b/CHANGES/8750.bugfix
@@ -1,0 +1,1 @@
+Ordered several ContentStages paths to fix deadlocks in high-concurrency scenarios.

--- a/pulpcore/app/models/content.py
+++ b/pulpcore/app/models/content.py
@@ -79,6 +79,7 @@ class BulkCreateManager(models.Manager):
         Returns:
             List of instances that were inserted into the database.
         """
+
         objs = list(objs)
         try:
             with transaction.atomic():
@@ -576,6 +577,35 @@ class ContentArtifact(BaseModel, QueryMixin):
 
     class Meta:
         unique_together = ("content", "relative_path")
+
+    @staticmethod
+    def sort_key(ca):
+        """
+        Static method for defining a sort-key for a specified ContentArtifact.
+
+        Sorting lists of ContentArtifacts is critical for avoiding deadlocks in high-concurrency
+        environments, when multiple workers may be operating on similar sets of content at the
+        same time. Providing a stable sort-order becomes problematic when the CAs in question
+        haven't been persisted - in that case, pulp_id can't be relied on, as it will change
+        when the object is stored in the DB and its "real" key is generated.
+
+        This method produces a key based on the content/artifact represented by the CA.
+
+        Args:
+            ca (:class:`~pulpcore.plugin.models.ContentArtifact`): The CA we need a key for
+
+        Returns:
+            a tuple of (str(content-key), str(artifact-key)) that can be reliably sorted on
+        """
+        c_key = ""
+        a_key = ""
+        # It's possible to only have one of content/artifact - handle that
+        if ca.content:
+            # Some key-fields aren't str, handle that
+            c_key = "".join(map(str, ca.content.natural_key()))
+        if ca.artifact:
+            a_key = str(ca.artifact.sha256)
+        return c_key, a_key
 
 
 class RemoteArtifactQuerySet(models.QuerySet):

--- a/pulpcore/plugin/stages/artifact_stages.py
+++ b/pulpcore/plugin/stages/artifact_stages.py
@@ -391,11 +391,16 @@ class RemoteArtifactSaver(Stage):
                     key = f"{content_artifact.pk}-{d_artifact.remote.pk}"
                     ras_to_create[key] = remote_artifact
 
+        # Make sure we create/update RemoteArtifacts in a stable order, to help
+        # prevent deadlocks in high-concurrency environments. We can rely on the
+        # Artifact sha256 for our ordering.
         if ras_to_create:
-            await sync_to_async(RemoteArtifact.objects.bulk_create)(list(ras_to_create.values()))
+            ras_to_create_ordered = sorted(list(ras_to_create.values()), key=lambda x: x.sha256)
+            await sync_to_async(RemoteArtifact.objects.bulk_create)(ras_to_create_ordered)
         if ras_to_update:
+            ras_to_update_ordered = sorted(list(ras_to_update.values()), key=lambda x: x.sha256)
             await sync_to_async(RemoteArtifact.objects.bulk_update)(
-                list(ras_to_update.values()), fields=["url"]
+                ras_to_update_ordered, fields=["url"]
             )
 
     @staticmethod


### PR DESCRIPTION
Forcing deadlocks requires a lot of time and pulpcore-workers running.
There is therefore no specific CI test for this, but there is a reproducer
script that will force deadlocks to happen (and show that they're fixed) here:

https://github.com/ggainey/pulp_startup/blob/main/8750_deadlocks/file_repro.sh

fixes #8750.
[nocoverage]

Please be sure you have read our documentation on creating PRs:
https://docs.pulpproject.org/contributing/pull-request-walkthrough.html
