### PR TITLE
Replaced incorrect use of 'filename' with 'natural_keys()' in error log.

### DIFF
--- a/CHANGES/9427.bugfix
+++ b/CHANGES/9427.bugfix
@@ -1,0 +1,1 @@
+Taught a remote-artifact error path to not assume 'filename' was valid for all content.

--- a/pulpcore/plugin/stages/artifact_stages.py
+++ b/pulpcore/plugin/stages/artifact_stages.py
@@ -351,7 +351,7 @@ class RemoteArtifactSaver(Stage):
                             log.warning(
                                 msg.format(
                                     rp=d_artifact.relative_path,
-                                    c=d_content.content.filename,
+                                    c=d_content.content.natural_key(),
                                     rname=d_artifact.remote.name,
                                     ap=avail_paths,
                                 )
@@ -365,7 +365,7 @@ class RemoteArtifactSaver(Stage):
                             raise ValueError(
                                 msg.format(
                                     rp=d_artifact.relative_path,
-                                    c=d_content.content.filename,
+                                    c=d_content.content.natural_key(),
                                     rname=d_artifact.remote.name,
                                 )
                             )


### PR DESCRIPTION
fixes #9247.
[nocoverage]
