### PR TITLE
Fix autogenerated pulpcore.tasking platform docs

### DIFF
--- a/docs/contributing/platform-api/tasking.rst
+++ b/docs/contributing/platform-api/tasking.rst
@@ -4,30 +4,20 @@ pulp.tasking
 
 .. automodule:: pulpcore.tasking
 
-pulp.tasking.connection
------------------------
-
-.. automodule:: pulpcore.tasking.connection
-
 pulp.tasking.constants
 ----------------------
 
 .. automodule:: pulpcore.tasking.constants
 
-pulp.tasking.manage_workers
-------------------------------------
+pulp.tasking.pulpcore_worker
+-------------------
 
-.. automodule:: pulpcore.tasking.manage_workers
+.. automodule:: pulpcore.tasking.pulpcore_worker
 
 pulp.tasking.storage
 --------------------
 
 .. automodule:: pulpcore.tasking.storage
-
-pulp.tasking.worker_watcher
-------------------------------------
-
-.. automodule:: pulpcore.tasking.worker_watcher
 
 pulp.tasking.tasks
 ------------------
@@ -38,8 +28,3 @@ pulp.tasking.util
 -----------------
 
 .. automodule:: pulpcore.tasking.util
-
-pulp.tasking.worker
--------------------
-
-.. automodule:: pulpcore.tasking.worker


### PR DESCRIPTION
I only saw these as warnings in the CI by accident.