### PR TITLE
Teach several touch() paths to apply order to avoid deadlocks.

### DIFF
--- a/CHANGES/9441.bugfix
+++ b/CHANGES/9441.bugfix
@@ -1,0 +1,1 @@
+Taught several more codepaths to order-before-update to avoid deadlocks.

--- a/pulpcore/app/models/content.py
+++ b/pulpcore/app/models/content.py
@@ -101,8 +101,11 @@ class BulkTouchQuerySet(models.QuerySet):
     def touch(self):
         """
         Update the ``timestamp_of_interest`` on all objects of the query.
+
+        We order-by-pk here to avoid deadlocking in high-concurrency
+        environments.
         """
-        return self.update(timestamp_of_interest=now())
+        return self.order_by("pk").update(timestamp_of_interest=now())
 
 
 class QueryMixin:


### PR DESCRIPTION
fixes #9441.
[nocoverage]
Required PR: https://github.com/pulp/pulpcore/pull/1637

