### PR TITLE
[cp] Improved messaging around timeout requests.

### DIFF
--- a/CHANGES/9491.bugfix
+++ b/CHANGES/9491.bugfix
@@ -1,0 +1,2 @@
+Improved messaging around timeout requests.
+(backported from #9301)

--- a/pulpcore/download/base.py
+++ b/pulpcore/download/base.py
@@ -11,6 +11,7 @@ from pulpcore.app.models import Artifact
 from pulpcore.exceptions import (
     DigestValidationError,
     SizeValidationError,
+    TimeoutException,
     UnsupportedDigestValidationError,
 )
 
@@ -240,7 +241,10 @@ class BaseDownloader:
 
         """
         async with self.semaphore:
-            return await self._run(extra_data=extra_data)
+            try:
+                return await self._run(extra_data=extra_data)
+            except asyncio.TimeoutError:
+                raise TimeoutException(self.url)
 
     async def _run(self, extra_data=None):
         """

--- a/pulpcore/exceptions/__init__.py
+++ b/pulpcore/exceptions/__init__.py
@@ -1,7 +1,8 @@
 from .base import (  # noqa
+    AdvisoryLockError,
     PulpException,
     ResourceImmutableError,
-    AdvisoryLockError,
+    TimeoutException,
     exception_to_dict,
 )
 from .http import MissingResource  # noqa

--- a/pulpcore/exceptions/base.py
+++ b/pulpcore/exceptions/base.py
@@ -66,3 +66,22 @@ class ResourceImmutableError(PulpException):
 
 class AdvisoryLockError(Exception):
     """Exception to signal that a lock could not be acquired."""
+
+
+class TimeoutException(PulpException):
+    """
+    Exception to signal timeout error.
+    """
+
+    def __init__(self, url):
+        """
+        :param url: the url the download for timed out
+        :type url: str
+        """
+        super().__init__("PLP0005")
+        self.url = url
+
+    def __str__(self):
+        return _(
+            "Request timed out for {}. Increasing the total_timeout value on the remote might help."
+        ).format(self.url)


### PR DESCRIPTION
backports #9301

fixes #9491

(cherry picked from commit 8a1db3b9c0bd44f6ea76eeb2a2cdbcd673b199c3)

Please be sure you have read our documentation on creating PRs:
https://docs.pulpproject.org/contributing/pull-request-walkthrough.html
