### PR TITLE
Disable DJANGO_ALLOW_ASYNC_UNSAFE for the content app

### DIFF
--- a/CHANGES/9354.misc
+++ b/CHANGES/9354.misc
@@ -1,0 +1,1 @@
+Disabled DJANGO_ALLOW_ASYNC_UNSAFE for the content app.

--- a/pulpcore/content/__init__.py
+++ b/pulpcore/content/__init__.py
@@ -11,10 +11,6 @@ from aiohttp import web
 import django
 
 os.environ.setdefault("DJANGO_SETTINGS_MODULE", "pulpcore.app.settings")
-# Until Django supports async ORM natively this is the best we can do given these parts of Pulp
-# run in coroutines. We try to ensure it is safe by never passing ORM data between co-routines.
-os.environ.setdefault("DJANGO_ALLOW_ASYNC_UNSAFE", "true")
-
 django.setup()
 
 from django.conf import settings  # noqa: E402: module level not at top of file


### PR DESCRIPTION
It's just hiding issues.

closes: #9354
https://pulp.plan.io/issues/9354
