### PR TITLE
Pass the public key fingerprint to the signing service subprocess

### DIFF
--- a/CHANGES/9532.feature
+++ b/CHANGES/9532.feature
@@ -1,0 +1,2 @@
+SigningService scripts can now access the public key fingerprint using the ``PULP_SIGNING_KEY_FINGERPRINT`` environment variable.
+This allows for more generic scripts, that do not need to "guess" (hardcode) what key they should use.

--- a/docs/plugins/reference/metadata-signing.rst
+++ b/docs/plugins/reference/metadata-signing.rst
@@ -35,23 +35,19 @@ requires inheriting from ``SiginingService`` and then implementing ``validate()`
     The existing ``AsciiArmoredDetachedSigningService`` requires a signing script that creates a detached
     ascii-armored signature file, and prints valid JSON in the following format to stdout:
 
-        {"file": "filename", "signature": "filename.asc", "key": "public.key"}
+        {"file": "filename", "signature": "filename.asc"}
 
     Here "filename" is a path to the original file that was signed (passed to the signing script by the
-    ``sign()`` method), "filename.asc" is a path to the signature file created by the script, and "public.key"
-    is a path to the signature file containing the public key used by the script.
+    ``sign()`` method), and "filename.asc" is a path to the signature file created by the script.
 
-    This json is converted to a python dict and returned by the ``sign()`` method. If an error occurs, a
+    The script may read the fingerprint of the key it should use for signing, from the
+    ``PULP_SIGNING_KEY_FINGERPRINT`` environment variable.
+
+    The json is converted to a python dict and returned by the ``sign()`` method. If an error occurs, a
     runtime error is raised instead. All of this is enforced by the ``validate()`` method at the time of
     instantiation.
 
     For more information see the corresponding :ref:`workflow documentation <configuring-signing>`.
-
-.. deprecated:: 3.10
-
-    The path to the public key is no longer required to be present in the output of a signing
-    script. It is recommended to pass the value of the public key during the object creation
-    process instead.
 
 The following procedure may be taken into account for the plugin writers:
 

--- a/docs/workflows/signed-metadata.rst
+++ b/docs/workflows/signed-metadata.rst
@@ -17,7 +17,8 @@ The example below demonstrates how a signing service can be created using ``gpg`
    hardware cryptographic device.
 
 2. Create a signing script that accepts a file name as the only argument. The script
-   needs to generate an ascii-armored detached GPG signature for that file. The script
+   needs to generate an ascii-armored detached GPG signature for that file, using the key
+   specified via the ``PULP_SIGNING_KEY_FINGERPRINT`` environment variable. The script
    should then print out a JSON structure with the following format. All the file names
    are relative paths inside the current working directory::
 
@@ -39,7 +40,7 @@ The example below demonstrates how a signing service can be created using ``gpg`
        FILE_PATH=$1
        SIGNATURE_PATH="$1.asc"
 
-       ADMIN_ID="658285BA1A648083"
+       ADMIN_ID="$PULP_SIGNING_KEY_FINGERPRINT"
        PASSWORD="password"
 
        # Create a detached signature

--- a/pulpcore/app/models/content.py
+++ b/pulpcore/app/models/content.py
@@ -733,7 +733,10 @@ class SigningService(BaseModel):
             A dictionary as validated by the validate() method.
         """
         completed_process = subprocess.run(
-            [self.script, filename], env={}, stdout=subprocess.PIPE, stderr=subprocess.PIPE
+            [self.script, filename],
+            env={"PULP_SIGNING_KEY_FINGERPRINT": self.pubkey_fingerprint},
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
         )
 
         if completed_process.returncode != 0:


### PR DESCRIPTION
closes #9532
https://pulp.plan.io/issues/9532

This will allow for a signing service script that is not hard coded to a
particular key. It should be fully backwards compatibile with all
existing scripts, since they need not make use of the new parameter.
