### PR TITLE
Keep listening on pg channels in workers

### DIFF
--- a/CHANGES/9549.bugfix
+++ b/CHANGES/9549.bugfix
@@ -1,0 +1,2 @@
+Fixed a bug in pulpcore-worker, where wakeup and cancel signals could be lost due to a race
+condition.

--- a/pulpcore/tasking/pulpcore_worker.py
+++ b/pulpcore/tasking/pulpcore_worker.py
@@ -229,8 +229,6 @@ class NewPulpWorker:
         """Wait for signals on the wakeup channel while heart beating."""
 
         _logger.debug(_("Worker %s entering sleep state."), self.name)
-        # Subscribe to "pulp_worker_wakeup"
-        self.cursor.execute("LISTEN pulp_worker_wakeup")
         while not self.shutdown_requested:
             r, w, x = select.select(
                 [self.sentinel, connection.connection], [], [], self.heartbeat_period
@@ -248,7 +246,6 @@ class NewPulpWorker:
                     break
             if self.sentinel in r:
                 os.read(self.sentinel, 256)
-        self.cursor.execute("UNLISTEN pulp_worker_wakeup")
 
     def supervise_task(self, task):
         """Call and supervise the task process while heart beating.
@@ -256,7 +253,6 @@ class NewPulpWorker:
         This function must only be called while holding the lock for that task."""
 
         self.task_grace_timeout = TASK_GRACE_INTERVAL
-        self.cursor.execute("LISTEN pulp_worker_cancel")
         task.worker = self.worker
         task.save(update_fields=["worker"])
         cancel_state = None
@@ -306,17 +302,21 @@ class NewPulpWorker:
                 self.cancel_abandoned_task(task, cancel_state, cancel_reason)
         if task.reserved_resources_record:
             self.notify_workers()
-        self.cursor.execute("UNLISTEN pulp_worker_cancel")
 
     def run_forever(self):
         with WorkerDirectory(self.name):
             signal.signal(signal.SIGINT, self._signal_handler)
             signal.signal(signal.SIGTERM, self._signal_handler)
+            # Subscribe to pgsql channels
+            self.cursor.execute("LISTEN pulp_worker_wakeup")
+            self.cursor.execute("LISTEN pulp_worker_cancel")
             while not self.shutdown_requested:
                 for task in self.iter_tasks():
                     self.supervise_task(task)
                 if not self.shutdown_requested:
                     self.sleep()
+            self.cursor.execute("UNLISTEN pulp_worker_cancel")
+            self.cursor.execute("UNLISTEN pulp_worker_wakeup")
             self.shutdown()
 
 


### PR DESCRIPTION
There seems to be a time window, where workers might miss a wakeup call
and end in waiting state, while tasks are still available.

[noissue]

@dalley i decided to turn this into a pr, because it might also fix a rare ci failure where canceling a task is lost in that window.