### PR TITLE
Handled duplicates during bulk_create calls

### DIFF
--- a/CHANGES/8967.bugfix
+++ b/CHANGES/8967.bugfix
@@ -1,0 +1,2 @@
+Fixes unhandled errors during bulk_save operations due to race conditions of multiple processes
+creating the same database objects in separate processes.

--- a/pulpcore/app/models/repository.py
+++ b/pulpcore/app/models/repository.py
@@ -769,7 +769,7 @@ class RepositoryVersion(BaseModel):
                 )
             )
 
-        RepositoryContent.objects.bulk_create(repo_content)
+        RepositoryContent.objects.bulk_create(repo_content, ignore_conflicts=True)
 
     def remove_content(self, content):
         """
@@ -948,7 +948,7 @@ class RepositoryVersion(BaseModel):
                         count_type=value,
                     )
                     counts_list.append(count_obj)
-            RepositoryVersionContentDetails.objects.bulk_create(counts_list)
+            RepositoryVersionContentDetails.objects.bulk_create(counts_list, ignore_conflicts=True)
 
     def __enter__(self):
         """

--- a/pulpcore/plugin/stages/artifact_stages.py
+++ b/pulpcore/plugin/stages/artifact_stages.py
@@ -396,7 +396,9 @@ class RemoteArtifactSaver(Stage):
         # Artifact sha256 for our ordering.
         if ras_to_create:
             ras_to_create_ordered = sorted(list(ras_to_create.values()), key=lambda x: x.sha256)
-            await sync_to_async(RemoteArtifact.objects.bulk_create)(ras_to_create_ordered)
+            await sync_to_async(RemoteArtifact.objects.bulk_create)(
+                ras_to_create_ordered, ignore_conflicts=True
+            )
         if ras_to_update:
             ras_to_update_ordered = sorted(list(ras_to_update.values()), key=lambda x: x.sha256)
             await sync_to_async(RemoteArtifact.objects.bulk_update)(

--- a/pulpcore/tests/unit/models/test_repository.py
+++ b/pulpcore/tests/unit/models/test_repository.py
@@ -15,7 +15,7 @@ class RepositoryVersionTestCase(TestCase):
         for _ in range(0, 5):
             contents.append(Content(pulp_type="core.content"))
 
-        Content.objects.bulk_create(contents)
+        Content.objects.bulk_create(contents, ignore_conflicts=True)
         self.pks = [c.pk for c in contents]
 
     def test_add_and_remove_content(self):
@@ -270,7 +270,7 @@ class RepositoryTestCase(TestCase):
         for _ in range(0, 3):
             contents.append(Content(pulp_type="core.content"))
 
-        Content.objects.bulk_create(contents)
+        Content.objects.bulk_create(contents, ignore_conflicts=True)
 
         versions = [self.repository.latest_version()]
         for content in contents:


### PR DESCRIPTION
Multiple processes inserting the same objects into the DB can cause
unexpected duplicates. Now that we're using Django 3+ we can use the
`ignore_conflicts=True` param for bulk_create.

closes #8967
