### PR TITLE
Adds additional lock cleanup to worker cleanup

### DIFF
--- a/CHANGES/9547.bugfix
+++ b/CHANGES/9547.bugfix
@@ -1,0 +1,3 @@
+Prevented a Redis failure scenario from causing the tasking system to back up due to "tasking system
+locks" not being released, even on worker restart.
+(backported from #7907)


### PR DESCRIPTION
As another layer of security to guard against lock cleanup not occurring
due to Redis not delivering the _release_resource task, ensure all locks
are also cleaned up even for tasks that are in their final states.

backports #7907

fixes #9547

(cherry picked from commit 516df3147b56660fbc9b22c215e309da1ff8080e)

