### PR TITLE
backports Artifact redownloading bug

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -481,7 +481,8 @@ Features
   .. warning::
 
      If you intend to stick with the old tasking system, you should configure the
-     ``USE_NEW_WORKER_TYPE`` setting to false before upgrading.
+     ``USE_NEW_WORKER_TYPE`` setting to false before upgrade
+
   `#8948 <https://pulp.plan.io/issues/8948>`_
 
 
@@ -888,15 +889,15 @@ Features
   `#8357 <https://pulp.plan.io/issues/8357>`_
 - Added the following new objects related to a new ``Distribution`` MasterModel:
   * ``pulpcore.plugin.models.Distribution`` - A new MasterModel ``Distribution`` which replaces the
-    ``pulpcore.plugin.models.BaseDistribution``. This now contains the ``repository``,
-    ``repository_version``, and ``publication`` fields on the MasterModel instead of on the detail
-    models as was done with ``pulpcore.plugin.models.BaseDistribution``.
+  ``pulpcore.plugin.models.BaseDistribution``. This now contains the ``repository``,
+  ``repository_version``, and ``publication`` fields on the MasterModel instead of on the detail
+  models as was done with ``pulpcore.plugin.models.BaseDistribution``.
   * ``pulpcore.plugin.serializer.DistributionSerializer`` - A serializer plugin writers should use
-    with the new ``pulpcore.plugin.models.Distribution``.
+  with the new ``pulpcore.plugin.models.Distribution``.
   * ``pulpcore.plugin.viewset.DistributionViewSet`` - The viewset that replaces the deprecated
-    ``pulpcore.plugin.viewset.BaseDistributionViewSet``.
+  ``pulpcore.plugin.viewset.BaseDistributionViewSet``.
   * ``pulpcore.plugin.viewset.NewDistributionFilter`` - The filter that pairs with the
-    ``Distribution`` model.
+  ``Distribution`` model.
   `#8384 <https://pulp.plan.io/issues/8384>`_
 - Added checksum type enforcement to ``pulpcore.plugin.download.BaseDownloader``.
   `#8435 <https://pulp.plan.io/issues/8435>`_
@@ -929,25 +930,26 @@ Deprecations
 
 - The following objects were deprecated:
   * ``pulpcore.plugin.models.BaseDistribution`` -- Instead use
-    ``pulpcore.plugin.models.Distribution``.
+  ``pulpcore.plugin.models.Distribution``.
   * ``pulpcore.plugin.viewset.BaseDistributionViewSet`` -- Instead use
-    ``pulpcore.plugin.viewset.DistributionViewSet``.
+  ``pulpcore.plugin.viewset.DistributionViewSet``.
   * ``pulpcore.plugin.serializer.BaseDistributionSerializer`` -- Instead use
-    ``pulpcore.plugin.serializer.DistributionSerializer``.
+  ``pulpcore.plugin.serializer.DistributionSerializer``.
   * ``pulpcore.plugin.serializer.PublicationDistributionSerializer`` -- Instead use define the
-    ``publication`` field directly on your detail distribution object. See the docstring for
-    ``pulpcore.plugin.serializer.DistributionSerializer`` for an example.
+  ``publication`` field directly on your detail distribution object. See the docstring for
+  ``pulpcore.plugin.serializer.DistributionSerializer`` for an example.
   * ``pulpcore.plugin.serializer.RepositoryVersionDistributionSerializer`` -- Instead use define the
-    ``repository_version`` field directly on your detail distribution object. See the docstring for
-    ``pulpcore.plugin.serializer.DistributionSerializer`` for an example.
+  ``repository_version`` field directly on your detail distribution object. See the docstring for
+  ``pulpcore.plugin.serializer.DistributionSerializer`` for an example.
   * ``pulpcore.plugin.viewset.DistributionFilter`` -- Instead use
-    ``pulpcore.plugin.viewset.NewDistributionFilter``.
+  ``pulpcore.plugin.viewset.NewDistributionFilter``.
 
   .. note::
 
       You will have to define a migration to move your data from
       ``pulpcore.plugin.models.BaseDistribution`` to ``pulpcore.plugin.models.Distribution``. See the
       pulp_file migration 0009 as a reference example.
+
   `#8385 <https://pulp.plan.io/issues/8385>`_
 - Deprecated the ``pulpcore.plugin.tasking.enqueue_with_reservation``. Instead use the
   ``pulpcore.plugin.tasking.dispatch`` interface.
@@ -958,7 +960,9 @@ Deprecations
   `#8505 <https://pulp.plan.io/issues/8505>`_
 
 
-3.11.2 (2021-05-25)REST API
+3.11.2 (2021-05-25)
+===================
+REST API
 --------
 
 Bugfixes
@@ -989,7 +993,7 @@ REST API
 --------
 
 Bugfixes
-~~~~~~~
+~~~~~~~~
 
 - Fixed a race condition that sometimes surfaced during handling of reserved resources.
   `#8632 <https://pulp.plan.io/issues/8632>`_
@@ -1001,7 +1005,7 @@ Plugin API
 ----------
 
 Bugfixes
-~~~~~~~
+~~~~~~~~
 
 - Allow plugins to unset the ``queryset_filtering_required_permission`` attribute in ``NamedModelViewSet``.
   `#8444 <https://pulp.plan.io/issues/8444>`_
@@ -1424,6 +1428,7 @@ Deprecations
       access_policy = AccessPolicy.get(viewset_name="MyViewSet")
       access_policy.viewset_name = "objectclass/myplugin/myclass"
       access_policy.save()
+
   `#7845 <https://pulp.plan.io/issues/7845>`_
 - The ``pulpcore.plugin.models.UnsupportedDigestValidationError`` is being deprecated and
   will be removed in 3.10.

--- a/CHANGES/9584.bugfix
+++ b/CHANGES/9584.bugfix
@@ -1,0 +1,2 @@
+Fixed bug where Artifacts were being downloaded even if they were already saved in Pulp.
+(backported from #9542)

--- a/docs/configuration/settings.rst
+++ b/docs/configuration/settings.rst
@@ -192,7 +192,7 @@ CONTENT_APP_TTL
 .. _pulp-cache:
 
 CACHE_ENABLED
-^^^^^^^^^^^^^^^^^^
+^^^^^^^^^^^^^
 
    .. note:: This feature is provided as a tech-preview
 
@@ -205,7 +205,7 @@ CACHE_ENABLED
      responses to be stored inside the cache.
 
 CACHE_SETTINGS
-^^^^^^^^^^^^^
+^^^^^^^^^^^^^^
 
    Dictionary with tunable settings for the cache:
 

--- a/docs/contributing/platform-api/app/index.rst
+++ b/docs/contributing/platform-api/app/index.rst
@@ -5,7 +5,6 @@ pulp.app
 
     apps
     auth
-    fields
     models
     response
     serializers

--- a/docs/contributing/platform-api/tasking.rst
+++ b/docs/contributing/platform-api/tasking.rst
@@ -15,7 +15,7 @@ pulp.tasking.constants
 .. automodule:: pulpcore.tasking.constants
 
 pulp.tasking.manage_workers
-------------------------------------
+---------------------------
 
 .. automodule:: pulpcore.tasking.manage_workers
 

--- a/docs/installation/index.rst
+++ b/docs/installation/index.rst
@@ -9,7 +9,6 @@ Installation Options
    hardware-requirements
    instructions
    storage
-   authentication
 
 Other links
    :ref:`DevSetup`

--- a/pulpcore/plugin/sync.py
+++ b/pulpcore/plugin/sync.py
@@ -1,6 +1,8 @@
 from asgiref.sync import sync_to_async
 
 
+# This is useful for querysets which don't have async support yet. Django querysets issue a db call
+# when the iterator for them is requested, so we need that to be wrapped in `sync_to_async` also.
 iter_async = sync_to_async(iter)
 
 
@@ -12,21 +14,24 @@ def next_async(it):
         raise StopAsyncIteration
 
 
-async def sync_to_async_iterable(sync_iterable):
+def sync_to_async_iterable(sync_iterable):
     """
-    Utility method which runs each iteration of a synchronous iterable in a threadpool. It also
-    sets a threadlocal inside the thread so calls to AsyncToSync can escape it. The implementation
-    relies on `asgiref.sync.sync_to_async`.  thread_sensitive parameter for sync_to_async defaults
-    to True. This code will run in the same thread as any outer code. This is needed for
-    underlying Python code that is not threadsafe (for example, code which handles database
-    connections).
+    Creates an async iterable.
+
+    The returned iterator is able to be reused and iterated through multiple times.
 
     Args:
-        sync_iterable (iter): A synchronous iterable such as a QuerySet.
+        sync_iterable: An iterable to be asynchronously iterated through.
     """
-    sync_iterator = await iter_async(sync_iterable)
-    while True:
-        try:
-            yield await next_async(sync_iterator)
-        except StopAsyncIteration:
-            return
+
+    class _Wrapper:
+        def __aiter__(self):
+            self.sync_iterator = None
+            return self
+
+        async def __anext__(self):
+            if self.sync_iterator is None:
+                self.sync_iterator = await iter_async(sync_iterable)
+            return await next_async(self.sync_iterator)
+
+    return _Wrapper()

--- a/pulpcore/tests/unit/models/test_content.py
+++ b/pulpcore/tests/unit/models/test_content.py
@@ -6,7 +6,7 @@ from django.core.files.storage import default_storage as storage
 from django.core.files.uploadedfile import SimpleUploadedFile
 
 from django.conf import settings
-from django.test import SimpleTestCase, TestCase
+from django.test import TestCase
 from pulpcore.plugin.exceptions import (
     UnsupportedDigestValidationError,
     MissingDigestValidationError,
@@ -82,7 +82,7 @@ class PulpTemporaryFileTestCase(TestCase):
         assert b"temp file test" in temp_file.file.read()
 
 
-class ArtifactAlgorithmTestCase(SimpleTestCase):
+class ArtifactAlgorithmTestCase(TestCase):
     @mock.patch(
         "pulpcore.app.models.Artifact.FORBIDDEN_DIGESTS",
         new_callable=mock.PropertyMock,


### PR DESCRIPTION
The `sync_to_async_iterable` wraps the Artifact queryset, but unlike
querysets, it can't be reused. This causes subsequent iterations
through it to not actually iterate.

backports #9542

fixes #9584

(cherry picked from commit a9431560785c5b16c27708928a3dd10763401899)

