### PR TITLE
Move user_agent into DownloaderFactory to expose it in plugin API.

### DIFF
--- a/CHANGES/plugin_api/9591.feature
+++ b/CHANGES/plugin_api/9591.feature
@@ -1,0 +1,1 @@
+`DownloaderFactory.user_agent()` method is now available if plugin needs to generate User-Agent header value to use in their custom (subclasssed) downloader factory.

--- a/pulpcore/download/factory.py
+++ b/pulpcore/download/factory.py
@@ -24,17 +24,6 @@ PROTOCOL_MAP = {
 }
 
 
-def user_agent():
-    """
-    Produce a User-Agent string to identify Pulp and relevant system info.
-    """
-    pulp_version = get_distribution("pulpcore").version
-    python = "{} {}.{}.{}-{}{}".format(sys.implementation.name, *sys.version_info)
-    uname = platform.uname()
-    system = f"{uname.system} {uname.machine}"
-    return f"pulpcore/{pulp_version} ({python}, {system}) (aiohttp {aiohttp_version})"
-
-
 class DownloaderFactory:
     """
     A factory for creating downloader objects that are configured from with remote settings.
@@ -90,6 +79,17 @@ class DownloaderFactory:
         self._semaphore = asyncio.Semaphore(value=download_concurrency)
         atexit.register(self._session_cleanup)
 
+    @staticmethod
+    def user_agent():
+        """
+        Produce a User-Agent string to identify Pulp and relevant system info.
+        """
+        pulp_version = get_distribution("pulpcore").version
+        python = "{} {}.{}.{}-{}{}".format(sys.implementation.name, *sys.version_info)
+        uname = platform.uname()
+        system = f"{uname.system} {uname.machine}"
+        return f"pulpcore/{pulp_version} ({python}, {system}) (aiohttp {aiohttp_version})"
+
     def _session_cleanup(self):
         asyncio.get_event_loop().run_until_complete(self._session.close())
 
@@ -125,7 +125,7 @@ class DownloaderFactory:
         if sslcontext:
             tcp_conn_opts["ssl_context"] = sslcontext
 
-        headers = MultiDict({"User-Agent": user_agent()})
+        headers = MultiDict({"User-Agent": DownloaderFactory.user_agent()})
         if self._remote.headers is not None:
             for header_dict in self._remote.headers:
                 user_agent_header = header_dict.pop("User-Agent", None)

--- a/pulpcore/tests/unit/download/test_factory.py
+++ b/pulpcore/tests/unit/download/test_factory.py
@@ -1,6 +1,6 @@
 from django.test import TestCase
 
-from pulpcore.download.factory import DownloaderFactory, user_agent
+from pulpcore.download.factory import DownloaderFactory
 from pulpcore.plugin.models import Remote
 
 
@@ -9,7 +9,7 @@ class DownloaderFactoryHeadersTestCase(TestCase):
         remote = Remote.objects.create(url="http://example.org/", name="foo")
         factory = DownloaderFactory(remote)
         downloader = factory.build(remote.url)
-        default_user_agent = user_agent()
+        default_user_agent = DownloaderFactory.user_agent()
         self.assertEqual(downloader.session.headers["User-Agent"], default_user_agent)
         remote.delete()
 
@@ -19,7 +19,7 @@ class DownloaderFactoryHeadersTestCase(TestCase):
         )
         factory = DownloaderFactory(remote)
         downloader = factory.build(remote.url)
-        default_user_agent = user_agent()
+        default_user_agent = DownloaderFactory.user_agent()
         expected_user_agent = f"{default_user_agent}, foo"
         self.assertEqual(downloader.session.headers["User-Agent"], expected_user_agent)
         remote.delete()


### PR DESCRIPTION
closes #9591
https://pulp.plan.io/issues/9591

