### PR TITLE
Redis not used by default

### DIFF
--- a/CHANGES/2057.feature
+++ b/CHANGES/2057.feature
@@ -1,0 +1,1 @@
+Allowed Pulp to install without Redis.

--- a/docs/configuration/settings.rst
+++ b/docs/configuration/settings.rst
@@ -105,6 +105,10 @@ AUTHENTICATION_BACKENDS
 Redis Settings
 --------------
 
+.. warning::
+
+   To enable usage of Redis the `CACHE_ENABLED`_ option must be set to `True`.
+
 The following Redis settings can be set in your Pulp config:
 
   * REDIS_URL
@@ -118,12 +122,12 @@ Below are some common settings used for Redis configuration.
 REDIS_HOST
 ^^^^^^^^^^
 
-   The hostname for Redis. By default Pulp will try to connect to Redis on localhost.
+   The hostname for Redis.
 
 REDIS_PORT
 ^^^^^^^^^^
 
-   The port for Redis. By default Pulp will try to connect to Redis on port 6379.
+   The port for Redis.
 
 REDIS_PASSWORD
 ^^^^^^^^^^^^^^
@@ -205,7 +209,7 @@ CACHE_ENABLED
    .. note:: This feature is provided as a tech-preview
 
    Store cached responses from the content app into Redis. This setting improves the performance
-   of the content app under heavy load for similar requests. Defaults to ``True``.
+   of the content app under heavy load for similar requests. Defaults to ``False``.
 
    .. note::
      The entire response is not stored in the cache. Only the location of the file needed to

--- a/docs/installation/instructions.rst
+++ b/docs/installation/instructions.rst
@@ -158,6 +158,11 @@ Redis
 Pulp can use Redis to cache requests to the content app. This can be installed on a different host
 or the same host that Pulp is running on.
 
+.. note::
+
+    Despite its huge performance improvement, Pulp doesn't use Redis by default
+    and must be configured manually.
+
 To install Redis, refer to your package manager or the
 `Redis download docs <https://redis.io/download>`_.
 

--- a/pulpcore/app/redis_connection.py
+++ b/pulpcore/app/redis_connection.py
@@ -8,6 +8,8 @@ _a_conn = None
 
 
 def _get_connection_from_class(redis_class):
+    if not settings.get("CACHE_ENABLED"):
+        return None
     redis_url = settings.get("REDIS_URL")
     if redis_url is not None:
         return redis_class.from_url(redis_url)

--- a/pulpcore/app/settings.py
+++ b/pulpcore/app/settings.py
@@ -200,8 +200,8 @@ DATABASES = {
 
 # Redis default config
 REDIS_URL = None
-REDIS_HOST = "localhost"
-REDIS_PORT = 6379
+REDIS_HOST = None
+REDIS_PORT = None
 REDIS_DB = 0
 REDIS_PASSWORD = None
 REDIS_SSL = False
@@ -257,7 +257,7 @@ ALLOWED_EXPORT_PATHS = []
 PROFILE_STAGES_API = False
 
 # https://docs.pulpproject.org/pulpcore/configuration/settings.html#pulp-cache
-CACHE_ENABLED = True
+CACHE_ENABLED = False
 CACHE_SETTINGS = {
     "EXPIRES_TTL": 600,  # 10 minutes
 }
@@ -310,6 +310,19 @@ settings = dynaconf.DjangoDynaconf(
 # HERE ENDS DYNACONF EXTENSION LOAD (No more code below this line)
 
 _logger = getLogger(__name__)
+
+# Post-dyna-conf check if user provided a redis connection when enabling cache
+try:
+    if CACHE_ENABLED:
+        REDIS_URL or (REDIS_HOST and REDIS_PORT)
+except NameError:
+    raise ImproperlyConfigured(
+        _(
+            "CACHE_ENABLED is enabled but it requires to have REDIS configured. Please check "
+            "https://docs.pulpproject.org/pulpcore/configuration/settings.html#redis-settings "
+            "for more information."
+        )
+    )
 
 try:
     CONTENT_ORIGIN

--- a/pulpcore/app/views/status.py
+++ b/pulpcore/app/views/status.py
@@ -60,7 +60,7 @@ class StatusView(APIView):
         if settings.CACHE_ENABLED:
             redis_status = {"connected": self._get_redis_conn_status()}
         else:
-            redis_status = None
+            redis_status = {"connected": False}
 
         db_status = {"connected": self._get_db_conn_status()}
 

--- a/pulpcore/tests/functional/api/utils.py
+++ b/pulpcore/tests/functional/api/utils.py
@@ -37,7 +37,6 @@ def get_redis_status():
 
     try:
         is_redis_connected = status_response["redis_connection"]["connected"]
-    except KeyError:
+    except (KeyError, TypeError):
         is_redis_connected = False
-
     return is_redis_connected

--- a/pulpcore/tests/unit/test_cache.py
+++ b/pulpcore/tests/unit/test_cache.py
@@ -7,7 +7,7 @@ from pulpcore.cache import Cache, ConnectionError
 
 try:
     is_redis_connected = Cache().redis.ping()
-except ConnectionError:
+except (ConnectionError, AttributeError):
     is_redis_connected = False
 
 


### PR DESCRIPTION
Pulp does not use redis if not configured by user.

closes: https://pulp.plan.io/issues/9475

Please be sure you have read our documentation on creating PRs:
https://docs.pulpproject.org/contributing/pull-request-walkthrough.html
