### PR TITLE
Removes the --resource-manager option

### DIFF
--- a/CHANGES/9327.removal
+++ b/CHANGES/9327.removal
@@ -1,0 +1,2 @@
+The ``pulpcore-worker`` binary no longer accepts the ``--resource-manager`` flag. There is no
+resource manager anymore, so this flag is no longer needed.

--- a/docs/installation/instructions.rst
+++ b/docs/installation/instructions.rst
@@ -92,9 +92,9 @@ PyPI Installation
 .. note::
 
     In place of using the systemd unit files provided in the `systemd-setup` section, you can run
-    the commands yourself inside of a shell. This is fine for development but not recommended in production::
+    the commands yourself inside of a shell. This is fine for development but not recommended for
+    production::
 
-    $ /path/to/python/bin/pulpcore-worker --resource-manager
     $ /path/to/python/bin/pulpcore-worker
 
 10. Collect Static Media for live docs and browsable API::

--- a/pulpcore/tasking/entrypoint.py
+++ b/pulpcore/tasking/entrypoint.py
@@ -1,11 +1,8 @@
 import click
 import logging
 import os
-import select
 
 import django
-
-from pulpcore.app.loggers import deprecation_logger
 
 os.environ.setdefault("DJANGO_SETTINGS_MODULE", "pulpcore.app.settings")
 
@@ -17,27 +14,15 @@ from pulpcore.tasking.pulpcore_worker import NewPulpWorker  # noqa: E402: module
 _logger = logging.getLogger(__name__)
 
 
-@click.option(
-    "--resource-manager",
-    is_flag=True,
-    help="Whether this worker should be started as a resource-manager",
-)
 @click.option("--pid", help="Write the process ID number to a file at the specified path")
 @click.command()
-def worker(resource_manager, pid):
+def worker(pid):
     """A Pulp worker."""
 
     if pid:
         with open(os.path.expanduser(pid), "w") as fp:
             fp.write(str(os.getpid()))
 
-    if resource_manager:
-        _logger.warn("Attempting to start a resource-manager with the distributed tasking system")
-        deprecation_logger.warn(
-            "The `--resource-manager` option of the pulpcore-worker entrypoint is deprecated and"
-            " will be removed in pulpcore 3.17."
-        )
-        select.select([], [], [])
     _logger.info("Starting distributed type worker")
 
     NewPulpWorker().run_forever()


### PR DESCRIPTION
The `pulpcore-worker` entrypoint no longer accepts the
`--resource-manager` option.

closes #9327
