### PR TITLE
Adds viewset name to accesspolicy deprecations

### DIFF
--- a/CHANGES/plugin_api/9608.bugfix
+++ b/CHANGES/plugin_api/9608.bugfix
@@ -1,0 +1,1 @@
+Include additional information about which AccessPolicy is using deprecated policy features.

--- a/pulpcore/app/apps.py
+++ b/pulpcore/app/apps.py
@@ -197,19 +197,21 @@ class PulpAppConfig(PulpPluginAppConfig):
         post_migrate.connect(_delete_anon_user, sender=self, dispatch_uid="delete_anon_identifier")
 
 
-def _rename_permissions_assignment_workaround(access_policy):
+def _rename_permissions_assignment_workaround(access_policy, viewset):
     from pulpcore.app.loggers import deprecation_logger
 
     if "permissions_assignment" in access_policy:
         deprecation_logger.warn(
-            "The field 'permissions_assignment' has been renamed to 'creation_hooks'. This "
+            f"In AccessPolicy for {viewset}, "
+            "the field 'permissions_assignment' has been renamed to 'creation_hooks'. This "
             "workaround may be removed with pulpcore 3.20."
         )
         access_policy["creation_hooks"] = access_policy.pop("permissions_assignment")
     if "creation_hooks" in access_policy:
         if any(hook.get("permissions") is not None for hook in access_policy["creation_hooks"]):
             deprecation_logger.warn(
-                "The 'permissions' field in 'creation_hooks' is deprecated and may be removed "
+                f"In AccessPolicy for {viewset}, "
+                "the 'permissions' field in 'creation_hooks' is deprecated and may be removed "
                 "with pulpcore 3.20. Use the 'parameters' field instead."
             )
 
@@ -228,8 +230,8 @@ def _populate_access_policies(sender, apps, verbosity, **kwargs):
         for viewset in viewset_batch:
             access_policy = getattr(viewset, "DEFAULT_ACCESS_POLICY", None)
             if access_policy is not None:
-                _rename_permissions_assignment_workaround(access_policy)
                 viewset_name = get_view_urlpattern(viewset)
+                _rename_permissions_assignment_workaround(access_policy, viewset)
                 db_access_policy, created = AccessPolicy.objects.get_or_create(
                     viewset_name=viewset_name, defaults=access_policy
                 )


### PR DESCRIPTION
The deprecation warning about an offending AccessPolicy now includes the
name of the Viewset that has the problem.

closes #9608

