### PR TITLE
Fix return value of get_all_permissions

### DIFF
--- a/pulpcore/app/viewsets/base.py
+++ b/pulpcore/app/viewsets/base.py
@@ -609,7 +609,11 @@ class RolesMixin:
     @action(detail=True, methods=["get"])
     def my_permissions(self, request, pk=None):
         obj = self.get_object()
-        return Response({"permissions": list(request.user.get_all_permissions(obj))})
+        app_label = obj._meta.app_label
+        permissions = [
+            ".".join((app_label, codename)) for codename in request.user.get_all_permissions(obj)
+        ]
+        return Response({"permissions": permissions})
 
 
 class BaseFilterSet(filterset.FilterSet):

--- a/pulpcore/backends.py
+++ b/pulpcore/backends.py
@@ -62,6 +62,17 @@ class ObjectRolePermissionBackend(BaseBackend):
                 .values("role__permissions__content_type__app_label", "role__permissions__codename")
                 .distinct()
             )
+            return [
+                item["role__permissions__content_type__app_label"]
+                + "."
+                + item["role__permissions__codename"]
+                for item in result
+            ] + [
+                item["role__permissions__content_type__app_label"]
+                + "."
+                + item["role__permissions__codename"]
+                for item in group_result
+            ]
 
         else:
             obj_type = ContentType.objects.get_for_model(obj, for_concrete_model=False)
@@ -72,7 +83,7 @@ class ObjectRolePermissionBackend(BaseBackend):
                     content_type=obj_type,
                     object_id=obj.pk,
                 )
-                .values("role__permissions__content_type__app_label", "role__permissions__codename")
+                .values("role__permissions__codename")
                 .distinct()
             )
             group_result = (
@@ -83,15 +94,9 @@ class ObjectRolePermissionBackend(BaseBackend):
                     content_type=obj_type,
                     object_id=obj.pk,
                 )
-                .values("role__permissions__content_type__app_label", "role__permissions__codename")
+                .values("role__permissions__codename")
                 .distinct()
             )
-        return [
-            f"{item['role__permissions__content_type__app_label']}."
-            f"{item['role__permissions__codename']}"
-            for item in result
-        ] + [
-            f"{item['role__permissions__content_type__app_label']}."
-            f"{item['role__permissions__codename']}"
-            for item in group_result
+        return [item["role__permissions__codename"] for item in result] + [
+            item["role__permissions__codename"] for item in group_result
         ]

--- a/pulpcore/tests/unit/roles/test_roles.py
+++ b/pulpcore/tests/unit/roles/test_roles.py
@@ -44,7 +44,7 @@ class UserRoleTestCase(TestCase):
         self.assertFalse(self.user.has_perm("core.view_repository"))
         self.assertTrue(self.user.has_perm("core.view_repository", self.repository))
         self.assertEqual(self.user.get_all_permissions(), set())
-        self.assertEqual(self.user.get_all_permissions(self.repository), {"core.view_repository"})
+        self.assertEqual(self.user.get_all_permissions(self.repository), {"view_repository"})
         remove_role("role1", self.user, self.repository)
 
     def test_user_role(self):
@@ -60,7 +60,7 @@ class UserRoleTestCase(TestCase):
         self.assertFalse(self.user.has_perm("core.view_remote"))
         self.assertTrue(self.user.has_perm("core.view_remote", self.remote))
         self.assertEqual(self.user.get_all_permissions(), set())
-        self.assertEqual(self.user.get_all_permissions(self.remote), {"core.view_remote"})
+        self.assertEqual(self.user.get_all_permissions(self.remote), {"view_remote"})
         remove_role("role2", self.group, self.remote)
 
     def test_group_role(self):
@@ -75,7 +75,7 @@ class UserRoleTestCase(TestCase):
         assign_role("role1", self.user, self.repository)
         assign_role("role2", self.group)
         self.assertEqual(self.user.get_all_permissions(), {"core.view_remote"})
-        self.assertEqual(self.user.get_all_permissions(self.repository), {"core.view_repository"})
+        self.assertEqual(self.user.get_all_permissions(self.repository), {"view_repository"})
         self.assertEqual(self.user.get_all_permissions(self.remote), set())
         self.assertEqual(
             set(


### PR DESCRIPTION
Django's interface for get_all_permissions seems to not include the
app_label in the permission strings.
We include them again in the my_permission endpoint, because that is the
way we represent them to our users everywhere.

https://docs.djangoproject.com/en/3.2/ref/contrib/auth/#django.contrib.auth.models.User.get_all_permissions

re #9411