### PR TITLE
Optional permissions_assignment and creation_hooks

### DIFF
--- a/CHANGES/9639.bugfix
+++ b/CHANGES/9639.bugfix
@@ -1,0 +1,2 @@
+Fixed an api schema bug where both ``permission_assignment`` and ``creation_hooks`` were required
+by the ``AccessPolicy`` serializer.

--- a/pulpcore/app/serializers/access_policy.py
+++ b/pulpcore/app/serializers/access_policy.py
@@ -19,11 +19,13 @@ class AccessPolicySerializer(ModelSerializer):
             "This is deprecated. Use `creation_hooks` instead."
         ),
         source="creation_hooks",
+        required=False,
     )
 
     creation_hooks = serializers.ListField(
         child=serializers.DictField(),
         help_text=_("List of callables that may associate user roles for new objects."),
+        required=False,
     )
 
     statements = serializers.ListField(

--- a/pulpcore/tests/functional/api/test_access_policy.py
+++ b/pulpcore/tests/functional/api/test_access_policy.py
@@ -52,9 +52,9 @@ class AccessPolicyTestCase(unittest.TestCase):
         self.assertTrue(task_access_policy.customized)
         self.assertEqual(task_access_policy.statements, [])
 
-        self.access_policy_api.partial_update(tasks_href, {"statements": original_statements})
+        self.access_policy_api.reset(tasks_href)
         task_access_policy = self.access_policy_api.read(tasks_href)
-        self.assertTrue(task_access_policy.customized)
+        self.assertFalse(task_access_policy.customized)
         self.assertEqual(task_access_policy.statements, original_statements)
 
     def test_creation_hooks_attr_can_be_modified(self):
@@ -72,11 +72,9 @@ class AccessPolicyTestCase(unittest.TestCase):
         self.assertTrue(groups_access_policy.customized)
         self.assertEqual(groups_access_policy.creation_hooks, [])
 
-        self.access_policy_api.partial_update(
-            groups_href, {"creation_hooks": original_creation_hooks}
-        )
+        self.access_policy_api.reset(groups_href)
         groups_access_policy = self.access_policy_api.read(groups_href)
-        self.assertTrue(groups_access_policy.customized)
+        self.assertFalse(groups_access_policy.customized)
         self.assertEqual(groups_access_policy.creation_hooks, original_creation_hooks)
 
     def test_customized_is_read_only(self):


### PR DESCRIPTION
These fields were both required by the serializer, which could never
validate.

fixes #9639