### PR TITLE
[3.16.z cp] Fix PulpImport in the presence of Django path-traversal CVE fix.

### DIFF
--- a/CHANGES/9663.bugfix
+++ b/CHANGES/9663.bugfix
@@ -1,0 +1,2 @@
+Fixed PulpImport to correctly save relative to MEDIA_ROOT.
+(backported from #9660)

--- a/doc_requirements.txt
+++ b/doc_requirements.txt
@@ -4,3 +4,4 @@ sphinx
 sphinx-rtd-theme
 sphinxcontrib-openapi
 towncrier
+mistune<2.0.0

--- a/pulpcore/app/tasks/importer.py
+++ b/pulpcore/app/tasks/importer.py
@@ -8,7 +8,6 @@ import tarfile
 from gettext import gettext as _
 from logging import getLogger
 
-from django.conf import settings
 from django.core.files.storage import default_storage
 from django.db.models import F
 
@@ -393,11 +392,10 @@ def pulp_import(importer_pk, path, toc):
                 artifact = Artifact.objects.get(pk=row.object_id)
                 base_path = os.path.join("artifact", artifact.sha256[0:2], artifact.sha256[2:])
                 src = os.path.join(temp_dir, base_path)
-                dest = os.path.join(settings.MEDIA_ROOT, base_path)
 
-                if not default_storage.exists(dest):
+                if not default_storage.exists(base_path):
                     with open(src, "rb") as f:
-                        default_storage.save(dest, f)
+                        default_storage.save(base_path, f)
 
         with open(os.path.join(temp_dir, REPO_FILE), "r") as repo_data_file:
             data = json.load(repo_data_file)


### PR DESCRIPTION
backports #9660.
[nocoverage]

fixes #9663

(cherry picked from commit ba1b9fa22ff59d63093560c3d03e26b7c0d6973c)

Please be sure you have read our documentation on creating PRs:
https://docs.pulpproject.org/contributing/pull-request-walkthrough.html
