### PR TITLE
Add logging around certain ways a task can fail

### DIFF
--- a/CHANGES/9666.bugfix
+++ b/CHANGES/9666.bugfix
@@ -1,0 +1,1 @@
+Added proper logging around certain ways a task could fail.


### PR DESCRIPTION
This adds some logging for cases, where the task executing process dies
unexpectedly (e.g. OOM) and is unable to properly set the task state and
error reason.

fixes #9666