### PR TITLE
Remove the pytest entry from pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -85,9 +85,3 @@ ignore = [
     ".ci/**",
     ".github/**",
 ]
-
-[tool.pytest.ini_options]
-markers = [
-    "parallel: marks tests as safe to run in parallel with all other parallel tests",
-    "serial: marks tests as required to run serially without any other tests also running",
-]


### PR DESCRIPTION
I introduced this, but actually I was able to move this to pulp-smash
instead so all plugins automatically receive it.

[noissue]

