### PR TITLE
replace redmine with github issues

### DIFF
--- a/docs/bugs-features.rst
+++ b/docs/bugs-features.rst
@@ -1,8 +1,8 @@
 Bugs, Feature and Backport Requests
 ===================================
 
-Bugs, feature and backport requests for :term:`pulpcore` are tracked with `Redmine
-<https://github.com/pulp/pulpcore/issues/>`_. Please see the `plugin table
+Bugs, feature and backport requests for :term:`pulpcore` are tracked with `GitHub Issues
+<https://github.com/pulp/pulpcore/issues>`_. Please see the `plugin table
 <https://pulpproject.org/content-plugins/>`_ for trackers for each plugin.
 
 .. _issue-writing:


### PR DESCRIPTION
@fao89  did this already for the plugins on pulpproject.org 
Updating here also for Pulpcore
[noissue]

Please be sure you have read our documentation on creating PRs:
https://docs.pulpproject.org/contributing/pull-request-walkthrough.html
