### PR TITLE
Fix import-uq-failure on ContentArtifact.

### DIFF
--- a/CHANGES/2102.bugfix
+++ b/CHANGES/2102.bugfix
@@ -1,0 +1,1 @@
+Taught PulpImport to retry in the event of a concurrency-collision on ContentArtifact.

--- a/pulpcore/app/tasks/importer.py
+++ b/pulpcore/app/tasks/importer.py
@@ -54,14 +54,37 @@ def _destination_repo(importer, source_repo_name):
     return Repository.objects.get(name=dest_repo_name)
 
 
-def _import_file(fpath, resource_class, do_raise=True):
+def _import_file(fpath, resource_class, retry=False):
     try:
         log.info(_("Importing file {}.").format(fpath))
         with open(fpath, "r") as json_file:
             data = Dataset().load(json_file.read(), format="json")
             resource = resource_class()
             log.info(_("...Importing resource {}.").format(resource.__class__.__name__))
-            return resource.import_data(data, raise_errors=do_raise)
+            if retry:
+                # django import-export can have a problem with concurrent-imports that are
+                # importing the same 'thing' (e.g., a Package that exists in two different
+                # repo-versions that are being imported at the same time). If we're asked to
+                # retry, we will try an import that will simply record errors as they happen
+                # (rather than failing with an exception) first. If errors happen, we'll do one
+                # retry before we give up on this repo-version's import.
+                a_result = resource.import_data(data, raise_errors=False)
+                if a_result.has_errors():
+                    log.info(
+                        _("...{} import-errors encountered importing {}, retrying").format(
+                            a_result.totals["error"], fpath
+                        )
+                    )
+                    # Second attempt, we raise an exception on any problem.
+                    # This will either succeed, or log a fatal error and fail.
+                    try:
+                        a_result = resource.import_data(data, raise_errors=True)
+                    except Exception as e:  # noqa log on ANY exception and then re-raise
+                        log.error(_("FATAL import-failure importing {}").format(fpath))
+                        raise
+            else:
+                a_result = resource.import_data(data, raise_errors=True)
+            return a_result
     except AttributeError:
         log.error(_("FAILURE importing file {}!").format(fpath))
         raise
@@ -157,36 +180,14 @@ def import_repository_version(importer_pk, destination_repo_pk, source_repo_name
         resulting_content_ids = []
         for res_class in cfg.exportable_classes:
             filename = f"{res_class.__module__}.{res_class.__name__}.json"
-            a_result = _import_file(os.path.join(rv_path, filename), res_class, do_raise=False)
-            # django import-export can have a problem with concurrent-imports that are
-            # importing the same 'thing' (e.g., a Package that exists in two different
-            # repo-versions that are being imported at the same time). We will try an import
-            # that will simply record errors as they happen (rather than failing with an exception)
-            # first. If errors happen, we'll do one retry before we give up on this repo-version's
-            # import.
-            if a_result.has_errors():
-                log.info(
-                    _("...{} import-errors encountered importing {} from {}, retrying").format(
-                        a_result.totals["error"], filename, rv_name
-                    )
-                )
-                # Second attempt, we allow to raise an exception on any problem.
-                # This will either succeed, or log a fatal error and fail.
-                try:
-                    a_result = _import_file(os.path.join(rv_path, filename), res_class)
-                except Exception as e:  # noqa log on ANY exception and then re-raise
-                    log.error(
-                        _("FATAL import-failure importing {} from {}").format(filename, rv_name)
-                    )
-                    raise
-
+            a_result = _import_file(os.path.join(rv_path, filename), res_class, retry=True)
             resulting_content_ids.extend(
                 row.object_id for row in a_result.rows if row.import_type in ("new", "update")
             )
 
         # Once all content exists, create the ContentArtifact links
         ca_path = os.path.join(rv_path, CA_FILE)
-        _import_file(ca_path, ContentArtifactResource)
+        _import_file(ca_path, ContentArtifactResource, retry=True)
 
         # see if we have a content mapping
         mapping_path = f"{rv_name}/{CONTENT_MAPPING_FILE}"


### PR DESCRIPTION
Note: there is no additional test for this, because it's a concurrency
window that is VERY hard to force. Here's a script that can occasionally
force the error:

https://github.com/ggainey/pulp_startup/blob/main/import_export/file_uq_repro.sh

fixes #2102.
[nocoverage]