### PR TITLE
Added a "current_task" field to the worker

### DIFF
--- a/CHANGES/2034.feature
+++ b/CHANGES/2034.feature
@@ -1,0 +1,1 @@
+Add a "current_task" field to workers so that you can easily see which workers are currently active.

--- a/pulpcore/app/models/task.py
+++ b/pulpcore/app/models/task.py
@@ -90,6 +90,16 @@ class Worker(BaseModel):
     last_heartbeat = models.DateTimeField(auto_now=True)
 
     @property
+    def current_task(self):
+        """
+        The task this worker is currently executing, if any.
+
+        Returns:
+            Task: The currently executing task
+        """
+        return self.tasks.filter(state="running").first()
+
+    @property
     def online(self):
         """
         Whether a worker can be considered 'online'

--- a/pulpcore/app/serializers/task.py
+++ b/pulpcore/app/serializers/task.py
@@ -192,10 +192,15 @@ class WorkerSerializer(ModelSerializer):
     last_heartbeat = serializers.DateTimeField(
         help_text=_("Timestamp of the last time the worker talked to the service."), read_only=True
     )
-    # disable "created" because we don't care about it
-    created = None
+    current_task = RelatedField(
+        help_text=_(
+            "The task this worker is currently executing, or empty if the worker is not "
+            "currently assigned to a task."
+        ),
+        read_only=True,
+        view_name="tasks-detail",
+    )
 
     class Meta:
         model = models.Worker
-        _base_fields = tuple(set(ModelSerializer.Meta.fields) - set(["created"]))
-        fields = _base_fields + ("name", "last_heartbeat")
+        fields = ModelSerializer.Meta.fields + ("name", "last_heartbeat", "current_task")

--- a/pulpcore/tests/functional/api/test_workers.py
+++ b/pulpcore/tests/functional/api/test_workers.py
@@ -10,18 +10,12 @@ from requests.exceptions import HTTPError
 from pulpcore.tests.functional.utils import set_up_module as setUpModule  # noqa:F401
 from pulpcore.tests.functional.utils import skip_if
 
-_DYNAMIC_WORKER_ATTRS = ("last_heartbeat",)
+_DYNAMIC_WORKER_ATTRS = ("last_heartbeat", "current_task")
 """Worker attributes that are dynamically set by Pulp, not set by a user."""
 
 
 class WorkersTestCase(unittest.TestCase):
-    """Test actions over workers.
-
-    This test targets the following issues:
-
-    * `Pulp #3143 <https://pulp.plan.io/issues/3143>`_
-    * `Pulp Smash #945 <https://github.com/pulp/pulp-smash/issues/945>`_
-    """
+    """Test actions over workers."""
 
     @classmethod
     def setUpClass(cls):
@@ -38,6 +32,8 @@ class WorkersTestCase(unittest.TestCase):
         workers = self.client.get(WORKER_PATH)["results"]
         for worker in workers:
             for key, val in worker.items():
+                if key in _DYNAMIC_WORKER_ATTRS:
+                    continue
                 with self.subTest(key=key):
                     self.assertIsNotNone(val)
         self.worker.update(choice(workers))


### PR DESCRIPTION
Provide the task href of the currently active task, if any, because it's useful information as an admin / support.

closes #2034
https://github.com/pulp/pulpcore/issues/2034
