### PR TITLE
Update link to Dynaconf mutiple formats

### DIFF
--- a/docs/configuration/applying.rst
+++ b/docs/configuration/applying.rst
@@ -22,8 +22,7 @@ Or in a systemd file you could::
     Environment="PULP_SETTINGS=/etc/pulp/settings.py" as the Ansible Installer does.
 
 
-Dynaconf supports `settings in multiple file formats <https://dynaconf.readthedocs.io/en/latest/
-guides/examples.html>`_
+Dynaconf supports `settings in multiple file formats <https://www.dynaconf.com/configuration/>`_
 
 This file should have permissions of:
 


### PR DESCRIPTION
The target of link to multiple file formats of Dynaconf does not exist any more (/yet).

So I updated the link with what sounds matching the best to me. Please double check as I don't know Dynaconf.