### PR TITLE
Adds the `handle_creation_hooks` interface

### DIFF
--- a/CHANGES/2116.feature
+++ b/CHANGES/2116.feature
@@ -1,0 +1,2 @@
+Specifying a different value for ``DEFAULT_PERMISSION_CLASSES`` will now automatically disable the
+permission assignment provided by the ``creation_hooks`` portion of an ``AccessPolicyFromDB``.

--- a/CHANGES/plugin_api/2116.feature
+++ b/CHANGES/plugin_api/2116.feature
@@ -1,0 +1,2 @@
+The ``AutoAddObjPermsMixin`` now calls a ``handle_creation_hooks`` interface on the configured DRF
+permission class, e.g. the default ``AccessPolicyFromDB``.


### PR DESCRIPTION
This change adds the `handle_creation_hooks` interface to the
``AccessPolicyFromDB`` method. If the AccessPolicy configured does not
have that interface, new model instances created will not have
permissions automatically added to them.

closes #2116

