### PR TITLE
Fix import and export OOM error

### DIFF
--- a/CHANGES/2072.bugfix
+++ b/CHANGES/2072.bugfix
@@ -1,0 +1,1 @@
+Fix import and export OOM error.

--- a/pulpcore/app/tasks/importer.py
+++ b/pulpcore/app/tasks/importer.py
@@ -58,7 +58,7 @@ def _import_file(fpath, resource_class, do_raise=True):
     try:
         log.info(_("Importing file {}.").format(fpath))
         with open(fpath, "r") as json_file:
-            data = Dataset().load(json_file.read(), format="json")
+            data = Dataset().load(json_file, format="json")
             resource = resource_class()
             log.info(_("...Importing resource {}.").format(resource.__class__.__name__))
             return resource.import_data(data, raise_errors=do_raise)

--- a/pulpcore/constants.py
+++ b/pulpcore/constants.py
@@ -63,3 +63,5 @@ FS_EXPORT_CHOICES = (
     (FS_EXPORT_METHODS.HARDLINK, "Export by hardlinking"),
     (FS_EXPORT_METHODS.SYMLINK, "Export by symlinking"),
 )
+
+EXPORT_BATCH_SIZE = 2000


### PR DESCRIPTION
json.dumps method consumes a lot of memory when converting data
to json string. While processing data, it seems to create
python object which is a number of times larger than the
parsing data. For example, a 5GB data is resulting more than 20GB
consumed.

This commit fixes the issue by processing the dataset in batch
and write into a temporary file.

This commit also fixes the import OOM error by parsing only the
file object to the json.load method instead of reading whole
file into the memory.

closes #9645

(cherry picked from commit da8770892af16992d5d546238bcf5b6e5a466978)

Please be sure you have read our documentation on creating PRs:
https://docs.pulpproject.org/contributing/pull-request-walkthrough.html
