### PR TITLE
Adds deprecation warning ACCESS_POLICY_VIEW_NAME

### DIFF
--- a/CHANGES/plugin_api/2209.deprecation
+++ b/CHANGES/plugin_api/2209.deprecation
@@ -1,0 +1,2 @@
+The ``ACCESS_POLICY_VIEWSET_NAME`` attribute is no longer expected to be present on models. The
+RBAC machinery no longer uses this, and if present a deprecation warning will be emitted.

--- a/docs/plugins/plugin-writer/concepts/rbac/adding_automatic_permissions.rst
+++ b/docs/plugins/plugin-writer/concepts/rbac/adding_automatic_permissions.rst
@@ -82,7 +82,6 @@ use the ``pulpcore.plugin.models.AutoAddObjPermsMixin``. See the example below a
 
 
     class MyModel(BaseModel, AutoAddObjPermsMixin):
-       ACCESS_POLICY_VIEWSET_NAME = "mymodel"
        ...
 
 See the docstring below for more information on this mixin.

--- a/pulpcore/app/models/access_policy.py
+++ b/pulpcore/app/models/access_policy.py
@@ -46,9 +46,6 @@ class AutoAddObjPermsMixin:
 
     To use this mixin, your model must support ``django-lifecycle``.
 
-    To use this mixin, you must define a class attribute named ``ACCESS_POLICY_VIEWSET_NAME``
-    containing the name of the ViewSet associated with this object.
-
     This mixin adds an ``after_create`` hook which properly interprets the ``creation_hooks``
     data and calls methods also provided by this mixin to add roles.
 
@@ -277,8 +274,6 @@ class AutoDeleteObjPermsMixin:
 
 
 class Group(LifecycleModelMixin, BaseGroup, AutoAddObjPermsMixin):
-    ACCESS_POLICY_VIEWSET_NAME = "groups"
-
     class Meta:
         proxy = True
         permissions = [

--- a/pulpcore/app/models/base.py
+++ b/pulpcore/app/models/base.py
@@ -8,6 +8,8 @@ from django.db.models import options
 from django.db.models.base import ModelBase
 from django_lifecycle import LifecycleModel
 
+from pulpcore.app.loggers import deprecation_logger
+
 
 class Label(LifecycleModel):
     """Model for handling resource labels.
@@ -66,6 +68,14 @@ class BaseModel(LifecycleModel):
 
     class Meta:
         abstract = True
+
+    def __init__(self, *args, **kwargs):
+        if hasattr(self, "ACCESS_POLICY_VIEWSET_NAME"):
+            deprecation_logger.warn(
+                f"The model {self.__class__} defines the 'ACCESS_POLICY_VIEWSET_NAME' class "
+                f"attribute which is no longer required and is discouraged to be set."
+            )
+        return super().__init__(*args, **kwargs)
 
     def __str__(self):
         try:

--- a/pulpcore/app/models/publication.py
+++ b/pulpcore/app/models/publication.py
@@ -345,7 +345,6 @@ class RBACContentGuard(ContentGuard, AutoAddObjPermsMixin):
     A content guard that protects content based on RBAC permissions.
     """
 
-    ACCESS_POLICY_VIEWSET_NAME = "contentguards/core/rbac"
     TYPE = "rbac"
 
     def permit(self, request):

--- a/pulpcore/app/models/task.py
+++ b/pulpcore/app/models/task.py
@@ -196,8 +196,6 @@ class Task(BaseModel, AutoDeleteObjPermsMixin, AutoAddObjPermsMixin):
     )
     reserved_resources_record = ArrayField(models.CharField(max_length=256), null=True)
 
-    ACCESS_POLICY_VIEWSET_NAME = "tasks"
-
     def __str__(self):
         return "Task: {name} [{state}]".format(name=self.name, state=self.state)
 


### PR DESCRIPTION
The `ACCESS_POLICY_VIEW_NAME` attribute on models is no longer in use by
the RBAC machinery and is discouraged from being defined. If present on
a model a deprecation warning is logged.

closes #2209

