### PR TITLE
Deprecate the API_ROOT constant

### DIFF
--- a/CHANGES/plugin_api/2148.deprecation
+++ b/CHANGES/plugin_api/2148.deprecation
@@ -1,0 +1,2 @@
+The ``API_ROOT`` constant has been deprecated and turned into a setting. Its removal is scheduled
+for 3.20. Please use the setting with the same name instead.

--- a/pulpcore/app/settings.py
+++ b/pulpcore/app/settings.py
@@ -447,4 +447,3 @@ settings.set("V3_API_ROOT", settings.API_ROOT + "api/v3/")  # Not user configura
 settings.set(
     "V3_API_ROOT_NO_FRONT_SLASH", settings.V3_API_ROOT.lstrip("/")
 )  # Not user configurable
-settings.unset("API_ROOT")

--- a/pulpcore/plugin/constants.py
+++ b/pulpcore/plugin/constants.py
@@ -1,9 +1,20 @@
 from pulpcore.constants import (  # noqa
     ALL_KNOWN_CONTENT_CHECKSUMS,
-    API_ROOT,
     SYNC_MODES,
     SYNC_CHOICES,
     TASK_STATES,
     TASK_CHOICES,
     TASK_FINAL_STATES,
 )
+
+
+@property
+def API_ROOT():
+    from django.conf import settings
+    from pulpcore.app.loggers import deprecation_logger
+
+    deprecation_logger.warn(
+        "The API_ROOT constant has been deprecated and turned into a setting. Please use "
+        "`settings.API_ROOT` instead. This symbol will be deleted with pulpcore 3.20."
+    )
+    return settings.API_ROOT


### PR DESCRIPTION
It was turned into a setting.

re #2148
[noissue]