### PR TITLE
Use V3_API_ROOT_NO_FRONT_SLASH on deprecation

### DIFF
--- a/pulpcore/app/settings.py
+++ b/pulpcore/app/settings.py
@@ -447,3 +447,4 @@ settings.set("V3_API_ROOT", settings.API_ROOT + "api/v3/")  # Not user configura
 settings.set(
     "V3_API_ROOT_NO_FRONT_SLASH", settings.V3_API_ROOT.lstrip("/")
 )  # Not user configurable
+settings.unset("API_ROOT")

--- a/pulpcore/plugin/constants.py
+++ b/pulpcore/plugin/constants.py
@@ -15,6 +15,7 @@ def API_ROOT():
 
     deprecation_logger.warn(
         "The API_ROOT constant has been deprecated and turned into a setting. Please use "
-        "`settings.API_ROOT` instead. This symbol will be deleted with pulpcore 3.20."
+        "`settings.V3_API_ROOT_NO_FRONT_SLASH` instead. This symbol will be deleted with pulpcore "
+        "3.20."
     )
-    return settings.API_ROOT
+    return settings.V3_API_ROOT_NO_FRONT_SLASH


### PR DESCRIPTION
re #2148

What used to be API_ROOT is V3_API_ROOT_NO_FRONT_SLASH now
https://github.com/pulp/pulpcore/blob/3.17/pulpcore/constants.py#L47

Noticed it when fixing pulp_file tests:
https://github.com/pulp/pulp_file/pull/643