### PR TITLE
Taught import-task to extract into current-working-dir.

### DIFF
--- a/CHANGES/2247.bugfix
+++ b/CHANGES/2247.bugfix
@@ -1,0 +1,4 @@
+PulpImporter now unpacks into the task-worker's working directory rather than /tmp. Unpacking
+large files into /tmp could cause the operation to fail, or even cause stability issues for
+Pulp instance, due to running /tmp out of space.
+

--- a/pulpcore/app/tasks/importer.py
+++ b/pulpcore/app/tasks/importer.py
@@ -378,7 +378,7 @@ def pulp_import(importer_pk, path, toc):
     current_task.refresh_from_db()
     CreatedResource.objects.create(content_object=task_group)
 
-    with tempfile.TemporaryDirectory() as temp_dir:
+    with tempfile.TemporaryDirectory(dir=".") as temp_dir:
         with tarfile.open(path, "r:gz") as tar:
             tar.extractall(path=temp_dir)
 


### PR DESCRIPTION
fixes #2247
[nocoverage]

(cherry picked from commit 2f565c936d03f26c61c4b992c5e98a2b835d7cc7)
