### PR TITLE
Fix delete repository version causing "duplicate key" error

### DIFF
--- a/CHANGES/2047.bugfix
+++ b/CHANGES/2047.bugfix
@@ -1,0 +1,1 @@
+Fix delete repository version causing "duplicate key value violates unique constraint" error.

--- a/CHANGES/2267.bugfix
+++ b/CHANGES/2267.bugfix
@@ -1,0 +1,1 @@
+This fix prevents the lost track of a content removed version when deleting a repository version that deletes a content that is added back in the subsequent version, but deleted again in a later version.

--- a/pulpcore/tests/conftest_pulp_file.py
+++ b/pulpcore/tests/conftest_pulp_file.py
@@ -8,6 +8,7 @@ import pytest
 from pulpcore.client.pulp_file import (
     ContentFilesApi,
     RepositoriesFileApi,
+    RepositoriesFileVersionsApi,
     RemotesFileApi,
 )
 from pulp_smash.pulp3.utils import gen_repo
@@ -33,6 +34,11 @@ def content_file_api_client(file_client):
 @pytest.fixture(scope="session")
 def file_repo_api_client(file_client):
     return RepositoriesFileApi(file_client)
+
+
+@pytest.fixture(scope="session")
+def file_repo_version_api_client(file_client):
+    return RepositoriesFileVersionsApi(file_client)
 
 
 @pytest.fixture


### PR DESCRIPTION
Add_and_remove task might fail with "duplicate key value violates
unique constraint" error after deleting a repository version.
    
Also added a test to cover this scenario.
    
fixes #2047
fixes #2267