### PR TITLE
Add a description filter to the RoleFilter

### DIFF
--- a/CHANGES/2276.feature
+++ b/CHANGES/2276.feature
@@ -1,0 +1,1 @@
+Added a filter to allow searching for user roles by their description.

--- a/pulpcore/app/viewsets/user.py
+++ b/pulpcore/app/viewsets/user.py
@@ -481,6 +481,7 @@ class RoleFilter(BaseFilterSet):
         model = Role
         fields = {
             "name": NAME_FILTER_OPTIONS,
+            "description": ["exact", "iexact", "icontains", "contains"],
             "locked": ["exact"],
         }
 


### PR DESCRIPTION
Issue: AAH-1409
https://issues.redhat.com/browse/AAH-1409

In the [ansible-hub-ui](https://github.com/ansible/ansible-hub-ui) we would like to filter the roles by description also. This PR makes the filtering available.