### PR TITLE
Handles closed db connections

### DIFF
--- a/CHANGES/2293.bugfix
+++ b/CHANGES/2293.bugfix
@@ -1,0 +1,1 @@
+Fixed bug where the content app would stop working after a brief loss of connection to the database. 

--- a/pulpcore/content/authentication.py
+++ b/pulpcore/content/authentication.py
@@ -3,9 +3,12 @@ import gettext
 import logging
 
 from aiohttp.web import middleware
+from django.db.utils import InterfaceError, OperationalError
 from django.http.request import HttpRequest
 from rest_framework.views import APIView
 from rest_framework.exceptions import APIException
+
+from .handler import Handler
 
 log = logging.getLogger(__name__)
 loop = asyncio.get_event_loop()
@@ -21,7 +24,11 @@ async def authenticate(request, handler):
     def _authenticate_blocking():
         drf_request = fake_view.initialize_request(django_request)
         try:
-            fake_view.perform_authentication(drf_request)
+            try:
+                fake_view.perform_authentication(drf_request)
+            except (InterfaceError, OperationalError):
+                Handler._reset_db_connection()
+                fake_view.perform_authentication(drf_request)
         except APIException as e:
             log.warning(_('"{} {}" "{}": {}').format(request.method, request.path, request.host, e))
 

--- a/pulpcore/content/handler.py
+++ b/pulpcore/content/handler.py
@@ -127,7 +127,6 @@ class Handler:
         Returns:
             :class:`aiohttp.web.HTTPOk`: The response back to the client.
         """
-        self._reset_db_connection()
 
         def get_base_paths_blocking():
             if self.distribution_model is None:
@@ -206,8 +205,6 @@ class Handler:
             :class:`aiohttp.web.StreamResponse` or :class:`aiohttp.web.FileResponse`: The response
                 back to the client.
         """
-        self._reset_db_connection()
-
         path = request.match_info["path"]
         return await self._match_and_stream(path, request)
 
@@ -246,8 +243,6 @@ class Handler:
         Raises:
             PathNotResolved: when not matched.
         """
-        cls._reset_db_connection()
-
         base_paths = cls._base_paths(path)
         if cls.distribution_model is None:
             try:

--- a/pulpcore/tests/functional/api/using_plugin/test_distributions.py
+++ b/pulpcore/tests/functional/api/using_plugin/test_distributions.py
@@ -1,6 +1,7 @@
 """Tests that perform actions over distributions."""
 import csv
 import hashlib
+from time import sleep
 import unittest
 from urllib.parse import urljoin
 
@@ -15,6 +16,7 @@ from pulp_smash.pulp3.utils import (
     get_versions,
     modify_repo,
     sync,
+    utils as pulp3_utils,
 )
 from requests.exceptions import HTTPError
 
@@ -392,6 +394,35 @@ class ContentServePublicationDistributionTestCase(unittest.TestCase):
                 headers={"Range": "bytes=10485860-10485870"},
             )
         self.assertEqual(cm.exception.response.status_code, 416)
+
+    def test_content_served_after_db_restart(self):
+        """
+        Assert that content can be downloaded after the database has been restarted.
+        This test also check that the HTML page with a list of distributions is also
+        available after the connection to the database has been closed.
+        """
+        cfg = config.get_config()
+        pulp_host = cfg.hosts[0]
+        svc_mgr = cli.ServiceManager(cfg, pulp_host)
+        if svc_mgr._svc_mgr == "s6":
+            postgresql_service_name = "postgresql"
+        else:
+            postgresql_service_name = "*postgresql*"
+        postgresql_found = svc_mgr.is_active([postgresql_service_name])
+        self.assertTrue(
+            postgresql_found, "PostgreSQL service not found or is not active. Can't restart it."
+        )
+        svc_mgr.restart([postgresql_service_name])
+        # Wait for postgres to come back and all services to recover
+        sleep(2)
+        self.setup_download_test("immediate")
+        self.do_test_content_served()
+        url_fragments = [
+            cfg.get_content_host_base_url(),
+            "pulp/content",
+        ]
+        content_app_root = "/".join(url_fragments)
+        pulp3_utils.http_get(content_app_root)
 
     def setup_download_test(self, policy, url=None, publish=True):
         # Create a repository

--- a/pulpcore/tests/unit/content/test_heartbeat.py
+++ b/pulpcore/tests/unit/content/test_heartbeat.py
@@ -1,0 +1,35 @@
+import asyncio
+from unittest import skip
+from unittest.mock import patch, call
+
+from django.db.utils import InterfaceError, OperationalError
+from django.test import TestCase
+
+from pulpcore.content import _heartbeat
+
+
+class ContentHeartbeatTestCase(TestCase):
+    @skip("Skipping while resolving https://github.com/rochacbruno/dynaconf/issues/689")
+    @patch("pulpcore.app.models.ContentAppStatus.objects.get_or_create")
+    @patch("pulpcore.content.handler.Handler._reset_db_connection")
+    def test_db_connection_interface_error(self, mock_reset_db, mock_get_or_create):
+        """
+        Test that if an InterfaceError or OperationalError is raised,
+        Handler._reset_db_connection() is called
+        """
+
+        class MockException(Exception):
+            pass
+
+        mock_get_or_create.side_effect = [InterfaceError(), OperationalError(), MockException()]
+
+        loop = asyncio.get_event_loop()
+        with self.settings(CONTENT_APP_TTL=1):
+            try:
+                loop.run_until_complete(_heartbeat())
+            except MockException:
+                pass
+        loop.close()
+
+        mock_get_or_create.assert_called()
+        mock_reset_db.assert_has_calls([call(), call()])


### PR DESCRIPTION
When the authentication middleware was added in pulpcore 3.15, it became the first place
in the content app that made an attempt to use the database. As a result, it is a convinient
place to handle InterfaceError and  OperationalError which are raised when the database
connection has been closed. When this occurs, Handler._reset_db_connection() is called to
clean up the database connection and the middleware tries to use the database again.

If the database connection is closed later in the handling of the request by the content app,
the user will still get a 500 error. However, the next request will be handled properly.

This patch also adds a call to Handler._reset_db_connection() inside the heartbeat method.

fixes: #2293
(cherry picked from commit 3faa649ddb0737c23d1e309a8c38ecb41804cebe)

Please be sure you have read our documentation on creating PRs:
https://docs.pulpproject.org/contributing/pull-request-walkthrough.html
