### PR TITLE
[3.14 backport] Fix delete repository version causing "duplicate key" error

### DIFF
--- a/CHANGES/2047.bugfix
+++ b/CHANGES/2047.bugfix
@@ -1,0 +1,1 @@
+Fix delete repository version causing "duplicate key value violates unique constraint" error.

--- a/CHANGES/2267.bugfix
+++ b/CHANGES/2267.bugfix
@@ -1,0 +1,1 @@
+This fix prevents the lost track of a content removed version when deleting a repository version that deletes a content that is added back in the subsequent version, but deleted again in a later version.

--- a/pulpcore/app/models/repository.py
+++ b/pulpcore/app/models/repository.py
@@ -4,6 +4,7 @@ Repository related Django models.
 from contextlib import suppress
 from gettext import gettext as _
 from os import path
+from collections import defaultdict
 import logging
 
 import django
@@ -853,9 +854,11 @@ class RepositoryVersion(BaseModel):
         # delete any relationships added in the version being deleted and removed in the next one.
         repo_relations.filter(version_added=self, version_removed=next_version).delete()
 
-        # If the same content is deleted in version, but added back in next_version
-        # set version_removed field in relation to None, and remove relation adding the content
-        # in next_version
+        # If the same content is deleted in version, but added back in next_version then:
+        # - set version_removed field in relation to version_removed of the relation adding
+        #   the content in next version because the content can be removed again after the
+        #   next_version
+        # - and remove relation adding the content in next_version
         content_added = repo_relations.filter(version_added=next_version).values_list("content_id")
 
         # use list() to force the evaluation of the queryset, otherwise queryset is affected
@@ -866,13 +869,26 @@ class RepositoryVersion(BaseModel):
             )
         )
 
-        repo_relations.filter(
-            version_removed=self, content_id__in=content_removed_and_readded
-        ).update(version_removed=None)
-
-        repo_relations.filter(
+        repo_contents_readded_in_next_version = repo_relations.filter(
             version_added=next_version, content_id__in=content_removed_and_readded
-        ).delete()
+        )
+
+        # Since the readded contents can be removed again by any subsequent version after the
+        # next version. Get the mapping of readded contents and their versions removed to use
+        # later. The version removed id will be None if a content is not removed.
+        version_removed_id_content_id_map = defaultdict(list)
+        for readded_repo_content in repo_contents_readded_in_next_version.iterator():
+            version_removed_id_content_id_map[readded_repo_content.version_removed_id].append(
+                readded_repo_content.content_id
+            )
+
+        repo_contents_readded_in_next_version.delete()
+
+        # Update the version removed of the readded contents
+        for version_removed_id, content_ids in version_removed_id_content_id_map.items():
+            repo_relations.filter(version_removed=self, content_id__in=content_ids).update(
+                version_removed_id=version_removed_id
+            )
 
         # "squash" by moving other additions and removals forward to the next version
         repo_relations.filter(version_added=self).update(version_added=next_version)

--- a/pulpcore/tests/conftest.py
+++ b/pulpcore/tests/conftest.py
@@ -1,0 +1,1 @@
+from .conftest_pulp_file import *  # noqa

--- a/pulpcore/tests/conftest_pulp_file.py
+++ b/pulpcore/tests/conftest_pulp_file.py
@@ -1,0 +1,141 @@
+import logging
+import uuid
+
+from pathlib import Path
+
+import pytest
+
+from pulpcore.client.pulp_file import (
+    ContentFilesApi,
+    RepositoriesFileApi,
+    RepositoriesFileVersionsApi,
+    RemotesFileApi,
+)
+from pulp_smash.pulp3.utils import gen_repo
+
+from pulpcore.tests.functional.api.using_plugin.utils import (
+    gen_file_client,
+)
+
+
+_logger = logging.getLogger(__name__)
+
+
+@pytest.fixture(scope="session")
+def file_client():
+    return gen_file_client()
+
+
+@pytest.fixture(scope="session")
+def content_file_api_client(file_client):
+    return ContentFilesApi(file_client)
+
+
+@pytest.fixture(scope="session")
+def file_repo_api_client(file_client):
+    return RepositoriesFileApi(file_client)
+
+
+@pytest.fixture(scope="session")
+def file_repo_version_api_client(file_client):
+    return RepositoriesFileVersionsApi(file_client)
+
+
+@pytest.fixture
+def file_repo(file_repo_api_client, gen_object_with_cleanup):
+    return gen_object_with_cleanup(file_repo_api_client, gen_repo())
+
+
+@pytest.fixture(scope="session")
+def file_remote_api_client(file_client):
+    return RemotesFileApi(file_client)
+
+
+@pytest.fixture(scope="session")
+def file_fixtures_root():
+    return Path(__file__).parent / "fixtures"
+
+
+@pytest.fixture
+def file_fixture_server_ssl_client_cert_req(
+    ssl_ctx_req_client_auth, file_fixtures_root, gen_fixture_server
+):
+    yield gen_fixture_server(file_fixtures_root, ssl_ctx_req_client_auth)
+
+
+@pytest.fixture
+def file_fixture_server_ssl(ssl_ctx, file_fixtures_root, gen_fixture_server):
+    yield gen_fixture_server(file_fixtures_root, ssl_ctx)
+
+
+@pytest.fixture
+def file_fixture_server(file_fixtures_root, gen_fixture_server):
+    yield gen_fixture_server(file_fixtures_root, None)
+
+
+@pytest.fixture
+def file_fixture_gen_remote(file_fixture_server, file_remote_api_client, gen_object_with_cleanup):
+    def _file_fixture_gen_remote(*, fixture_name, policy, **kwargs):
+        url = file_fixture_server.make_url(f"/{fixture_name}/PULP_MANIFEST")
+        kwargs.update({"url": str(url), "policy": policy, "name": str(uuid.uuid4())})
+        return gen_object_with_cleanup(file_remote_api_client, kwargs)
+
+    yield _file_fixture_gen_remote
+
+
+@pytest.fixture
+def file_fixture_gen_remote_ssl(
+    file_fixture_server_ssl,
+    file_remote_api_client,
+    tls_certificate_authority_cert,
+    gen_object_with_cleanup,
+):
+    def _file_fixture_gen_remote_ssl(*, fixture_name, policy, **kwargs):
+        url = file_fixture_server_ssl.make_url(f"/{fixture_name}/PULP_MANIFEST")
+        kwargs.update(
+            {
+                "url": str(url),
+                "policy": policy,
+                "name": str(uuid.uuid4()),
+                "ca_cert": tls_certificate_authority_cert,
+            }
+        )
+        return gen_object_with_cleanup(file_remote_api_client, kwargs)
+
+    yield _file_fixture_gen_remote_ssl
+
+
+@pytest.fixture
+def file_fixture_gen_remote_client_cert_req(
+    file_fixture_server_ssl_client_cert_req,
+    file_remote_api_client,
+    tls_certificate_authority_cert,
+    client_tls_certificate_cert_pem,
+    client_tls_certificate_key_pem,
+    gen_object_with_cleanup,
+):
+    def _file_fixture_gen_remote_client_cert_req(*, fixture_name, policy, **kwargs):
+        url = file_fixture_server_ssl_client_cert_req.make_url(f"/{fixture_name}/PULP_MANIFEST")
+        kwargs.update(
+            {
+                "url": str(url),
+                "policy": policy,
+                "name": str(uuid.uuid4()),
+                "ca_cert": tls_certificate_authority_cert,
+                "client_cert": client_tls_certificate_cert_pem,
+                "client_key": client_tls_certificate_key_pem,
+            }
+        )
+        return gen_object_with_cleanup(file_remote_api_client, kwargs)
+
+    yield _file_fixture_gen_remote_client_cert_req
+
+
+@pytest.fixture
+def file_fixture_gen_file_repo(file_repo_api_client, gen_object_with_cleanup):
+    """A factory to generate a File Repository with auto-deletion after the test run."""
+
+    def _file_fixture_gen_file_repo(**kwargs):
+        return gen_object_with_cleanup(file_repo_api_client, kwargs)
+
+    yield _file_fixture_gen_file_repo


### PR DESCRIPTION
Add_and_remove task might fail with "duplicate key value violates
unique constraint" error after deleting a repository version.

Also added a test to cover this scenario.

fixes #2047
fixes #2267

(cherry picked from commit a28b7116e550b35241a39d35935007e860face04)
(cherry picked from commit c0f04d8f991e45ccc6a5de13fcaf2564016ce4c7)
(cherry picked from commit 603a60d996c12f1f22bdf924ec5aff8d72306654)
