### PR TITLE
Reduces queue size between stages from 1000 to 1

### DIFF
--- a/CHANGES/2069.bugfix
+++ b/CHANGES/2069.bugfix
@@ -1,0 +1,1 @@
+Reduced memory usage during tasks like sync by holding fewer objects in-memory unnecessarily.

--- a/CHANGES/plugin_api/2069.bugfix
+++ b/CHANGES/plugin_api/2069.bugfix
@@ -1,0 +1,3 @@
+Adjusted the default size of the queues between pipelines to be 1 instead of 1000. The batchers in
+the stage will still accumulate up to 500 (by default) items so batching is still in-effect there
+where it matters.

--- a/pulpcore/plugin/stages/api.py
+++ b/pulpcore/plugin/stages/api.py
@@ -179,12 +179,12 @@ class Stage:
         return "[{id}] {name}".format(id=id(self), name=self.__class__.__name__)
 
 
-async def create_pipeline(stages, maxsize=1000):
+async def create_pipeline(stages, maxsize=1):
     """
     A coroutine that builds a Stages API linear pipeline from the list `stages` and runs it.
 
     Each stage is an instance of a class derived from :class:`pulpcore.plugin.stages.Stage` that
-    implements the :meth:`run` coroutine. This coroutine reads asyncromously either from the
+    implements the :meth:`run` coroutine. This coroutine reads asynchronously either from the
     `items()` iterator or the `batches()` iterator and outputs the items with `put()`. Here is an
     example of the simplest stage that only passes data::
 
@@ -196,7 +196,7 @@ async def create_pipeline(stages, maxsize=1000):
     Args:
         stages (list of coroutines): A list of Stages API compatible coroutines.
         maxsize (int): The maximum amount of items a queue between two stages should hold. Optional
-            and defaults to 100.
+            and defaults to 1.
 
     Returns:
         A single coroutine that can be used to run, wait, or cancel the entire pipeline with.


### PR DESCRIPTION
The runtime was actually slightly slower with the 1000 objects in-memory
and much more memory use.

closes #2069

