### PR TITLE
Fixes RemoteArtifact duplicate key error

### DIFF
--- a/CHANGES/2381.bugfix
+++ b/CHANGES/2381.bugfix
@@ -1,0 +1,2 @@
+Fixes duplicate key error ``Key (content_artifact_id, remote_id)`` when creating ``RemoteArtifacts``
+during syncs in pulp_container and possibly other plugins.

--- a/pulpcore/plugin/stages/artifact_stages.py
+++ b/pulpcore/plugin/stages/artifact_stages.py
@@ -293,6 +293,11 @@ class RemoteArtifactSaver(Stage):
         """
         remotes_present = set()
         for d_content in batch:
+            # https://code.djangoproject.com/ticket/33596
+            # If the content was pre-fetched previously, remove that cached data, which could be out
+            # of date.
+            if hasattr(d_content.content, "_remote_artifact_saver_cas"):
+                delattr(d_content.content, "_remote_artifact_saver_cas")
             for d_artifact in d_content.d_artifacts:
                 if d_artifact.remote:
                     remotes_present.add(d_artifact.remote)


### PR DESCRIPTION
The Django Prefetch caching is providing older data previously fetched,
so we need to invaidate the caches when prefetching.

closes #2381
