### PR TITLE
Pin redis on pulpcore < 3.17

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -25,7 +25,7 @@ pygtrie~=2.4.2
 psycopg2~=2.9.1
 PyYAML>=5.1.1,<5.5.0
 python-gnupg~=0.4.7
-redis>=3.4.0
+redis>=3.4.0,<4.2.0
 setuptools>=39.2.0
 whitenoise>=5.0.0,<5.4.0
 yarl>1.0.0


### PR DESCRIPTION
```
fatal: [fedora-34]: FAILED! => {
    "changed": false, 
    "cmd": [
        "/usr/local/lib/pulp/bin/pip-compile"
    ], 
    "delta": "0:00:40.624751", 
    "end": "2022-03-23 18:08:48.547438", 
    "failed_when_result": true, 
    "rc": 2, 
    "start": "2022-03-23 18:08:07.922687"
}

STDERR:

Could not find a version that matches async-timeout<4.0,>=3.0,>=4.0.2 (from redis==4.2.0->pulpcore==3.15.6->-r requirements.in (line 1))
Tried: 1.0.0, 1.0.0, 1.1.0, 1.1.0, 1.2.0, 1.2.0, 1.2.1, 1.2.1, 1.3.0, 1.3.0, 1.4.0, 1.4.0, 2.0.0, 2.0.0, 2.0.1, 2.0.1, 3.0.0, 3.0.0, 3.0.1, 3.0.1, 4.0.0, 4.0.0, 4.0.1, 4.0.1, 4.0.2, 4.0.2
Skipped pre-versions: 4.0.0a0, 4.0.0a0, 4.0.0a1, 4.0.0a1, 4.0.0a2, 4.0.0a2, 4.0.0a3, 4.0.0a3
There are incompatible versions in the resolved dependencies:
  async-timeout<4.0,>=3.0 (from aiohttp==3.7.4.post0->pulpcore==3.15.6->-r requirements.in (line 1))
  async-timeout>=4.0.2 (from redis==4.2.0->pulpcore==3.15.6->-r requirements.in (line 1))
  async-timeout (from aioredis==2.0.1->pulpcore==3.15.6->-r requirements.in (line 1))


MSG:

non-zero return code
```

new redis release conflicts with aiohttp from pulpcore < 3.17