### PR TITLE
Revert "pulpcore-manager defaults to '/etc/pulp/settings.py'"

### DIFF
--- a/CHANGES/2038.feature
+++ b/CHANGES/2038.feature
@@ -1,2 +1,0 @@
-``pulpcore-manager`` now uses '/etc/pulp/settings.py' as default settings location if
- ``PULP_SETTINGS`` is not set.

--- a/pulpcore/app/manage.py
+++ b/pulpcore/app/manage.py
@@ -5,7 +5,6 @@ import sys
 
 def manage():
     os.environ.setdefault("DJANGO_SETTINGS_MODULE", "pulpcore.app.settings")
-    os.environ.setdefault("PULP_SETTINGS", "/etc/pulp/settings.py")
 
     from django.core.management import execute_from_command_line
 


### PR DESCRIPTION
Reverts pulp/pulpcore#2401