### PR TITLE
Taught ArtifactSaver to order artifacts prior to attempting bulk-create.

### DIFF
--- a/CHANGES/2420.bugfix
+++ b/CHANGES/2420.bugfix
@@ -1,0 +1,1 @@
+Fixed a rare deadlock when sync'ing overlapping content in high-concurrency envs.

--- a/pulpcore/plugin/stages/artifact_stages.py
+++ b/pulpcore/plugin/stages/artifact_stages.py
@@ -242,12 +242,13 @@ class ArtifactSaver(Stage):
                     if d_artifact.artifact._state.adding and not d_artifact.deferred_download:
                         d_artifact.artifact.file = str(d_artifact.artifact.file)
                         da_to_save.append(d_artifact)
+            da_to_save_ordered = sorted(da_to_save, key=lambda x: x.artifact.sha256)
 
             if da_to_save:
                 for d_artifact, artifact in zip(
-                    da_to_save,
+                    da_to_save_ordered,
                     await sync_to_async(Artifact.objects.bulk_get_or_create)(
-                        d_artifact.artifact for d_artifact in da_to_save
+                        d_artifact.artifact for d_artifact in da_to_save_ordered
                     ),
                 ):
                     d_artifact.artifact = artifact


### PR DESCRIPTION
Reproducing/testing is at best timeconsuming, and dependent on an empty
pulp instance being set up for high (>10 workers) concurrency. See the
associated issue for manual test process.

fixes #2420
[nocoverage]

