### PR TITLE
Run pulp_file tests in pulpcore CI

### DIFF
--- a/.github/workflows/scripts/script.sh
+++ b/.github/workflows/scripts/script.sh
@@ -186,9 +186,13 @@ else
     if [[ "$GITHUB_WORKFLOW" == "Pulpcore Nightly CI/CD" ]]; then
         pytest -v -r sx --color=yes --suppress-no-test-exit-code --pyargs pulpcore.tests.functional -m parallel -n 8
         pytest -v -r sx --color=yes --pyargs pulpcore.tests.functional -m "not parallel"
+        pytest -v -r sx --color=yes --suppress-no-test-exit-code --pyargs pulp_file.tests.functional -m parallel -n 8
+        pytest -v -r sx --color=yes --pyargs pulp_file.tests.functional -m "not parallel"
     else
         pytest -v -r sx --color=yes --suppress-no-test-exit-code --pyargs pulpcore.tests.functional -m "parallel and not nightly" -n 8
         pytest -v -r sx --color=yes --pyargs pulpcore.tests.functional -m "not parallel and not nightly"
+        pytest -v -r sx --color=yes --suppress-no-test-exit-code --pyargs pulp_file.tests.functional -m "parallel and not nightly" -n 8
+        pytest -v -r sx --color=yes --pyargs pulp_file.tests.functional -m "not parallel and not nightly"
     fi
 
 fi

--- a/template_config.yml
+++ b/template_config.yml
@@ -6,6 +6,7 @@
 additional_repos:
 - branch: main
   name: pulp_file
+  pytest_args: pulp_file.tests.functional
 - branch: main
   name: pulp-certguard
 aiohttp_fixtures_origin: 172.18.0.1


### PR DESCRIPTION
The pulp_file tests are eventually going to hold all of the tests which
involve pulp_file. Those are needed to assert correctness on pulpcore
though so let's run those with pulpcore too!

[noissue]