### PR TITLE
Fixes secure proxy support by updating aiohttp to 3.8.1

### DIFF
--- a/CHANGES/2423.bugfix
+++ b/CHANGES/2423.bugfix
@@ -1,0 +1,1 @@
+Fixed secure proxy support by updating aiohttp version to ~=3.8.1.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 asyncio-throttle~=1.0
-aiohttp~=3.7.4
+aiohttp~=3.8.1
 aiodns~=3.0.0
 aiofiles==0.7.0
 aioredis~=2.0.0


### PR DESCRIPTION
fixes: #2423

Please be sure you have read our documentation on creating PRs:
https://docs.pulpproject.org/contributing/pull-request-walkthrough.html
