### PR TITLE
Use dynaconf validators for settings.py

### DIFF
--- a/CHANGES/1968.bugfix
+++ b/CHANGES/1968.bugfix
@@ -1,0 +1,1 @@
+Fixed validation order of required settings to occur before plugin settings are loaded.

--- a/docs/plugins/plugin-writer/concepts/index.rst
+++ b/docs/plugins/plugin-writer/concepts/index.rst
@@ -266,6 +266,25 @@ usage.html#merging-existing-values>`_ which is for merging settings instead of o
 example, pulp_ansible makes use of this `here <https://github.com/pulp/pulp_ansible/blob/
 31dd6b77f0e2748644a4b76607be4a6cd2b6ce89/pulp_ansible/app/settings.py>`_.
 
+Some settings require validation to ensure the user has entered a valid value. Plugins can add
+validation for their settings using validators added in a ``dynaconf`` hook file that will run
+after all the settings have been loaded. Create a ``<your plugin>.app.dynaconf_hooks`` module like
+below so ``dynaconf`` can run your plugin's validators. See `dynaconf validator docs 
+<https://www.dynaconf.com/validation/>`_ for more information on writing validators.
+
+.. code-block:: python
+
+    from dynaconf import Validator
+
+    def post(settings):
+        """This hook is called by dynaconf after the settings are completely loaded"""
+        settings.validators.register(
+            Validator(...),
+            Validator(...),
+            ...
+        )
+        settings.validators.validate()
+
 
 .. _custom-url-routes:
 

--- a/pulpcore/tests/unit/test_settings.py
+++ b/pulpcore/tests/unit/test_settings.py
@@ -1,0 +1,59 @@
+from django.test import TestCase
+from django.conf import settings
+from dynaconf.validator import ValidationError
+
+
+class SettingsTestCase(TestCase):
+    def test_content_origin(self):
+        """Test validation error is raised when CONTENT_ORIGIN is missing."""
+        # See https://github.com/rochacbruno/dynaconf/issues/731
+        # keep needs to be True in order to copy all the current settings already initialized
+        msettings = settings.from_env("development", keep=True, validators=settings.validators)
+        # force needs to be True in order to remove CONTENT_ORIGIN since keep makes it a default
+        msettings.unset("CONTENT_ORIGIN", force=True)
+        with self.assertRaises(ValidationError):
+            msettings.validators.validate()
+
+    def test_cache_enabled(self):
+        """Test that when CACHE_ENABLED is set REDIS_URL or REDIS_HOST & REDIS_PORT."""
+        msettings = settings.from_env("development", keep=True, validators=settings.validators)
+        msettings.set("CACHE_ENABLED", True)
+        msettings.unset("REDIS_URL", force=True)
+        msettings.unset("REDIS_HOST", force=True)
+        msettings.unset("REDIS_PORT", force=True)
+        with self.assertRaises(ValidationError):
+            msettings.validators.validate()
+
+        msettings.set("REDIS_HOST", "localhost")
+        with self.assertRaises(ValidationError):
+            msettings.validators.validate()
+
+        msettings.unset("REDIS_HOST", force=True)
+        msettings.set("REDIS_PORT", 8000)
+        with self.assertRaises(ValidationError):
+            msettings.validators.validate()
+
+    def test_allowed_content_checksums(self):
+        """Test that removing 'sha256' from ALLOWED_CONTENT_CHECKSUMS raises ValidationError."""
+        msettings = settings.from_env("development", keep=True, validators=settings.validators)
+        msettings.set("ALLOWED_CONTENT_CHECKSUMS", ["sha224", "sha512"])
+        with self.assertRaises(ValidationError):
+            msettings.validators.validate()
+
+    def test_unknown_content_checksums(self):
+        """Test that providing invalid checksum for ALLOWED_CONTENT_CHECKSUMS fails."""
+        msettings = settings.from_env("development", keep=True, validators=settings.validators)
+        msettings.set("ALLOWED_CONTENT_CHECKSUMS", ["aaa"])
+        with self.assertRaises(ValidationError):
+            msettings.validators.validate()
+
+    def test_api_root(self):
+        """Test that API_ROOT validation checks for beginning and ending '/'."""
+        msettings = settings.from_env("development", keep=True, validators=settings.validators)
+        msettings.set("API_ROOT", "/hi/there")
+        with self.assertRaises(ValidationError):
+            msettings.validators.validate()
+
+        msettings.set("API_ROOT", "hi/there/")
+        with self.assertRaises(ValidationError):
+            msettings.validators.validate()


### PR DESCRIPTION
An experimental PR to see if it is possible to do our settings validation using dynaconf's Validators. This should also ensure that plugins that use pulpcore's settings will all receive the same error message if that setting isn't define (https://github.com/pulp/pulpcore/issues/1968). 

I opened this PR to get discussion around this option. I'm not sure how much better this way is or if I even used the Validators correctly (@rochacbruno). Also, I think there is another way to fix #1968 using [hooks](https://www.dynaconf.com/advanced/#hooks) if this way doesn't pan out.
