### PR TITLE
Fix instances of writing to /tmp

### DIFF
--- a/CHANGES/2061.bugfix
+++ b/CHANGES/2061.bugfix
@@ -1,0 +1,1 @@
+Fixed two instances of Pulp not writing to the task worker's temporary directory.

--- a/pulpcore/app/importexport.py
+++ b/pulpcore/app/importexport.py
@@ -45,7 +45,7 @@ def _write_export(the_tarfile, resource, dest_dir=None):
     # Otherwise, export all data in oneshot. This is because the underlying libraries
     # (json; django-import-export) do not support to stream the output to file, we export
     # the data in batches to memory and concatenate the json lists via string manipulation.
-    with tempfile.NamedTemporaryFile(dir=os.getcwd(), mode="w", encoding="utf8") as temp_file:
+    with tempfile.NamedTemporaryFile(dir=".", mode="w", encoding="utf8") as temp_file:
         if isinstance(resource.queryset, QuerySet):
             temp_file.write("[")
             total = resource.queryset.count()
@@ -104,7 +104,7 @@ def export_artifacts(export, artifacts):
         for artifact in pb.iter(artifacts):
             dest = artifact.file.name
             if settings.DEFAULT_FILE_STORAGE != "pulpcore.app.models.storage.FileSystem":
-                with tempfile.TemporaryDirectory() as temp_dir:
+                with tempfile.TemporaryDirectory(dir=".") as temp_dir:
                     with tempfile.NamedTemporaryFile(dir=temp_dir) as temp_file:
                         temp_file.write(artifact.file.read())
                         temp_file.flush()

--- a/pulpcore/app/tasks/importer.py
+++ b/pulpcore/app/tasks/importer.py
@@ -137,7 +137,7 @@ def import_repository_version(importer_pk, destination_repo_pk, source_repo_name
     )
     pb.save()
 
-    with tempfile.TemporaryDirectory() as temp_dir:
+    with tempfile.TemporaryDirectory(dir=".") as temp_dir:
         # Extract the repo file for the repo info
         with tarfile.open(tar_path, "r:gz") as tar:
             tar.extract(REPO_FILE, path=temp_dir)

--- a/pulpcore/download/base.py
+++ b/pulpcore/download/base.py
@@ -129,7 +129,7 @@ class BaseDownloader:
         allowing plugin writers to instantiate many downloaders in memory.
         """
         if not self._writer:
-            self._writer = tempfile.NamedTemporaryFile(dir=os.getcwd(), delete=False)
+            self._writer = tempfile.NamedTemporaryFile(dir=".", delete=False)
             self.path = self._writer.name
             self._digests = {n: pulp_hashlib.new(n) for n in Artifact.DIGEST_FIELDS}
             self._size = 0


### PR DESCRIPTION
fixes: #2061

There is also two instances of writing to `/tmp` in [factory.py](https://github.com/pulp/pulpcore/blob/main/pulpcore/download/factory.py#L113-L116) for writing a temp key and cert for the downloader, but that code can be called outside of a worker (like in the content app), so I didn't change it.

Please be sure you have read our documentation on creating PRs:
https://docs.pulpproject.org/contributing/pull-request-walkthrough.html
