### PR TITLE
Enable bypassing DB encryption [#2466]

### DIFF
--- a/CHANGES/2466.feature
+++ b/CHANGES/2466.feature
@@ -1,0 +1,3 @@
+Adds the ``DB_ENCRYPTION`` setting which if ``False`` disables at-rest database encryption.
+
+Note: does not decrypt already encrypted values

--- a/docs/configuration/settings.rst
+++ b/docs/configuration/settings.rst
@@ -36,6 +36,17 @@ SECRET_KEY
    chars = 'abcdefghijklmnopqrstuvwxyz0123456789!@#$%^&*(-_=+)'
    print(''.join(random.choice(chars) for i in range(50)))
 
+DB_ENCRYPTION
+^^^^^^^^^^^^^
+
+  By default Pulp uses database encryption. If ``False`` the at-rest database encryption is not used and values are stored
+  in plain text.
+
+  .. warning::
+
+     values which are already encrypted are not decrypted if this setting is changed; best 
+     to only bypass encryption in a clean installation. 
+
 DB_ENCRYPTION_KEY
 ^^^^^^^^^^^^^^^^^
 

--- a/pulpcore/app/management/commands/datarepair-2327.py
+++ b/pulpcore/app/management/commands/datarepair-2327.py
@@ -36,8 +36,9 @@ class Command(BaseCommand):
         dry_run = options["dry_run"]
         fields = ("username", "password", "proxy_username", "proxy_password", "client_key")
 
-        with open(settings.DB_ENCRYPTION_KEY, "rb") as key_file:
-            fernet = cryptography.fernet.Fernet(key_file.read())
+        if settings.DB_ENCRYPTION:
+            with open(settings.DB_ENCRYPTION_KEY, "rb") as key_file:
+                fernet = cryptography.fernet.Fernet(key_file.read())
 
         possibly_affected_remotes = (
             Q(username__isnull=False)
@@ -88,8 +89,9 @@ class Command(BaseCommand):
                             continue
 
                         try:
-                            # try to decrypt it again
-                            field_value = force_str(fernet.decrypt(force_bytes(field_value)))
+                            if settings.DB_ENCRYPTION:
+                                # try to decrypt it again
+                                field_value = force_str(fernet.decrypt(force_bytes(field_value)))
                             # it was decrypted successfully again time, so it was probably
                             # encrypted multiple times over. lets re-set the value with the
                             # newly decrypted value

--- a/pulpcore/app/models/fields.py
+++ b/pulpcore/app/models/fields.py
@@ -96,10 +96,14 @@ class EncryptedTextField(TextField):
 
     def get_db_prep_save(self, value, connection):
         value = super().get_db_prep_save(value, connection)
+        if not settings.DB_ENCRYPTION:
+            return value
         if value is not None:
             return force_str(self._fernet.encrypt(force_bytes(value)))
 
     def from_db_value(self, value, expression, connection):
+        if not settings.DB_ENCRYPTION:
+            return value
         if value is not None:
             return force_str(self._fernet.decrypt(force_bytes(value)))
 

--- a/pulpcore/app/settings.py
+++ b/pulpcore/app/settings.py
@@ -55,6 +55,8 @@ FILE_UPLOAD_HANDLERS = ("pulpcore.app.files.HashingFileUploadHandler",)
 
 SECRET_KEY = True
 
+DB_ENCRYPTION = True
+
 # Key used to encrypt fields in the database
 DB_ENCRYPTION_KEY = "/etc/pulp/certs/database_fields.symmetric.key"
 
@@ -383,6 +385,7 @@ if not (
     Path(sys.argv[0]).name == "pytest"
     or Path(sys.argv[0]).name == "sphinx-build"
     or (len(sys.argv) >= 2 and sys.argv[1] == "collectstatic")
+    or (not DB_ENCRYPTION or not DB_ENCRYPTION_KEY)
 ):
     try:
         with open(DB_ENCRYPTION_KEY, "rb") as key_file:

--- a/pulpcore/tests/unit/models/test_remote.py
+++ b/pulpcore/tests/unit/models/test_remote.py
@@ -2,7 +2,7 @@ from uuid import uuid4
 from unittest.mock import patch, mock_open
 
 from django.db import connection
-from django.test import TestCase
+from django.test import TestCase, override_settings
 
 from pulpcore.app.models import Remote
 from pulpcore.app.models.fields import EncryptedTextField
@@ -36,3 +36,26 @@ class RemoteTestCase(TestCase):
             self.assertNotEqual(db_proxy_password, "test")
             self.assertEqual(proxy_password, "test")
             self.assertEqual(mock_file.call_count, 2)
+
+    @patch(
+        "pulpcore.app.models.fields.open",
+        new_callable=mock_open,
+        read_data=b"hPCIFQV/upbvPRsEpgS7W32XdFA2EQgXnMtyNAekebQ=",
+    )
+    @override_settings(DB_ENCRYPTION=False)
+    def test_bypassed_encrypted_proxy_password(self, mock_file):
+        self.remote = Remote(name=uuid4(), proxy_password="test")
+        self.remote.save()
+        self.assertEqual(Remote.objects.get(pk=self.remote.pk).proxy_password, "test")
+
+        # check the database that proxy_password is not encrypted
+        with connection.cursor() as cursor:
+            cursor.execute(
+                "SELECT proxy_password FROM core_remote " f"WHERE pulp_id = '{self.remote.pulp_id}'"
+            )
+            db_proxy_password = cursor.fetchone()[0]
+            proxy_password = EncryptedTextField().from_db_value(db_proxy_password, None, connection)
+            self.assertEqual(proxy_password, "test")
+            # these two tests should be what differs from the non-bypassed test
+            self.assertEqual(db_proxy_password, "test")
+            self.assertEqual(mock_file.call_count, 0)


### PR DESCRIPTION
Alter behavior of field-level encryption such that a false value in DB_ENCRYPTION_KEY results in bypassing the encryption and decryption of "encrypted" text field data

Fixes #2466

PR is initially expecting to solicit input.  In particular, I'd like to know if this approach seems like the most reasonable approach (it seemed like the least invasive way to mess with the code), and I'd like to know if it's appropriate to leave without a "decrypt migration".  Presumably it would be possible to add a `old_encryption_key` parameter or something like that which could be used as a one-off to decrypt the DB with a migration if someone decided to turn off encryption.  Perhaps addressing the logic to decrypt would help resolve #2048; there's just be a two-step process where the current key is moved to the old key, and then the DB is reencrypted with the new key (which could be empty in this case, or a new key in that case).  In any event, I'm not sure how to do a conditional migration or if migration is the right facility - I guess it'd have to be based on 1) old key parameter is present and 2) the value of the old key hasn't already been subjected to a migration.