### PR TITLE
Ignore black commit

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,3 @@
+# .git-blame-ignore-revs
+# enabled black formatting
+b94abd64d76ea4554e6750ff38ce458eaa888cc8

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,6 +70,7 @@ exclude = '''
 
 [tool.check-manifest]
 ignore = [
+    ".git-blame-ignore-revs",
     ".bumpversion.cfg",
     "CHANGES/**",
     "CONTRIBUTING.rst",


### PR DESCRIPTION
Thought this looked useful:

https://github.blog/changelog/2022-03-24-ignore-commits-in-the-blame-view-beta/
