### PR TITLE
Make tests independant

### DIFF
--- a/pulpcore/tests/functional/api/using_plugin/test_content_delivery.py
+++ b/pulpcore/tests/functional/api/using_plugin/test_content_delivery.py
@@ -105,7 +105,6 @@ class ContentDeliveryTestCase(unittest.TestCase):
         self.addCleanup(client.delete, remote["pulp_href"])
 
         sync(cfg, remote, repo)
-        repo = client.get(repo["pulp_href"])
 
         content = download_content_unit(cfg, distribution, unit_path)
         pulp_hash = hashlib.sha256(content).hexdigest()

--- a/pulpcore/tests/functional/api/using_plugin/test_content_guard.py
+++ b/pulpcore/tests/functional/api/using_plugin/test_content_guard.py
@@ -36,93 +36,101 @@ class RBACContentGuardTestCase(unittest.TestCase):
 
     @classmethod
     def setUpClass(cls):
-        """Set up test variables"""
-        client = gen_file_client()  # This is admin client, following apis are for admin user
-        api_config = config.get_config().get_bindings_config()
+        cls.client = gen_file_client()  # This is admin client, following apis are for admin user
+        cls.api_config = config.get_config().get_bindings_config()
         core_client = CoreApiClient(config.get_config().get_bindings_config())
         cls.groups_api = GroupsApi(core_client)
         cls.group_users_api = GroupsUsersApi(core_client)
-        cls.distro_api = DistributionsFileApi(client)
-        response = monitor_task(cls.distro_api.create(gen_distribution()).task)
-        cls.distro = cls.distro_api.read(response.created_resources[0])
-        cls.rbac_guard_api = ContentguardsRbacApi(client)
+        cls.distro_api = DistributionsFileApi(cls.client)
 
-        cls.admin = {
-            "username": client.configuration.username,
-            "password": client.configuration.password,
+    def setUp(self):
+        response = monitor_task(self.distro_api.create(gen_distribution()).task)
+        self.distro = self.distro_api.read(response.created_resources[0])
+        self.rbac_guard_api = ContentguardsRbacApi(self.client)
+
+        self.admin = {
+            "username": self.client.configuration.username,
+            "password": self.client.configuration.password,
         }
         user = gen_user_rest(model_roles=["core.rbaccontentguard_creator"])
-        api_config.username = user["username"]
-        api_config.password = user["password"]
-        user["rbac_guard_api"] = ContentguardsRbacApi(CoreApiClient(api_config))
-        cls.creator_user = user
-        cls.user_a = gen_user_rest()
-        cls.user_b = gen_user_rest()
-        cls.all_users = [cls.creator_user, cls.user_a, cls.user_a, cls.admin, None]
+        self.api_config.username = user["username"]
+        self.api_config.password = user["password"]
+        user["rbac_guard_api"] = ContentguardsRbacApi(CoreApiClient(self.api_config))
+        self.creator_user = user
+        self.user_a = gen_user_rest()
+        self.user_b = gen_user_rest()
+        self.all_users = [self.creator_user, self.user_a, self.user_a, self.admin, None]
 
-        cls.group = cls.groups_api.create({"name": utils.uuid4()})
-        cls.group_users_api.create(cls.group.pulp_href, {"username": cls.user_b["username"]})
-        cls.group_users_api.create(cls.group.pulp_href, {"username": cls.user_a["username"]})
+        self.group = self.groups_api.create({"name": utils.uuid4()})
+        self.group_users_api.create(self.group.pulp_href, {"username": self.user_b["username"]})
+        self.group_users_api.create(self.group.pulp_href, {"username": self.user_a["username"]})
 
-        cls.url = urljoin(PULP_CONTENT_BASE_URL, f"{cls.distro.base_path}/")
+        self.url = urljoin(PULP_CONTENT_BASE_URL, f"{self.distro.base_path}/")
 
-    @classmethod
-    def tearDownClass(cls):
-        """Clean up all class variables"""
-        cls.distro_api.delete(cls.distro.pulp_href)
-        cls.rbac_guard_api.delete(cls.distro.content_guard)
-        cls.groups_api.delete(cls.group.pulp_href)
-        del_user_rest(cls.creator_user["pulp_href"])
-        del_user_rest(cls.user_a["pulp_href"])
-        del_user_rest(cls.user_b["pulp_href"])
+    def tearDown(self):
+        self.distro_api.delete(self.distro.pulp_href)
+        self.rbac_guard_api.delete(self.distro.content_guard)
+        self.groups_api.delete(self.group.pulp_href)
+        del_user_rest(self.creator_user["pulp_href"])
+        del_user_rest(self.user_a["pulp_href"])
+        del_user_rest(self.user_b["pulp_href"])
 
-    def test_01_all_users_access(self):
+    def test_workflow(self):
+        self._all_users_access()
+        self._content_guard_creation()
+        self._only_creator_access()
+        self._add_users()
+        self._remove_users()
+        self._add_group()
+        self._remove_group()
+
+    def _all_users_access(self):
         """Sanity check that all users can access distribution with no content guard"""
-        self.assert_access(self.all_users)
+        self._assert_access(self.all_users)
 
-    def test_02_content_guard_creation(self):
+    def _content_guard_creation(self):
         """Checks that RBAC ContentGuard can be created and assigned to a distribution"""
         guard = self.creator_user["rbac_guard_api"].create({"name": self.distro.name})
         body = PatchedfileFileDistribution(content_guard=guard.pulp_href)
         monitor_task(self.distro_api.partial_update(self.distro.pulp_href, body).task)
-        RBACContentGuardTestCase.distro = self.distro_api.read(self.distro.pulp_href)
+        self.distro = self.distro_api.read(self.distro.pulp_href)
         self.assertEqual(guard.pulp_href, self.distro.content_guard)
 
-    def test_03_only_creator_access(self):
+    def _only_creator_access(self):
         """Checks that now only the creator and admin user can access the distribution"""
-        self.assert_access([self.creator_user, self.admin])
+        self._assert_access([self.creator_user, self.admin])
 
-    def test_04_add_users(self):
+    def _add_users(self):
         """Use the /add/ endpoint to give the users permission to access distribution"""
         body = {
             "users": (self.user_a["username"], self.user_b["username"]),
             "role": self.DOWNLOAD_ROLE,
         }
         self.creator_user["rbac_guard_api"].add_role(self.distro.content_guard, body)
-        self.assert_access([self.creator_user, self.user_b, self.user_a, self.admin])
+        self._assert_access([self.creator_user, self.user_b, self.user_a, self.admin])
 
-    def test_05_remove_users(self):
+    def _remove_users(self):
         """Use the /remove/ endpoint to remove users permission to access distribution"""
         body = {
             "users": (self.user_a["username"], self.user_b["username"]),
             "role": self.DOWNLOAD_ROLE,
         }
         self.creator_user["rbac_guard_api"].remove_role(self.distro.content_guard, body)
-        self.assert_access([self.creator_user, self.admin])
+        self._assert_access([self.creator_user, self.admin])
 
-    def test_06_add_group(self):
+    def _add_group(self):
         """Use the /add/ endpoint to add group"""
         body = {"groups": [self.group.name], "role": self.DOWNLOAD_ROLE}
         self.creator_user["rbac_guard_api"].add_role(self.distro.content_guard, body)
-        self.assert_access([self.creator_user, self.user_b, self.user_a, self.admin])
+        self._assert_access([self.creator_user, self.user_b, self.user_a, self.admin])
 
-    def test_07_remove_group(self):
+    def _remove_group(self):
         """Use the /remove/ endpoint to remove group"""
         body = {"groups": [self.group.name], "role": self.DOWNLOAD_ROLE}
         self.creator_user["rbac_guard_api"].remove_role(self.distro.content_guard, body)
-        self.assert_access([self.creator_user, self.admin])
+        self._assert_access([self.creator_user, self.admin])
 
-    def assert_access(self, auth_users):
+    def _assert_access(self, auth_users):
         """Helper for asserting functionality and correct permissions on the content guard"""
         for user in self.all_users:
             auth = (user["username"], user["password"]) if user else None

--- a/pulpcore/tests/functional/api/using_plugin/test_generic_list.py
+++ b/pulpcore/tests/functional/api/using_plugin/test_generic_list.py
@@ -3,7 +3,7 @@ import tempfile
 import unittest
 
 from pulp_smash import config, utils
-from pulp_smash.pulp3.bindings import delete_orphans, monitor_task
+from pulp_smash.pulp3.bindings import monitor_task
 from pulp_smash.pulp3.utils import gen_repo
 
 from pulpcore.tests.functional.api.using_plugin.constants import X509_CA_CERT_FILE_PATH
@@ -32,39 +32,41 @@ class GenericListTestCase(unittest.TestCase):
 
     @classmethod
     def setUpClass(cls):
-        """Create class-wide variables."""
         cls.cfg = config.get_config()
         cls.file_repositories_api = RepositoriesFileApi(
             FileApiClient(cls.cfg.get_bindings_config())
         )
-        cls.repo = cls.file_repositories_api.create(gen_repo())
-
         cls.file_content_api = ContentFilesApi(FileApiClient(cls.cfg.get_bindings_config()))
+        cls.cert_guards_api = ContentguardsX509Api(
+            CertGuardApiClient(cls.cfg.get_bindings_config())
+        )
+
+    def setUp(self):
+        self.repo = self.file_repositories_api.create(gen_repo())
         with tempfile.NamedTemporaryFile() as tmp_file:
             tmp_file.write(b"not empty")
             tmp_file.flush()
             monitor_task(
-                cls.file_content_api.create(relative_path=utils.uuid4(), file=tmp_file.name).task
+                self.file_content_api.create(relative_path=utils.uuid4(), file=tmp_file.name).task
             )
 
-        cls.cert_guards_api = ContentguardsX509Api(
-            CertGuardApiClient(cls.cfg.get_bindings_config())
-        )
         with open(X509_CA_CERT_FILE_PATH, "r") as x509_ca_cert_data_file:
             x509_ca_cert_data = x509_ca_cert_data_file.read()
 
-        cls.content_guard = cls.cert_guards_api.create(
+        self.content_guard = self.cert_guards_api.create(
             {"name": utils.uuid4(), "ca_certificate": x509_ca_cert_data}
         )
 
-    @classmethod
-    def tearDownClass(cls):
-        """Cleanup class-wide variables."""
-        monitor_task(cls.file_repositories_api.delete(cls.repo.pulp_href).task)
-        cls.cert_guards_api.delete(cls.content_guard.pulp_href)
-        delete_orphans()
+    def tearDown(self):
+        monitor_task(self.file_repositories_api.delete(self.repo.pulp_href).task)
+        self.cert_guards_api.delete(self.content_guard.pulp_href)
 
-    def test_read_all_repos_generic(self):
+    def test_read_generic_endpoints(self):
+        self._read_all_repos_generic()
+        self._read_all_content_generic()
+        self._read_all_content_guards_generic()
+
+    def _read_all_repos_generic(self):
         """Ensure name is displayed when listing repositories generic."""
         repositories_api = RepositoriesApi(CoreApiClient(self.cfg.get_bindings_config()))
 
@@ -73,7 +75,7 @@ class GenericListTestCase(unittest.TestCase):
         for repo in response.results:
             self.assertIsNotNone(repo.name)
 
-    def test_read_all_content_generic(self):
+    def _read_all_content_generic(self):
         """Ensure href is displayed when listing content generic."""
         content_api = ContentApi(CoreApiClient(self.cfg.get_bindings_config()))
 
@@ -82,7 +84,7 @@ class GenericListTestCase(unittest.TestCase):
         for content in response.results:
             self.assertIsNotNone(content.pulp_href)
 
-    def test_read_all_content_guards_generic(self):
+    def _read_all_content_guards_generic(self):
         """Ensure name is displayed when listing content guards generic."""
         content_guards_api = ContentguardsApi(CoreApiClient(self.cfg.get_bindings_config()))
 

--- a/pulpcore/tests/functional/api/using_plugin/test_repo_versions.py
+++ b/pulpcore/tests/functional/api/using_plugin/test_repo_versions.py
@@ -64,7 +64,6 @@ from pulpcore.tests.functional.api.using_plugin.utils import (
     populate_pulp,
 )
 from pulpcore.tests.functional.api.using_plugin.utils import set_up_module as setUpModule  # noqa
-from pulpcore.tests.functional.api.using_plugin.utils import skip_if
 
 
 def remove_created_key(dic):
@@ -80,32 +79,31 @@ class AddRemoveContentTestCase(unittest.TestCase):
     inspect any repository version and discover which content is present, which
     content was removed, and which content was added. This test case explores
     these features.
-
-    This test targets the following issues:
-
-    * `Pulp #3059 <https://pulp.plan.io/issues/3059>`_
-    * `Pulp #3234 <https://pulp.plan.io/issues/3234>`_
-    * `Pulp Smash #878 <https://github.com/pulp/pulp-smash/issues/878>`_
     """
 
     @classmethod
     def setUpClass(cls):
-        """Create class-wide variables."""
         cls.cfg = config.get_config()
         cls.client = api.Client(cls.cfg, api.page_handler)
-        cls.remote = {}
-        cls.repo = {}
-        cls.content = {}
 
-    @classmethod
-    def tearDownClass(cls):
-        """Destroy resources created by test methods."""
-        if cls.remote:
-            cls.client.delete(cls.remote["pulp_href"])
-        if cls.repo:
-            cls.client.delete(cls.repo["pulp_href"])
+    def setUp(self):
+        self.remote = {}
+        self.repo = {}
+        self.content = {}
 
-    def test_01_create_repository(self):
+    def tearDown(self):
+        if self.remote:
+            self.client.delete(self.remote["pulp_href"])
+        if self.repo:
+            self.client.delete(self.repo["pulp_href"])
+
+    def test_workflow(self):
+        self._create_repository()
+        self._sync_content()
+        self._remove_content()
+        self._add_content()
+
+    def _create_repository(self):
         """Create a repository.
 
         Assert that:
@@ -120,8 +118,7 @@ class AddRemoveContentTestCase(unittest.TestCase):
 
         self.assertEqual(self.repo["latest_version_href"], f"{self.repo['pulp_href']}versions/0/")
 
-    @skip_if(bool, "repo", False)
-    def test_02_sync_content(self):
+    def _sync_content(self):
         """Sync content into the repository.
 
         Assert that:
@@ -167,8 +164,7 @@ class AddRemoveContentTestCase(unittest.TestCase):
         content_removed_summary = get_removed_content_summary(repo)
         self.assertDictEqual(content_removed_summary, {})
 
-    @skip_if(bool, "repo", False)
-    def test_03_remove_content(self):
+    def _remove_content(self):
         """Remove content from the repository.
 
         Make roughly the same assertions as :meth:`test_02_sync_content`.
@@ -205,8 +201,7 @@ class AddRemoveContentTestCase(unittest.TestCase):
         content_removed_summary = get_removed_content_summary(repo)
         self.assertDictEqual(content_removed_summary, {FILE_CONTENT_NAME: 1})
 
-    @skip_if(bool, "repo", False)
-    def test_04_add_content(self):
+    def _add_content(self):
         """Add content to the repository.
 
         Make roughly the same assertions as :meth:`test_02_sync_content`.

--- a/pulpcore/tests/functional/api/using_plugin/test_sync.py
+++ b/pulpcore/tests/functional/api/using_plugin/test_sync.py
@@ -155,6 +155,7 @@ def test_header_for_sync(
     file_repo,
     file_repo_api_client,
     content_file_api_client,
+    gen_object_with_cleanup,
 ):
     """
     Test file sync will correctly submit header data during download when configured.
@@ -166,15 +167,14 @@ def test_header_for_sync(
     header_value = str(uuid.uuid4())
     headers = [{header_name: header_value}]
 
-    remote_on_demand = file_remote_api_client.create(
-        {
-            "url": str(url),
-            "policy": "on_demand",
-            "name": str(uuid.uuid4()),
-            "ca_cert": tls_certificate_authority_cert,
-            "headers": headers,
-        }
-    )
+    remote_on_demand_data = {
+        "url": str(url),
+        "policy": "on_demand",
+        "name": str(uuid.uuid4()),
+        "ca_cert": tls_certificate_authority_cert,
+        "headers": headers,
+    }
+    remote_on_demand = gen_object_with_cleanup(file_remote_api_client, remote_on_demand_data)
 
     _run_basic_sync_and_assert(
         remote_on_demand, file_repo, file_repo_api_client, content_file_api_client

--- a/pulpcore/tests/functional/api/using_plugin/test_tasking.py
+++ b/pulpcore/tests/functional/api/using_plugin/test_tasking.py
@@ -97,6 +97,7 @@ class CancelTaskTestCase(unittest.TestCase):
 
     def test_cancel_finished_task(self):
         repo = self.client.post(FILE_REPO_PATH, gen_repo())
+        self.addCleanup(self.client.delete, repo["pulp_href"])
         repo["name"] = utils.uuid4()
         task_href = self.client.patch(repo["pulp_href"], json=repo)
         with self.assertRaises(HTTPError) as ctx:

--- a/pulpcore/tests/functional/api/using_plugin/test_tasks.py
+++ b/pulpcore/tests/functional/api/using_plugin/test_tasks.py
@@ -173,39 +173,29 @@ class FilterTaskCreatedResourcesTestCase(unittest.TestCase):
 
 
 class FilterTaskResourcesTestCase(unittest.TestCase):
-    """Perform filtering over reserved resources.
-
-    This test targets the following issue:
-    * `Pulp #5120 <https://pulp.plan.io/issues/5120>`_
-
-    Perform filtering for contents of created resources.
-
-    This test targets the following issue:
-    * `Pulp #4931 <https://pulp.plan.io/issues/4931>`_
-    """
+    """Perform filtering of reserved resources and the contents of created resources."""
 
     @classmethod
     def setUpClass(cls):
-        """Create class-wide variables."""
         cls.cfg = config.get_config()
         cls.client = api.Client(cls.cfg, api.page_handler)
-        cls.remote = cls.client.post(FILE_REMOTE_PATH, gen_file_remote())
-        cls.repository = cls.client.post(FILE_REPO_PATH, gen_repo())
-        response = sync(cls.cfg, cls.remote, cls.repository)
-        cls.created_repo_version = response["pulp_href"]
-        cls.repository = cls.client.get(cls.repository["pulp_href"])
-        for file_content in get_content(cls.repository)[FILE_CONTENT_NAME]:
-            modify_repo(cls.cfg, cls.repository, remove_units=[file_content])
-        attrs = {"description": utils.uuid4()}
-        response = cls.client.patch(cls.repository["pulp_href"], attrs)
-        cls.repo_update_task = cls.client.get(response["task"])
 
-    @classmethod
-    def tearDownClass(cls):
-        """Clean created resources."""
-        cls.client.delete(cls.repository["pulp_href"])
-        cls.client.delete(cls.remote["pulp_href"])
-        cls.client.delete(cls.repo_update_task["pulp_href"])
+    def setUp(self):
+        self.remote = self.client.post(FILE_REMOTE_PATH, gen_file_remote())
+        self.repository = self.client.post(FILE_REPO_PATH, gen_repo())
+        response = sync(self.cfg, self.remote, self.repository)
+        self.created_repo_version = response["pulp_href"]
+        self.repository = self.client.get(self.repository["pulp_href"])
+        for file_content in get_content(self.repository)[FILE_CONTENT_NAME]:
+            modify_repo(self.cfg, self.repository, remove_units=[file_content])
+        attrs = {"description": utils.uuid4()}
+        response = self.client.patch(self.repository["pulp_href"], attrs)
+        self.repo_update_task = self.client.get(response["task"])
+
+    def tearDown(self):
+        self.client.delete(self.repository["pulp_href"])
+        self.client.delete(self.remote["pulp_href"])
+        self.client.delete(self.repo_update_task["pulp_href"])
 
     def test_01_filter_tasks_by_reserved_resources(self):
         """Filter all tasks by a particular reserved resource."""


### PR DESCRIPTION
To avoid errors the pulpcore tests have been updated to leave to objects
except FileContent and Tasks behind. Also all tests are now independant.

[noissue]
