### PR TITLE
Fixed rare bulk_update() deadlock in ContentSaver.

### DIFF
--- a/CHANGES/2430.bugfix
+++ b/CHANGES/2430.bugfix
@@ -1,0 +1,1 @@
+Fixed a (rare) deadlock around bulk_update() during syncs with overlapping content.


### PR DESCRIPTION
See https://bugzilla.redhat.com/show_bug.cgi?id=2062526 for details on
forcing the deadlock and discussion of the fix.

fixes #2430.
[nocoverage]

(cherry picked from commit 0238741f707c4f2c7d702e2ac221c1f73df6cd60)

