### PR TITLE
Update RBAC guide for plugin writers

### DIFF
--- a/CHANGES/plugin_api/2463.doc
+++ b/CHANGES/plugin_api/2463.doc
@@ -1,0 +1,2 @@
+Updated plugin writers RBAC guide to explain more roles and less permissions. Removed mentions of
+django-guardian.

--- a/docs/plugins/plugin-writer/concepts/rbac/access_policy.rst
+++ b/docs/plugins/plugin-writer/concepts/rbac/access_policy.rst
@@ -83,17 +83,16 @@ authorized.
 
     The ``admin`` user created on installations prior to RBAC being enabled has
     ``is_superuser=True``. Django assumes a superuser has any model-level permission even without it
-    being assigned. Additionally, django-guardian when checking object-level permissions defaults to
-    assuming the same although it is configurable. Generally, superusers are expected to bypass
-    authorization checks.
+    being assigned. Django's permission checking machinery assumes superusers bypass authorization
+    checks.
 
 
 Custom ViewSet Actions
 ----------------------
 
 The ``action`` part of a policy statement can reference `any custom action your viewset has
-<https://www.django-rest-framework.org/api-guide/viewsets/#marking-extra-actions-for-routing>`_. For
-example ``FileRepositoryViewSet`` has a ``sync`` custom action used by users to sync a given
+<https://www.django-rest-framework.org/api-guide/viewsets/#marking-extra-actions-for-routing>`_.
+For example ``FileRepositoryViewSet`` has a ``sync`` custom action used by users to sync a given
 ``FileRepository``. Below is an example of the default policy used to guard that action::
 
     {
@@ -198,9 +197,9 @@ For an explanation of the ``creation_hooks`` see the
 
 The attribute ``LOCKED_ROLES`` contains roles that are managed by the plugin author. Their name
 needs to be prefixed by the plugins ``app_label`` with a dot to prevent collisions. Roles defined
-there will be replicated and updated in the database after every migration. They are also
-marked ``locked=True`` to prevent being modified by users. The primary purpose of these roles is to
-allow plugin writers to refer to them in the default access policy.
+there will be replicated and updated in the database after every migration. They are also marked
+``locked=True`` to prevent being modified by users. The primary purpose of these roles is to allow
+plugin writers to refer to them in the default access policy.
 
 
 .. _handling_objects_created_prior_to_RBAC:
@@ -235,3 +234,42 @@ different Permission check by declaring the ``permission_classes`` check. For ex
         ...
         permission_classes = tuple()
         ...
+
+
+.. _permission_checking_machinery:
+
+Permission Checking Machinery
+-----------------------------
+
+drf-access-policy provides a feature to enable conditional checks to be globally available as their
+docs `describe here <https://rsinger86.github.io/ drf-access-policy/reusable_conditions/>`_. Pulp
+enables the ``reusable_conditions`` in its settings.py file, allowing a variety of condition checks
+to be globally available. Pulp enables this as follows:
+
+.. code-block:: python
+
+    DRF_ACCESS_POLICY = {"reusable_conditions": ["pulpcore.app.global_access_conditions"]}
+
+The ``pulpcore.app.global_access_conditions`` provides the following checks that are available for
+both users and plugin writers to use in their policies:
+
+.. automodule:: pulpcore.app.global_access_conditions
+   :members:
+
+
+.. _custom_permission_checks:
+
+Custom Permission Checks
+------------------------
+
+Plugins can provide their own permission checks by defining them in a
+``app.global_access_conditions`` module and adding an operation like
+
+.. code-block:: python
+
+    DRF_ACCESS_POLICY = {
+        "dynaconf_merge_unique": True,
+        "reusable_conditions": ["pulp_container.app.global_access_conditions"],
+    }
+
+to their ``app.settings`` module.

--- a/docs/plugins/plugin-writer/concepts/rbac/adding_automatic_permissions.rst
+++ b/docs/plugins/plugin-writer/concepts/rbac/adding_automatic_permissions.rst
@@ -57,7 +57,7 @@ example assigning the ``"core.task_viewer"`` role to the group ``"foo"``.
 .. code-block:: python
 
     {
-        "function": "add_for_groups",
+        "function": "add_roles_for_groups",
         "parameters": {
             "roles": ["core.task_viewer"],
             "groups": "foo",

--- a/docs/plugins/plugin-writer/concepts/rbac/queryset_scoping.rst
+++ b/docs/plugins/plugin-writer/concepts/rbac/queryset_scoping.rst
@@ -41,8 +41,7 @@ like more control over the QuerySet Scoping feature it can be added manually by 
 ``get_queryset`` method to your ViewSet which returns the filtered QuerySet.
 
 To look up objects by permission easily from an existing QuerySet use the ``get_objects_for_user``
-provided by pulpcore or django-guardian. Here's an example where all items are displayed accessible
-via either of the permission frameworks:
+provided by pulpcore. Here's an example:
 
 .. code-block:: python
 

--- a/docs/plugins/plugin-writer/concepts/rbac/users_groups.rst
+++ b/docs/plugins/plugin-writer/concepts/rbac/users_groups.rst
@@ -3,11 +3,12 @@
 Users and Groups
 ================
 
-Users and Groups is always stored in the Django database. This is a requirement so that
-``Roles`` or ``Permissions`` can relate to them.
+Users and Groups are always stored in the Django database. This is a requirement so that ``Roles`` and
+``Permissions`` can relate to them.
 
 :User: Provided by Django with the ``django.contrib.auth.models.User`` model.
 :Group: Provided by Django with the ``django.contrib.auth.models.Group`` model.
 
-Any role or permission can be assigned to either users, groups, or both. This includes both
-Model-level and Object-level roles as well as permissions.
+Any role can be assigned to either users, groups, or both. This includes both Model-level and
+Object-level role assignments. Direct permission assignments are not recommended and cannot be
+operated on within the Pulp-API.


### PR DESCRIPTION
Explain the concept of roles, their relationship to permissions, how
they are associated with personas and objects and also remove any
mention of django-guardian that is to be removed in 3.20.

fixes #2463
