### PR TITLE
Add error reason for accessing distribution w/o publication

### DIFF
--- a/CHANGES/1910.bugfix
+++ b/CHANGES/1910.bugfix
@@ -1,0 +1,1 @@
+Added reason for 404 error when accessing distributions without a publication.

--- a/pulpcore/content/handler.py
+++ b/pulpcore/content/handler.py
@@ -623,7 +623,7 @@ class Handler:
                     request, StreamResponse(headers=headers), ra
                 )
 
-        raise PathNotResolved(path)
+        raise PathNotResolved(path, reason=_("Distribution is not pointing to a publication."))
 
     async def _stream_content_artifact(self, request, response, content_artifact):
         """


### PR DESCRIPTION
fixes: #1910

Working on a couple content app user improvements for 3.20. This one is the simplest change, but maybe the issue wanted something more explicit for this scenario.