### PR TITLE
[3.16]  Fixed "Too many open files" error during upload. 

### DIFF
--- a/CHANGES/2087.bugfix
+++ b/CHANGES/2087.bugfix
@@ -1,0 +1,1 @@
+Fixed file descriptior leak during upload.

--- a/pulpcore/app/importexport.py
+++ b/pulpcore/app/importexport.py
@@ -108,6 +108,7 @@ def export_artifacts(export, artifacts):
                     with tempfile.NamedTemporaryFile(dir=temp_dir) as temp_file:
                         temp_file.write(artifact.file.read())
                         temp_file.flush()
+                        artifact.file.close()
                         export.tarfile.add(temp_file.name, dest)
             else:
                 export.tarfile.add(artifact.file.path, dest)

--- a/pulpcore/app/tasks/upload.py
+++ b/pulpcore/app/tasks/upload.py
@@ -29,6 +29,7 @@ def commit(upload_id, sha256):
     with NamedTemporaryFile("ab") as temp_file:
         for chunk in chunks:
             temp_file.write(chunk.file.read())
+            chunk.file.close()
         temp_file.flush()
 
         file = files.PulpTemporaryUploadedFile.from_file(File(open(temp_file.name, "rb")))


### PR DESCRIPTION
Please be sure you have read our documentation on creating PRs:
https://docs.pulpproject.org/contributing/pull-request-walkthrough.html
