### PR TITLE
[3.15]  Fixed "Too many open files" error during upload. 

### DIFF
--- a/CHANGES/2087.bugfix
+++ b/CHANGES/2087.bugfix
@@ -1,0 +1,1 @@
+Fixed file descriptior leak during upload.

--- a/pulpcore/app/importexport.py
+++ b/pulpcore/app/importexport.py
@@ -83,6 +83,7 @@ def export_artifacts(export, artifacts):
                     with tempfile.NamedTemporaryFile(dir=temp_dir) as temp_file:
                         temp_file.write(artifact.file.read())
                         temp_file.flush()
+                        artifact.file.close()
                         export.tarfile.add(temp_file.name, dest)
             else:
                 export.tarfile.add(artifact.file.path, dest)

--- a/pulpcore/app/tasks/upload.py
+++ b/pulpcore/app/tasks/upload.py
@@ -29,6 +29,7 @@ def commit(upload_id, sha256):
     with NamedTemporaryFile("ab") as temp_file:
         for chunk in chunks:
             temp_file.write(chunk.file.read())
+            chunk.file.close()
         temp_file.flush()
 
         file = files.PulpTemporaryUploadedFile.from_file(File(open(temp_file.name, "rb")))


### PR DESCRIPTION
closes #2087
(cherry picked from commit dcbf935)
(cherry picked from commit 3fb0e5cd270ce71c722d9a6d8669bf44aac61c45)
