### PR TITLE
Update CI + upper bound check

### DIFF
--- a/.ci/scripts/update_ci_branches.py
+++ b/.ci/scripts/update_ci_branches.py
@@ -25,10 +25,10 @@ if not initial_branch or initial_branch not in branches:
 else:
     starting = branches.index(initial_branch)
 
+github_api = "https://api.github.com"
+workflow_path = "/actions/workflows/update_ci.yml/dispatches"
+url = f"{github_api}/repos/pulp/pulpcore{workflow_path}"
+
 for branch in branches[starting:]:
     print(f"Updating {branch}")
-    requests.post(
-        "https://api.github.com/repos/pulp/pulpcore/actions/workflows/update_ci.yml/dispatches",
-        headers=headers,
-        json={"ref": branch},
-    )
+    requests.post(url, headers=headers, json={"ref": branch})

--- a/.ci/scripts/upper_bound.py
+++ b/.ci/scripts/upper_bound.py
@@ -1,0 +1,12 @@
+from pkg_resources import Requirement
+
+packages = []
+with open("requirements.txt", "r") as fd:
+    for line in fd.readlines():
+        req = Requirement.parse(line)
+        if len(req.specs) < 2 and "~=" not in str(req.specs) and "==" not in str(req.specs):
+            packages.append(req.name)
+if packages:
+    raise RuntimeError(
+        "The following packages are missing upper bound: {}".format(", ".join(packages))
+    )

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -57,6 +57,9 @@ jobs:
         env:
           SECRETS_CONTEXT: ${{ toJson(secrets) }}
 
+      - name: Verify upper bound requirements
+        run: python .ci/scripts/upper_bound.py
+
       - name: Create the release commit, tag it, create a post-release commit, and build plugin package
         run: python .github/workflows/scripts/release.py ${{ github.event.inputs.release }}
 

--- a/.github/workflows/scripts/script.sh
+++ b/.github/workflows/scripts/script.sh
@@ -29,6 +29,10 @@ export PULP_SETTINGS=$PWD/.ci/ansible/settings/settings.py
 export PULP_URL="https://pulp"
 
 if [[ "$TEST" = "docs" ]]; then
+  if [[ "$GITHUB_WORKFLOW" == "Pulpcore CI" ]]; then
+    pip install towncrier==19.9.0
+    towncrier --yes --version 4.0.0.ci
+  fi
   cd docs
   make PULP_URL="$PULP_URL" diagrams html
   tar -cvf docs.tar ./_build


### PR DESCRIPTION
```python
pulpcore on  main [$] via 🐍 v3.10.0 (venv) took 24m31s 
❯ ipython
Python 3.10.0 (default, Dec  2 2021, 14:45:52) [GCC 11.2.1 20210728 (Red Hat 11.2.1-1)]
Type 'copyright', 'credits' or 'license' for more information
IPython 7.30.1 -- An enhanced Interactive Python. Type '?' for help.

In [1]: from pkg_resources import Requirement
   ...: 
   ...: packages = []
   ...: with open("requirements.txt", "r") as fd:
   ...:     for line in fd.readlines():
   ...:         req = Requirement.parse(line)
   ...:         if len(req.specs) < 2 and "~=" not in str(req.specs) and "==" not in str(req.specs):
   ...:             packages.append(req.name)
   ...: if packages:
   ...:     raise RuntimeError("The following packages are missing upper bound: {}".format(", ".join(packages)))
   ...: 
---------------------------------------------------------------------------
RuntimeError                              Traceback (most recent call last)
<ipython-input-1-4efaaf3e0e8b> in <module>
     10             packages.append(req.name)
     11 if packages:
---> 12     raise RuntimeError("The following packages are missing upper bound: {}".format(", ".join(packages)))

RuntimeError: The following packages are missing upper bound: click, jinja2, redis, setuptools, yarl
```