### PR TITLE
Fix does_batch for resolved content

### DIFF
--- a/CHANGES/2557.bugfix
+++ b/CHANGES/2557.bugfix
@@ -1,0 +1,1 @@
+Fixed `does_batch` method in sync pipeline to allow waiting on content that is already resolved.

--- a/pulpcore/plugin/stages/models.py
+++ b/pulpcore/plugin/stages/models.py
@@ -136,7 +136,7 @@ class DeclarativeContent:
         """Whether this content is being awaited on and must therefore not wait forever in batches.
         When overwritten in subclasses, a `True` value must never be turned into `False`.
         """
-        return not self._resolved and self._future is None
+        return self._resolved or self._future is None
 
     async def resolution(self):
         """Coroutine that waits for the content to be saved to database.


### PR DESCRIPTION
This bug lead to serious sync performance degredation in some plugins,
because batching was de facto disabled for the ContentAssociation stage.

fixes #2557