### PR TITLE
Removes pulpcore.plugin.constants.API_ROOT

### DIFF
--- a/CHANGES/plugin_api/2556.removal
+++ b/CHANGES/plugin_api/2556.removal
@@ -1,0 +1,2 @@
+The pulpcore.plugin.constants.API_ROOT has been removed. Use the ``V3_API_ROOT`` and
+``V3_API_ROOT_NO_FRONT_SLASH`` settings instead.

--- a/pulpcore/plugin/constants.py
+++ b/pulpcore/plugin/constants.py
@@ -6,16 +6,3 @@ from pulpcore.constants import (  # noqa
     TASK_CHOICES,
     TASK_FINAL_STATES,
 )
-
-
-@property
-def API_ROOT():
-    from django.conf import settings
-    from pulpcore.app.loggers import deprecation_logger
-
-    deprecation_logger.warn(
-        "The API_ROOT constant has been deprecated and turned into a setting. Please use "
-        "`settings.V3_API_ROOT_NO_FRONT_SLASH` instead. This symbol will be deleted with pulpcore "
-        "3.20."
-    )
-    return settings.V3_API_ROOT_NO_FRONT_SLASH


### PR DESCRIPTION
Plugin writers should use the `V3_API_ROOT` or
`V3_API_ROOT_NO_FRONT_SLASH` settings instead.

closes #2556
