### PR TITLE
Taught PulpImport how to stream import-files.

### DIFF
--- a/CHANGES/2307.bugfix
+++ b/CHANGES/2307.bugfix
@@ -1,0 +1,4 @@
+Taught PulpImport to stream imports rather than reading files into memory in one chunk.
+
+This largely alleviates the memory-pressure that results from importing multiple
+large repositories in parallel.

--- a/requirements.txt
+++ b/requirements.txt
@@ -21,6 +21,7 @@ drf-spectacular==0.22.1
 dynaconf~=3.1.8
 gunicorn~=20.1.0
 jinja2~=3.1
+naya~=1.1.1
 pygtrie~=2.4.2
 psycopg2~=2.9.3
 PyYAML>=5.1.1,<6.1.0


### PR DESCRIPTION
This lets us limit the amount of memory being used at import-time. It's
especially important in the presence of large imports of large entities
(e.g., "RHEL7 Package resources").

Test-coverage is provided by the existing test_pulpimport - this change
is completely "under the covers".

fixes #2307.
[nocoverage]

