### PR TITLE
Ensure download has fresh file on retry

### DIFF
--- a/CHANGES/2576.bugfix
+++ b/CHANGES/2576.bugfix
@@ -1,0 +1,1 @@
+Ensure downloader resets file on retry.

--- a/pulpcore/download/http.py
+++ b/pulpcore/download/http.py
@@ -272,6 +272,7 @@ class HttpDownloader(BaseDownloader):
         Args:
             extra_data (dict): Extra data passed by the downloader.
         """
+        self._ensure_fresh_file()
         if self.download_throttler:
             await self.download_throttler.acquire()
         async with self.session.get(
@@ -283,3 +284,10 @@ class HttpDownloader(BaseDownloader):
         if self._close_session_on_finalize:
             await self.session.close()
         return to_return
+
+    def _ensure_fresh_file(self):
+        """Upon retry reset writer back to None to get a fresh file."""
+        if self._writer is not None:
+            self._writer.delete = True
+            self._writer.close()
+            self._writer = None


### PR DESCRIPTION
[noissue]

Not sure if this has an issue already or not. Related to https://issues.redhat.com/browse/AAH-1202 and test found in: https://github.com/pulp/pulp_file/pull/689

Our downloaders really need to be refactored and will be (https://discourse.pulpproject.org/t/downloader-refactor-sig/393/4), so not sure how useful this fix is. Also, I only fixed this on the http downloader, base and file are unaffected, and if any other downloaders override the `_run` method then this fix won't occur.