### PR TITLE
Add more details to an error message

### DIFF
--- a/CHANGES/2550.feature
+++ b/CHANGES/2550.feature
@@ -1,0 +1,2 @@
+Added more details to an error message that is shown when none of the allowed content checksums
+hashers could be used.

--- a/pulpcore/download/base.py
+++ b/pulpcore/download/base.py
@@ -102,9 +102,10 @@ class BaseDownloader:
             if not set(self.expected_digests).intersection(set(Artifact.DIGEST_FIELDS)):
                 raise UnsupportedDigestValidationError(
                     _(
-                        "Content at the url {} does not contain at least one trusted hasher which"
-                        " is specified in 'ALLOWED_CONTENT_CHECKSUMS' setting."
-                    ).format(self.url)
+                        "Content at the URL '{}' does not contain at least one trusted hasher which"
+                        " is specified in the 'ALLOWED_CONTENT_CHECKSUMS' setting ({}). The"
+                        " downloader expected one of the following hashers: {}"
+                    ).format(self.url, Artifact.DIGEST_FIELDS, set(self.expected_digests))
                 )
 
     def _ensure_writer_has_open_file(self):


### PR DESCRIPTION
After applying the changes, an error message looks like this:
```
Content at the URL 'https://fixtures.pulpproject.org/file/1.iso' does not contain at least one trusted hasher which is specified in the 'ALLOWED_CONTENT_CHECKSUMS' setting (['sha512', 'sha224]). The downloader expected one of the following hashers: {'sha256'}
```

closes #2550