### PR TITLE
Removed an outdated deprecation warning

### DIFF
--- a/CHANGES/plugin_api/2634.misc
+++ b/CHANGES/plugin_api/2634.misc
@@ -1,0 +1,2 @@
+Removed the deprecation warning logged if plugin writers had set the `ACCESS_POLICY_VIEWSET_NAME`
+attribute on a model.

--- a/pulpcore/app/models/base.py
+++ b/pulpcore/app/models/base.py
@@ -8,8 +8,6 @@ from django.db.models import options
 from django.db.models.base import ModelBase
 from django_lifecycle import LifecycleModel
 
-from pulpcore.app.loggers import deprecation_logger
-
 
 class Label(LifecycleModel):
     """Model for handling resource labels.
@@ -68,14 +66,6 @@ class BaseModel(LifecycleModel):
 
     class Meta:
         abstract = True
-
-    def __init__(self, *args, **kwargs):
-        if hasattr(self, "ACCESS_POLICY_VIEWSET_NAME"):
-            deprecation_logger.warn(
-                f"The model {self.__class__} defines the 'ACCESS_POLICY_VIEWSET_NAME' class "
-                f"attribute which is no longer required and is discouraged to be set."
-            )
-        return super().__init__(*args, **kwargs)
 
     def __str__(self):
         try:


### PR DESCRIPTION
If plugin writers had set the `ACCESS_POLICY_VIEWSET_NAME` attribute on
a model they would receive a deprecation warning. That's an old warning
and it is now removed.

closes #2634

