### PR TITLE
Enable admins to specify a custom GnuPG directory or keyring

### DIFF
--- a/CHANGES/2476.feature
+++ b/CHANGES/2476.feature
@@ -1,0 +1,3 @@
+Enabled administrators to work with a customized GnuPG home directory and keyring during the
+creation of a signing service. The introduced optional arguments ``--gnupghome`` and ``--keyring``
+are available under the ``pulpcore-manager add-signing-service`` command.

--- a/CHANGES/plugin_api/2476.feature
+++ b/CHANGES/plugin_api/2476.feature
@@ -1,0 +1,2 @@
+Exposed the function ``pulpcore.plugin.util.verify_signature`` for verifying signatures created
+by signing services.

--- a/docs/workflows/signed-metadata.rst
+++ b/docs/workflows/signed-metadata.rst
@@ -61,34 +61,24 @@ The example below demonstrates how a signing service can be created using ``gpg`
        Make sure the script contains a proper shebang and Pulp has got valid permissions
        to execute it.
 
-3. Create a signing service consisting of an absolute path to the script and a meaningful
-   name describing the script's purpose. It is possible to insert the signing service in
-   to a database by using the ``pulpcore-manager shell_plus`` interactive Python shell. Here is an
-   example showing how to create one instance pointing to a script:
+3. Create a signing service consisting of an absolute path to the script, a meaningful
+   name describing the script's purpose, and the identity identifying the key for signing. The
+   script must be executable. Here is an example showing how to create one instance of a signing
+   service:
 
-   .. code-block:: python
+   .. code-block:: bash
 
-       from pulpcore.app.models.content import AsciiArmoredDetachedSigningService
-
-       # read an already exported public key
-       with open("public.key") as key:
-           AsciiArmoredDetachedSigningService.objects.create(
-               name="sign-metadata",
-               public_key=key.read(),
-               pubkey_fingerprint="19CD52BD1CA9A00DF10A842D74B14E3590C2231F",
-               script="/var/lib/pulp/scripts/sign-metadata.sh",
-           )
+        pulpcore-manager add-signing-service ${SERVICE_NAME} ${SCRIPT_ABS_FILENAME} ${KEYID}
 
    .. note::
 
-       While creating a signing service, the model ``AsciiArmoredDetachedSigningService``
-       runs additional checks in order to prevent saving invalid scripts to the database.
-       This feature enables administrators to validate their signing scripts in advance.
+      The public key must be available on the caller's keyring or on a keyring provided via the
+      ``--gpghome`` or ``--keyring`` parameters.
 
-   .. note::
+   .. warning::
 
-      You can use `pulpcore-manager add-signing-service` to add a ``SigningService``.
-      This command is however still in tech-preview.
+      It is possible to insert a new signing service into the database by using the
+      ``pulpcore-manager shell_plus`` interactive Python shell. However, this is not recommended.
 
 4. Retrieve and check the saved signing service via REST API::
 

--- a/pulpcore/app/management/commands/add-signing-service.py
+++ b/pulpcore/app/management/commands/add-signing-service.py
@@ -1,4 +1,7 @@
+import os
+
 import gnupg
+
 from pathlib import Path
 
 from gettext import gettext as _
@@ -37,6 +40,17 @@ class Command(BaseCommand):
             required=False,
             help=_("Signing service class prefixed by the app label separated by a colon."),
         )
+        parser.add_argument(
+            "--gnupghome",
+            default=os.getenv("GNUPGHOME", ""),
+            required=False,
+            help=_("A default GnuPG home directory to use during the initialization."),
+        )
+        parser.add_argument(
+            "--keyring",
+            required=False,
+            help=_("The name of the keyring file."),
+        )
 
     def handle(self, *args, **options):
         name = options["name"]
@@ -52,7 +66,8 @@ class Command(BaseCommand):
         except LookupError as e:
             raise CommandError(str(e))
 
-        gpg = gnupg.GPG()
+        gpg = gnupg.GPG(gnupghome=options["gnupghome"], keyring=options["keyring"])
+
         key_list = gpg.list_keys(keys=[key_id])
         if not len(key_list) == 1:
             raise CommandError(_("There are {} keys matching the key id.").format(len(key_list)))

--- a/pulpcore/exceptions/__init__.py
+++ b/pulpcore/exceptions/__init__.py
@@ -7,6 +7,7 @@ from .base import (  # noqa
 )
 from .validation import (  # noqa
     DigestValidationError,
+    InvalidSignatureError,
     SizeValidationError,
     ValidationError,
     MissingDigestValidationError,

--- a/pulpcore/exceptions/validation.py
+++ b/pulpcore/exceptions/validation.py
@@ -75,3 +75,11 @@ class UnsupportedDigestValidationError(Exception):
     """
 
     pass
+
+
+class InvalidSignatureError(RuntimeError):
+    """
+    Raised when a signature could not be verified by the GnuPG utility.
+    """
+
+    pass

--- a/pulpcore/plugin/exceptions.py
+++ b/pulpcore/plugin/exceptions.py
@@ -1,5 +1,6 @@
 from pulpcore.exceptions import (  # noqa
     DigestValidationError,
+    InvalidSignatureError,
     PulpException,
     SizeValidationError,
     MissingDigestValidationError,

--- a/pulpcore/plugin/util.py
+++ b/pulpcore/plugin/util.py
@@ -11,3 +11,5 @@ from pulpcore.app.role_util import (  # noqa
     get_users_with_perms_attached_roles,
     remove_role,
 )
+
+from pulpcore.app.util import verify_signature  # noqa


### PR DESCRIPTION
In this commit, the validation procedure triggered before saving signing services was refactored. As of this commit, users will no longer experience problems with missing keys or improperly configured GnuPG home directory. Public keys are imported to a temporary GnuPG directory where everything is correctly staged for validation purposes.

Also, redundant validation checks in the AsciiArmoredDetached's validate() method were removed as well.

closes https://github.com/pulp/pulpcore/issues/2476