### PR TITLE
Improved the error message when HTTP proxies reject requests from Pulp.

### DIFF
--- a/CHANGES/2654.bugfix
+++ b/CHANGES/2654.bugfix
@@ -1,0 +1,1 @@
+Improved the error message when HTTP proxies reject requests from Pulp.

--- a/pulpcore/download/http.py
+++ b/pulpcore/download/http.py
@@ -256,6 +256,17 @@ class HttpDownloader(BaseDownloader):
                     return await self._run(extra_data=extra_data)
                 except asyncio.TimeoutError:
                     raise TimeoutException(self.url)
+                except aiohttp.ClientHttpProxyError as e:
+                    log.error(
+                        "Proxy {!r} rejected connection request during a request to "
+                        "{!r}, status={}, message={!r}".format(
+                            e.request_info.real_url,
+                            e.request_info.url,
+                            e.status,
+                            e.message,
+                        )
+                    )
+                    raise e
 
             return await download_wrapper()
 


### PR DESCRIPTION
closes #2654

Please be sure you have read our documentation on creating PRs:
https://docs.pulpproject.org/contributing/pull-request-walkthrough.html
