### PR TITLE
Replaces "//" with "/" in base_url.

### DIFF
--- a/CHANGES/2553.bugfix
+++ b/CHANGES/2553.bugfix
@@ -1,0 +1,1 @@
+Replaced "//" with "/" in base_url when CONTENT_PATH_PREFIX is "" or "/".

--- a/pulpcore/app/serializers/fields.py
+++ b/pulpcore/app/serializers/fields.py
@@ -1,6 +1,7 @@
 import os
 import re
 from gettext import gettext as _
+from urllib.parse import urljoin
 
 from django.conf import settings
 from rest_framework import serializers
@@ -285,7 +286,7 @@ class BaseURLField(serializers.CharField):
         prefix = settings.CONTENT_PATH_PREFIX.strip("/")
         base_path = value.strip("/")
 
-        return "/".join((origin, prefix, base_path)) + "/"
+        return urljoin(urljoin(origin, prefix + "/"), base_path + "/")
 
 
 class ExportsIdentityFromExporterField(DetailIdentityField):


### PR DESCRIPTION
This bug would appear when CONTENT_PATH_PREFIX was set to "" or "/".

fixes: #2553
