### PR TITLE
Create missing repositories automatically on import

### DIFF
--- a/CHANGES/1920.feature
+++ b/CHANGES/1920.feature
@@ -1,0 +1,3 @@
+Added an option for automatically creating repositories on the fly during an import procedure. The
+option is disabled by default. Enable it by setting the field ``create_repositories`` to ``True``
+via the REST API.

--- a/CHANGES/plugin_api/1920.feature
+++ b/CHANGES/plugin_api/1920.feature
@@ -1,0 +1,3 @@
+Exposed the ``RepositoryResource`` class to enable plugin writers to customize the way of
+importing/exporting of particular repository types. Repositories should be now a part of exported
+resources to enable automatic creation of missing repositories.

--- a/docs/plugins/plugin-writer/concepts/subclassing/import-export.rst
+++ b/docs/plugins/plugin-writer/concepts/subclassing/import-export.rst
@@ -88,6 +88,32 @@ this::
     IMPORT_ORDER = [FileContentResource]
 
 
+Plugin writers are encouraged to subclass the ``RepositoryResource`` class to enable automatic
+repository creation during the import. For the ``pulp_file`` plugin, the following implementation
+should be considered::
+
+    from pulpcore.plugin.modelresources import RepositoryResource
+    from pulp_file.app.models import FileRepository
+
+    class FileRepositoryResource(RepositoryResource):
+        """
+        A resource for importing/exporting file repository entities
+        """
+
+        def set_up_queryset(self):
+            """
+            :return: A queryset containing one repository that will be exported.
+            """
+            return FileRepository.objects.filter(pk=self.repo_version.repository)
+
+        class Meta:
+            model = FileRepository
+
+
+    # the list signifying the order of imports must also include the repository resource class
+    IMPORT_ORDER = [FileContentResource, FileRepositoryResource]
+
+
 content_mapping
 ~~~~~~~~~~~~~~~
 

--- a/docs/workflows/import-export.rst
+++ b/docs/workflows/import-export.rst
@@ -366,10 +366,17 @@ to the names of repos in Pulp. For example, suppose the name of the repo in the 
 
     http :/pulp/api/v3/importers/core/pulp/ name="test" repo_mapping:="{\"source\": \"dest\"}"
 
-.. note::
-   Pulp import expects destination repository/repositories to be present at the import process.
-
 After the importer is created, a POST request to create an import will trigger the import process.
+
+.. note::
+    By default, the Pulp import machinery expects destination repositories to be present at the time
+    of the import. This can be overridden by passing the ``create_repositories=True`` field via the
+    POST request that will lead Pulp to create missing repositories on the fly.
+
+.. warning::
+    The options ``repo_mapping`` and ``create_repositories`` are not compatible with each other. The
+    existence of a repository specified in the ``repo_mapping`` option is tested before the importer
+    is initialized. Thus, the repository has to be already created in advance.
 
 You can import an exported ``.tar.gz`` directly using the ``path`` parameter::
 

--- a/pulpcore/app/modelresource.py
+++ b/pulpcore/app/modelresource.py
@@ -56,6 +56,9 @@ class RepositoryResource(QueryModelResource):
             "pulp_created",
             "pulp_last_updated",
             "content",
+            "next_version",
+            "repository_ptr",
+            "remote",
         )
 
 

--- a/pulpcore/app/serializers/importer.py
+++ b/pulpcore/app/serializers/importer.py
@@ -102,6 +102,13 @@ class PulpImportSerializer(ModelSerializer):
         ),
         required=False,
     )
+    create_repositories = serializers.BooleanField(
+        help_text=_(
+            "If True, missing repositories will be automatically created during the import."
+        ),
+        required=False,
+        default=False,
+    )
 
     def _check_path_allowed(self, param, a_path):
         user_provided_realpath = os.path.realpath(a_path)
@@ -158,6 +165,12 @@ class PulpImportSerializer(ModelSerializer):
         if not data.get("path", None) and not data.get("toc", None):
             raise serializers.ValidationError(_("One of 'path' or 'toc' must be specified."))
 
+        if importer := self.context.get("importer"):
+            if importer.repo_mapping and data.get("create_repositories"):
+                raise serializers.ValidationError(
+                    _("The option 'create_repositories' is not compatible with 'repo_mapping'.")
+                )
+
         return super().validate(data)
 
     class Meta:
@@ -165,6 +178,7 @@ class PulpImportSerializer(ModelSerializer):
         fields = (
             "path",
             "toc",
+            "create_repositories",
         )
 
 

--- a/pulpcore/plugin/modelresources.py
+++ b/pulpcore/plugin/modelresources.py
@@ -1,0 +1,1 @@
+from pulpcore.app.modelresource import RepositoryResource  # noqa


### PR DESCRIPTION
As of this commit, repositories are identified as standard import/export resource objects. It allows the automatic creation of importing repositories that were not created beforehand or do not exist.

closes #1920
