### PR TITLE
Update get_[users|groups]_with_perms to match guardian.

### DIFF
--- a/CHANGES/2739.bugfix
+++ b/CHANGES/2739.bugfix
@@ -1,0 +1,1 @@
+Add options to the role_util functions to make them work the same as guardian did.


### PR DESCRIPTION
This fixes two inconsistencies with the guardian interfaces:
- `for_concrete_model=False` makes it so that these functions don't work with proxy models (which guardian allowed)
- `Q(object_id=None)` causes users/groups with model permissions to be returned (which guardian didn't do)

@mdellweg do these changes make sense to you? I've only tested it with `get_groups_with_perms_attached_roles` (which is currently breaking stuff for us in galaxy_ng), so I'm not sure if these changes are going to cause problems for other plugins or not. If it does, we can just create our own function for this in galaxy_ng.