### PR TITLE
Output CID in tests stdout

### DIFF
--- a/pulpcore/tests/functional/__init__.py
+++ b/pulpcore/tests/functional/__init__.py
@@ -53,7 +53,9 @@ def pytest_configure(config):
 
 @pytest.fixture
 def cid():
-    return str(uuid.uuid4())
+    value = str(uuid.uuid4())
+    yield value
+    print(f"Correlation-ID = {value}")
 
 
 @pytest.fixture


### PR DESCRIPTION
This is needed, because pytest does not automatically report on
transitively received fixtures.

[noissue]