### PR TITLE
Add ?for_object_type to roles API

### DIFF
--- a/CHANGES/2747.feature
+++ b/CHANGES/2747.feature
@@ -1,0 +1,2 @@
+Add ?for_object_type query parameter to Roles API that accepts an object HREF and returns a list
+of roles that only contain permissions for the given object type.

--- a/pulpcore/app/viewsets/base.py
+++ b/pulpcore/app/viewsets/base.py
@@ -157,6 +157,30 @@ class NamedModelViewSet(viewsets.GenericViewSet):
         return self.serializer_class
 
     @staticmethod
+    def get_resource_model(uri):
+        """
+        Resolve a resource URI to the model for the resource.
+
+        Provides a means to resolve an href passed in a POST body to an
+        model for the resource.
+
+        Args:
+            uri (str): A resource URI.
+
+        Returns:
+            django.models.Model: The model for the specified URI.
+
+        Raises:
+            rest_framework.exceptions.ValidationError: on invalid URI.
+        """
+        try:
+            match = resolve(urlparse(uri).path)
+        except Resolver404:
+            raise DRFValidationError(detail=_("URI not valid: {u}").format(u=uri))
+
+        return match.func.cls.queryset.model
+
+    @staticmethod
     def get_resource(uri, model=None):
         """
         Resolve a resource URI to an instance of the resource.

--- a/pulpcore/tests/functional/__init__.py
+++ b/pulpcore/tests/functional/__init__.py
@@ -130,6 +130,14 @@ def orphans_cleanup_api_client(pulpcore_client):
 
 
 @pytest.fixture
+def role_factory(roles_api_client, gen_object_with_cleanup):
+    def _role_factory(**kwargs):
+        return gen_object_with_cleanup(roles_api_client, kwargs)
+
+    return _role_factory
+
+
+@pytest.fixture
 def gen_user(bindings_cfg, users_api_client, users_roles_api_client, gen_object_with_cleanup):
     class user_context:
         def __init__(self, username=None, model_roles=None, object_roles=None):

--- a/pulpcore/tests/functional/api/test_role.py
+++ b/pulpcore/tests/functional/api/test_role.py
@@ -1,3 +1,9 @@
+import uuid
+import pytest
+
+from pulp_smash.pulp3 import constants
+
+
 def test_contains_permission_filter(roles_api_client):
     """Test contains_permission query parameter."""
     # Test single permission
@@ -27,3 +33,67 @@ def test_contains_permission_filter(roles_api_client):
         )
 
     assert change_task_present and view_taskschedule_present
+
+
+@pytest.mark.parallel
+def test_for_object_type_filter(roles_api_client, role_factory):
+    """Test for_object_type query parameter."""
+
+    group_href = constants.BASE_PATH + "groups/"
+    prefix = str(uuid.uuid4())
+
+    multiple = role_factory(
+        name=prefix + "_multi",
+        description="test_role",
+        permissions=["core.add_group", "core.view_task"],
+    )
+
+    single_type = role_factory(
+        name=prefix + "_single",
+        description="test_role",
+        permissions=[
+            "core.add_group",
+        ],
+    )
+
+    single_type2 = role_factory(
+        name=prefix + "_single2",
+        description="test_role",
+        permissions=["core.add_group", "core.view_group", "core.change_group", "core.delete_group"],
+    )
+
+    empty = role_factory(
+        name=prefix + "_empty",
+        description="test_role",
+        permissions=[],
+    )
+
+    # verify that roles with permissions for other objects aren't returned.
+    roles = roles_api_client.list(for_object_type=group_href, name=multiple.name)
+
+    assert roles.count == 0
+
+    # verify that roles for a single object type are returned.
+    roles = roles_api_client.list(for_object_type=group_href, name=single_type.name)
+
+    assert roles.count == 1
+
+    roles = roles_api_client.list(for_object_type=group_href, name=single_type2.name)
+
+    assert roles.count == 1
+
+    # verify that empty roles are not returned
+    roles = roles_api_client.list(for_object_type=group_href, name=empty.name)
+
+    assert roles.count == 0
+
+    # check multiple roles
+    roles = roles_api_client.list(for_object_type=group_href, name__startswith=prefix)
+
+    assert roles.count == 2
+
+    returned_roles = set()
+    for role in roles.results:
+        returned_roles.add(role.name)
+
+    assert returned_roles == set([single_type.name, single_type2.name])


### PR DESCRIPTION
fixes: #2747

Example usage: http://localhost:8080/pulp/api/v3/roles/?for_object_type=/pulp/api/v3/groups/

Returns roles that only have permissions on the `/pulp/api/v3/groups/` resource type.
