### PR TITLE
Fix use of count() method for Content objects in remove_content()

### DIFF
--- a/pulpcore/app/models/repository.py
+++ b/pulpcore/app/models/repository.py
@@ -825,7 +825,7 @@ class RepositoryVersion(BaseModel):
         if self.complete:
             raise ResourceImmutableError(self)
 
-        if not content or not content.count():
+        if not content or not hasattr(content, '__iter__'):
             return
 
         # Normalize representation if content has already been added in this version.


### PR DESCRIPTION
As explained in https://bugzilla.redhat.com/show_bug.cgi?id=2091438 , app/models/repository.py uses `not content.count()` as a condition inside the `remove_content()` function. However, the `count()` method is not implemented for the `Content` class.

On the actual live system where this happened I modified the `not content.count()` test to do `not hasattr(content, '__iter__')` instead, assuming this condition in `repository.py` is there to check for non-iterable contents. The code, when modified like this, ran successfully and was able to successfully complete the pulp-2to3 migration, which was so far failing with a traceback that said,
~~~
'Content' object has no attribute 'count'
~~~

This PR changes just that: the test condition inside app/models/repository.py's `remove_content()`.