### PR TITLE
Fixes extlinks to be Sphinx==5.0.0 compatible

### DIFF
--- a/CHANGES/2782.doc
+++ b/CHANGES/2782.doc
@@ -1,0 +1,1 @@
+Fixed ``extlinks`` use in docs to be Sphinx==5.0.0 compatible.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -262,8 +262,8 @@ texinfo_documents = [
 #texinfo_show_urls = 'footnote'
 
 extlinks = {
-    'github': ('https://github.com/pulp/pulpcore/issues/%s', '#'),
-    'redmine': ('https://pulp.plan.io/issues/%s', '#'),
+    'github': ('https://github.com/pulp/pulpcore/issues/%s', '#%s'),
+    'redmine': ('https://pulp.plan.io/issues/%s', '#%s'),
 }
 
 # napoleon uses .. attribute by default, but :ivar: is more succinct and looks better,


### PR DESCRIPTION
The extlinks with Sphinx==5.0.0 emitted warnings that were treated as
failures. This updates the extlinks definition to have it work with the
newer versions also.

closes #2782
