### PR TITLE
Allow uploads to be turned into content directly

### DIFF
--- a/CHANGES/plugin_api/2786.feature
+++ b/CHANGES/plugin_api/2786.feature
@@ -1,0 +1,2 @@
+Added the ability to specify an upload for the single shot upload serializer. This allows to
+upload files in chunks and attach them with content in repositories without creating orphans.

--- a/CHANGES/plugin_api/2786.removal
+++ b/CHANGES/plugin_api/2786.removal
@@ -1,0 +1,3 @@
+Plugins using the ``SingleArtifactContentUploadSerializer`` must place a super call when
+overwriting ``deferred_validate``. They can only assume the existance of the ``Artifact`` in the
+database, after this call.

--- a/pulpcore/app/files.py
+++ b/pulpcore/app/files.py
@@ -32,7 +32,11 @@ class PulpTemporaryUploadedFile(TemporaryUploadedFile):
             PulpTemporaryUploadedFile: instantiated instance from file
         """
         name = os.path.basename(file.name)
-        instance = cls(name, "", file.size, "", "")
+        try:
+            size = file.size
+        except AttributeError:
+            size = os.path.getsize(file.name)
+        instance = cls(name, "", size, "", "")
         instance.file = file
         # Default 1MB
         while data := file.read(1048576):

--- a/pulpcore/app/tasks/upload.py
+++ b/pulpcore/app/tasks/upload.py
@@ -2,10 +2,7 @@ from gettext import gettext as _
 from logging import getLogger
 from tempfile import NamedTemporaryFile
 
-from django.core.files import File
-
 from pulpcore.app import files, models
-from pulpcore.app.models import CreatedResource
 from pulpcore.app.serializers import ArtifactSerializer
 
 log = getLogger(__name__)
@@ -32,14 +29,15 @@ def commit(upload_id, sha256):
             chunk.file.close()
         temp_file.flush()
 
-        file = files.PulpTemporaryUploadedFile.from_file(File(open(temp_file.name, "rb")))
+    with open(temp_file.name, "rb") as artifact_file:
+        file = files.PulpTemporaryUploadedFile.from_file(artifact_file)
 
-    data = {"file": file, "sha256": sha256}
-    serializer = ArtifactSerializer(data=data)
-    serializer.is_valid(raise_exception=True)
-    artifact = serializer.save()
+        data = {"file": file, "sha256": sha256}
+        serializer = ArtifactSerializer(data=data)
+        serializer.is_valid(raise_exception=True)
+        artifact = serializer.save()
 
-    resource = CreatedResource(content_object=artifact)
+    resource = models.CreatedResource(content_object=artifact)
     resource.save()
 
     # delete the upload since it can't be reused to create another artifact

--- a/pulpcore/tasking/tasks.py
+++ b/pulpcore/tasking/tasks.py
@@ -23,6 +23,9 @@ def _validate_and_get_resources(resources):
             resource_set.add(r)
         elif isinstance(r, Model):
             resource_set.add(get_url(r))
+        elif r is None:
+            # Silently drop None values
+            pass
         else:
             raise ValueError(_("Must be (str|Model)"))
     return list(resource_set)

--- a/pulpcore/tests/functional/__init__.py
+++ b/pulpcore/tests/functional/__init__.py
@@ -28,6 +28,7 @@ from pulpcore.client.pulpcore import (
     StatusApi,
     TasksApi,
     TaskSchedulesApi,
+    UploadsApi,
     UsersApi,
     UsersRolesApi,
 )
@@ -83,6 +84,11 @@ def tasks_api_client(pulpcore_client):
 @pytest.fixture
 def artifacts_api_client(pulpcore_client):
     return ArtifactsApi(pulpcore_client)
+
+
+@pytest.fixture
+def uploads_api_client(pulpcore_client):
+    return UploadsApi(pulpcore_client)
 
 
 @pytest.fixture


### PR DESCRIPTION
This is needed to prevent creating orphans in the meantime.

fixes #2786