### PR TITLE
Fixes OpenAPI schema for Content create operations

### DIFF
--- a/CHANGES/2806.bugfix
+++ b/CHANGES/2806.bugfix
@@ -1,0 +1,1 @@
+Fixed the OpenAPI schema generation for Content create operations.

--- a/pulpcore/openapi/__init__.py
+++ b/pulpcore/openapi/__init__.py
@@ -13,7 +13,6 @@ from drf_spectacular.plumbing import (
     build_basic_type,
     build_parameter_type,
     build_root_object,
-    force_instance,
     normalize_result_object,
     resolve_django_path_parameter,
     resolve_regex_path_parameter,
@@ -21,7 +20,7 @@ from drf_spectacular.plumbing import (
 from drf_spectacular.settings import spectacular_settings
 from drf_spectacular.types import OpenApiTypes
 from drf_spectacular.utils import OpenApiParameter
-from rest_framework import mixins, serializers
+from rest_framework import mixins
 from rest_framework.schemas.utils import get_pk_description
 
 from pulpcore.app.apps import pulp_plugin_configs
@@ -177,19 +176,6 @@ class PulpAutoSchema(AutoSchema):
         elif direction == "response" and "Response" not in name:
             name = name + "Response"
         return name
-
-    def map_parsers(self):
-        """
-        Get request parsers.
-
-        Handling cases with `FileField`.
-        """
-        parsers = super().map_parsers()
-        serializer = force_instance(self.get_request_serializer())
-        for field_name, field in getattr(serializer, "fields", {}).items():
-            if isinstance(field, serializers.FileField) and self.method in ("PUT", "PATCH", "POST"):
-                return ["multipart/form-data", "application/x-www-form-urlencoded"]
-        return parsers
 
     def _get_request_body(self):
         """Get request body."""


### PR DESCRIPTION
The code[0] for special handling of FileFields when generating the OpenAPI schema was
introduced to work around a bug in drf-yasg[1]. This code was then ported when pulpcore
switched to using drf_spectacular for generating OpenAPI. This code is not needed. It
actually causes the OpenAPI schema for Content creation APIs to be different from all
other create operations.

[0] https://github.com/pulp/pulpcore/commit/24b50710201a5fea73898f8a1fcff286f9e47809#diff-0535b5e0e76e73cdc44991f38a187114c123eb5ba125bda3015ca222a2b18088
[1] https://github.com/axnsan12/drf-yasg/issues/386

closes: #2806