### PR TITLE
Adds Python package name to the status API

### DIFF
--- a/CHANGES/1982.feature
+++ b/CHANGES/1982.feature
@@ -1,0 +1,1 @@
+The status API endpoint now shows the python package name that provides a given plugin.

--- a/CHANGES/plugin_api/1982.feature
+++ b/CHANGES/plugin_api/1982.feature
@@ -1,0 +1,2 @@
+Plugins are required to provide the ``python_package_name`` as a string attribute on their subclass
+of ``PulpPluginAppConfig``.

--- a/pulpcore/app/apps.py
+++ b/pulpcore/app/apps.py
@@ -70,6 +70,17 @@ class PulpPluginAppConfig(apps.AppConfig):
             )
             raise ImproperlyConfigured(msg.format(self.label))
 
+        try:
+            self.python_package_name
+        except AttributeError:
+            msg = (
+                "The plugin `{}` is missing a `python_package_name` declaration. Starting with "
+                "pulpcore==3.20, plugins are required to define the python package name providing "
+                "the Pulp plugin on the PulpPluginAppConfig subclass as the `python_package_name` "
+                "attribute."
+            )
+            raise ImproperlyConfigured(msg.format(self.label))
+
         # Module containing viewsets eg. <module 'pulp_plugin.app.viewsets'
         # from 'pulp_plugin/app/viewsets.py'>. Set by import_viewsets().
         # None if the application doesn't have a viewsets module, automatically set
@@ -191,6 +202,9 @@ class PulpAppConfig(PulpPluginAppConfig):
 
     # The version of this app
     version = "3.20.0.dev"
+
+    # The python package name providing this app
+    python_package_name = "pulpcore"
 
     def ready(self):
         super().ready()

--- a/pulpcore/app/serializers/status.py
+++ b/pulpcore/app/serializers/status.py
@@ -14,6 +14,8 @@ class VersionSerializer(serializers.Serializer):
 
     version = serializers.CharField(help_text=_("Version of the component (e.g. 3.0.0)"))
 
+    package = serializers.CharField(help_text=_("Python package name providing the component"))
+
 
 class DatabaseConnectionSerializer(serializers.Serializer):
     """

--- a/pulpcore/app/views/status.py
+++ b/pulpcore/app/views/status.py
@@ -55,7 +55,9 @@ class StatusView(APIView):
         """
         versions = []
         for app in pulp_plugin_configs():
-            versions.append({"component": app.label, "version": app.version})
+            versions.append(
+                {"component": app.label, "version": app.version, "package": app.python_package_name}
+            )
 
         if settings.CACHE_ENABLED:
             redis_status = {"connected": self._get_redis_conn_status()}

--- a/pulpcore/tests/functional/api/test_status.py
+++ b/pulpcore/tests/functional/api/test_status.py
@@ -28,7 +28,11 @@ STATUS = {
             "type": "array",
             "items": {
                 "type": "object",
-                "properties": {"component": {"type": "string"}, "version": {"type": "string"}},
+                "properties": {
+                    "component": {"type": "string"},
+                    "version": {"type": "string"},
+                    "package": {"type": "string"},
+                },
             },
         },
         "storage": {


### PR DESCRIPTION
Plugins are now required to declare the python package name so pulpcore
can include it in the status API response.

Required PR: https://github.com/pulp/pulp-certguard/pull/184
Required PR: https://github.com/pulp/pulp_file/pull/738

closes #1982
