### PR TITLE
PoC: Related fields

### DIFF
--- a/pulpcore/app/serializers/repository.py
+++ b/pulpcore/app/serializers/repository.py
@@ -20,56 +20,6 @@ from pulpcore.app.serializers import (
 )
 
 
-class RepositorySerializer(ModelSerializer):
-    pulp_href = DetailIdentityField(view_name_pattern=r"repositories(-.*/.*)-detail")
-    pulp_labels = LabelsField(required=False)
-    versions_href = RepositoryVersionsIdentityFromRepositoryField()
-    latest_version_href = LatestVersionField()
-    name = serializers.CharField(
-        help_text=_("A unique name for this repository."),
-        validators=[UniqueValidator(queryset=models.Repository.objects.all())],
-    )
-    description = serializers.CharField(
-        help_text=_("An optional description."), required=False, allow_null=True
-    )
-    retain_repo_versions = serializers.IntegerField(
-        help_text=_(
-            "Retain X versions of the repository. Default is null which retains all versions."
-            " This is provided as a tech preview in Pulp 3 and may change in the future."
-        ),
-        allow_null=True,
-        required=False,
-        min_value=1,
-    )
-    remote = DetailRelatedField(
-        help_text=_("An optional remote to use by default when syncing."),
-        view_name_pattern=r"remotes(-.*/.*)-detail",
-        queryset=models.Remote.objects.all(),
-        required=False,
-        allow_null=True,
-    )
-
-    def validate_remote(self, value):
-        if value and type(value) not in self.Meta.model.REMOTE_TYPES:
-            raise serializers.ValidationError(
-                detail=_("Type for Remote '{}' does not match Repository.").format(value.name)
-            )
-
-        return value
-
-    class Meta:
-        model = models.Repository
-        fields = ModelSerializer.Meta.fields + (
-            "versions_href",
-            "pulp_labels",
-            "latest_version_href",
-            "name",
-            "description",
-            "retain_repo_versions",
-            "remote",
-        )
-
-
 class RemoteSerializer(ModelSerializer):
     """
     Every remote defined by a plugin should have a Remote serializer that inherits from this
@@ -318,6 +268,57 @@ class RemoteSerializer(ModelSerializer):
             "sock_read_timeout",
             "headers",
             "rate_limit",
+        )
+
+
+class RepositorySerializer(ModelSerializer):
+    pulp_href = DetailIdentityField(view_name_pattern=r"repositories(-.*/.*)-detail")
+    pulp_labels = LabelsField(required=False)
+    versions_href = RepositoryVersionsIdentityFromRepositoryField()
+    latest_version_href = LatestVersionField()
+    name = serializers.CharField(
+        help_text=_("A unique name for this repository."),
+        validators=[UniqueValidator(queryset=models.Repository.objects.all())],
+    )
+    description = serializers.CharField(
+        help_text=_("An optional description."), required=False, allow_null=True
+    )
+    retain_repo_versions = serializers.IntegerField(
+        help_text=_(
+            "Retain X versions of the repository. Default is null which retains all versions."
+            " This is provided as a tech preview in Pulp 3 and may change in the future."
+        ),
+        allow_null=True,
+        required=False,
+        min_value=1,
+    )
+    remote = DetailRelatedField(
+        help_text=_("An optional remote to use by default when syncing."),
+        view_name_pattern=r"remotes(-.*/.*)-detail",
+        queryset=models.Remote.objects.all(),
+        required=False,
+        allow_null=True,
+        related_serializer=RemoteSerializer
+    )
+
+    def validate_remote(self, value):
+        if value and type(value) not in self.Meta.model.REMOTE_TYPES:
+            raise serializers.ValidationError(
+                detail=_("Type for Remote '{}' does not match Repository.").format(value.name)
+            )
+
+        return value
+
+    class Meta:
+        model = models.Repository
+        fields = ModelSerializer.Meta.fields + (
+            "versions_href",
+            "pulp_labels",
+            "latest_version_href",
+            "name",
+            "description",
+            "retain_repo_versions",
+            "remote",
         )
 
 

--- a/pulpcore/app/viewsets/base.py
+++ b/pulpcore/app/viewsets/base.py
@@ -746,6 +746,7 @@ class BaseFilterSet(filterset.FilterSet):
             "offset",
             "page_size",
             "ordering",
+            "include_related",
         ]
         for field in self.data.keys():
             if field in DEFAULT_FILTERS:


### PR DESCRIPTION
This is something I've been thinking about in my free time and wanted to share it more broadly.

One of the big issues with developing UIs for the pulp apis is that related information on lists is always included as an href. If I need to iterate through a list of objects (say repositories) and display the remote url for each repo in the UI I need to make an API call for each remote HREF the repo responds. This is inefficient for the server and slow for the UI. This PoC explores the possibility of adding an `?include_related` query parameter that would include objects in the API response. Here's how it works:

Plugin writers can add a `related_serializer` param on any `DetailRelatedField` like so

```python
class RepositorySerializer(ModelSerializer):

    [...]

    remote = DetailRelatedField(
        help_text=_("An optional remote to use by default when syncing."),
        view_name_pattern=r"remotes(-.*/.*)-detail",
        queryset=models.Remote.objects.all(),
        required=False,
        allow_null=True,
        related_serializer=RemoteSerializer
    )
```

This adds a `"related_fields": {},` to the API response for Repositories. By default this is blank, however when I include `?include_related=remote` or `?include_related=_all` in the query parameters for the API request, the object is serialized and returned under `related_fields`

Example
```
GET /pulp/api/v3/repositories/?include_related=remote

{
    "count": 7,
    "next": null,
    "previous": null,
    "results": [
        {
            "pulp_href": "/api/automation-hub/pulp/api/v3/repositories/ansible/ansible/6bbeb226-f4d4-4f0e-811e-a569a321e145/",
            "pulp_created": "2022-06-10T17:00:35.527766Z",
            "related_fields": {
                "remote": {
                    "pulp_href": "/api/automation-hub/pulp/api/v3/remotes/ansible/collection/a0ad3b70-b3f3-423b-8278-f3a925291971/",
                    "pulp_created": "2022-06-10T17:00:35.520711Z",
                    "related_fields": {},
                    "name": "rh-certified",
                    "url": "https://cloud.redhat.com/api/automation-hub/",
                    "ca_cert": null,
                    "client_cert": null,
                    "tls_validation": true,
                    "proxy_url": null,
                    "pulp_labels": {},
                    "pulp_last_updated": "2022-06-10T17:00:35.520751Z",
                    "download_concurrency": null,
                    "max_retries": null,
                    "policy": "immediate",
                    "total_timeout": null,
                    "connect_timeout": null,
                    "sock_connect_timeout": null,
                    "sock_read_timeout": null,
                    "headers": null,
                    "rate_limit": 8
                }
            },
            "versions_href": "/api/automation-hub/pulp/api/v3/repositories/ansible/ansible/6bbeb226-f4d4-4f0e-811e-a569a321e145/versions/",
            "pulp_labels": {},
            "latest_version_href": "/api/automation-hub/pulp/api/v3/repositories/ansible/ansible/6bbeb226-f4d4-4f0e-811e-a569a321e145/versions/0/",
            "name": "rh-certified",
            "description": "Red Hat certified content repository",
            "retain_repo_versions": 1,
            "remote": "/api/automation-hub/pulp/api/v3/remotes/ansible/collection/a0ad3b70-b3f3-423b-8278-f3a925291971/"
        },
        {
            "pulp_href": "/api/automation-hub/pulp/api/v3/repositories/ansible/ansible/8203451a-2c82-4c9a-82bd-bb7a66acf7a4/",
            "pulp_created": "2022-06-10T17:00:35.479673Z",
            "related_fields": {
                "remote": null
            },
            "versions_href": "/api/automation-hub/pulp/api/v3/repositories/ansible/ansible/8203451a-2c82-4c9a-82bd-bb7a66acf7a4/versions/",
            "pulp_labels": {},
            "latest_version_href": "/api/automation-hub/pulp/api/v3/repositories/ansible/ansible/8203451a-2c82-4c9a-82bd-bb7a66acf7a4/versions/0/",
            "name": "published",
            "description": "Certified content repository",
            "retain_repo_versions": 1,
            "remote": null
        }
    ]
}
```

Now my UI doesn't have to make a ton of API calls to get the data on remotes.

### Considerations

#### Performance:
Right now this adds a bunch of extra DB queries (one for each object in related_fields). This could be optimized by reading the `include_related` in the viewset and prefetching related data.

This could also make API responses fairly large. Both of these increase the risk of DoS attacks.

#### Open API spec

Communicating what's available in the `related_fields` response to clients is a challenge that this PoC hasn't tried to solve for. This include telling clients and users what fields are avaialable for the `include_related` param as well as what objects to expect as a response in `related_fields`.