### PR TITLE
Update Database installation instructions

### DIFF
--- a/CHANGES/2877.doc
+++ b/CHANGES/2877.doc
@@ -1,0 +1,1 @@
+Update installation instructions about "User and database configuration" for the Database setup to point to a matching Django documentation.

--- a/docs/installation/instructions.rst
+++ b/docs/installation/instructions.rst
@@ -134,7 +134,7 @@ The default PostgreSQL user and database name in the provided server.yaml file i
 customize the configuration of your Pulp installation, you will need to create this user with the proper permissions
 and also create the ``pulp`` database owned by the ``pulp`` user. If you do choose to customize your installation,
 the database options can be configured in the `DATABASES` section of your server.yaml settings file.
-See the `Django database settings documentation <https://docs.djangoproject.com/en/2.2/ref/settings/#databases>`_
+See the `Django database settings documentation <https://docs.djangoproject.com/en/3.2/ref/settings/#databases>`_
 for more information on setting the `DATABASES` values in server.yaml.
 
 UTF-8 encoding


### PR DESCRIPTION
This updates the installation instructions about "User and database configuration" for the Database setup to point to a matching Django documentation.

fixes #2877
