### PR TITLE
Add `.doc` as possible changelog update extension

### DIFF
--- a/docs/contributing/git.rst
+++ b/docs/contributing/git.rst
@@ -131,6 +131,8 @@ or ``CHANGES/plugin_api/`` directory named after that issue number with one of t
 +--------------+----------------------------------------------------------------------+
 | .deprecation | Information about an upcoming backwards incompatible change          |
 +--------------+----------------------------------------------------------------------+
+| .doc         | A documentation improvement                                          |
++--------------+----------------------------------------------------------------------+
 | .misc        | A change that is not visible to the end user                         |
 +--------------+----------------------------------------------------------------------+
 


### PR DESCRIPTION
The list of extensions for the towncrier changelog fragments was missing `.doc` for documentation improvements.
