### PR TITLE
Adds signing service pytest fixtures

### DIFF
--- a/functest_requirements.txt
+++ b/functest_requirements.txt
@@ -6,3 +6,4 @@ pulp-smash @ git+https://github.com/pulp/pulp-smash.git
 pulpcore-client
 pulp-file-client
 pytest
+python-gnupg

--- a/pulpcore/tests/functional/__init__.py
+++ b/pulpcore/tests/functional/__init__.py
@@ -32,6 +32,16 @@ from pulpcore.client.pulpcore import (
     UsersRolesApi,
 )
 
+from .gpg_ascii_armor_signing_service import (  # noqa: F401
+    _ascii_armored_detached_signing_service_name,
+    ascii_armored_detached_signing_service,
+    sign_with_ascii_armored_detached_signing_service,
+    gpg_homedir_with_trusted_private_key,
+    signing_gpg_homedir_path,
+    signing_script_path,
+    signing_script_temp_dir,
+)
+
 
 @pytest.hookimpl(tryfirst=True)
 def pytest_check_for_leftover_pulp_objects(config):

--- a/pulpcore/tests/functional/gpg_ascii_armor_signing_service.py
+++ b/pulpcore/tests/functional/gpg_ascii_armor_signing_service.py
@@ -1,0 +1,166 @@
+import asyncio
+import json
+import os
+import stat
+import subprocess
+import uuid
+
+import aiohttp
+import gnupg
+import pytest
+
+
+signing_script_string = r"""#!/usr/bin/env bash
+
+FILE_PATH=$1
+SIGNATURE_PATH="$1.asc"
+
+GPG_KEY_ID="Pulp QE"
+
+# Create a detached signature
+gpg --quiet --batch --homedir HOMEDIRHERE --detach-sign --local-user "${GPG_KEY_ID}" \
+   --armor --output ${SIGNATURE_PATH} ${FILE_PATH}
+
+# Check the exit status
+STATUS=$?
+if [[ ${STATUS} -eq 0 ]]; then
+   echo {\"file\": \"${FILE_PATH}\", \"signature\": \"${SIGNATURE_PATH}\"}
+else
+   exit ${STATUS}
+fi
+"""
+
+
+@pytest.fixture(scope="session")
+def signing_script_path(signing_script_temp_dir):
+    signing_script_filename = signing_script_temp_dir / "sign-metadata.sh"
+    with open(signing_script_filename, "w", 0o770) as sign_metadata_file:
+        sign_metadata_file.write(
+            signing_script_string.replace("HOMEDIRHERE", str(signing_script_temp_dir))
+        )
+
+    st = os.stat(signing_script_filename)
+    os.chmod(signing_script_filename, st.st_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
+
+    return signing_script_filename
+
+
+@pytest.fixture(scope="session")
+def signing_script_temp_dir(tmpdir_factory):
+    yield tmpdir_factory.mktemp(str(uuid.uuid4()))
+
+
+@pytest.fixture(scope="session")
+def signing_gpg_homedir_path(tmpdir_factory):
+    return tmpdir_factory.mktemp(str(uuid.uuid4()))
+
+
+@pytest.fixture
+def sign_with_ascii_armored_detached_signing_service(
+    signing_script_path, gpg_homedir_with_trusted_private_key
+):
+    """
+    Runs the test signing script manually, locally, and returns the signature file produced.
+    """
+
+    def _sign_with_ascii_armored_detached_signing_service(filename):
+        env = {"PULP_SIGNING_KEY_FINGERPRINT": gpg_homedir_with_trusted_private_key[1]}
+        cmd = (signing_script_path, filename)
+        completed_process = subprocess.run(
+            cmd,
+            env=env,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+        )
+
+        if completed_process.returncode != 0:
+            raise RuntimeError(str(completed_process.stderr))
+
+        try:
+            return_value = json.loads(completed_process.stdout)
+        except json.JSONDecodeError:
+            raise RuntimeError("The signing script did not return valid JSON!")
+
+        return return_value
+
+    return _sign_with_ascii_armored_detached_signing_service
+
+
+@pytest.fixture(scope="session")
+def gpg_homedir_with_trusted_private_key(signing_script_temp_dir, signing_gpg_homedir_path):
+    """A fixture creating a GPG homedir with one, trusted private key for signing."""
+    private_key_url = (
+        "https://raw.githubusercontent.com/pulp/pulp-fixtures/master/common/GPG-PRIVATE-KEY-pulp-qe"
+    )
+
+    async def download_key():
+        async with aiohttp.ClientSession() as session:
+            async with session.get(private_key_url) as response:
+                return await response.text()
+
+    private_key_data = asyncio.run(download_key())
+
+    gpg = gnupg.GPG(gnupghome=signing_script_temp_dir)
+
+    gpg.import_keys(private_key_data)
+
+    fingerprint = gpg.list_keys()[0]["fingerprint"]
+    keyid = gpg.list_keys()[0]["keyid"]
+
+    gpg.trust_keys(fingerprint, "TRUST_ULTIMATE")
+
+    return gpg, fingerprint, keyid
+
+
+@pytest.fixture(scope="session")
+def _ascii_armored_detached_signing_service_name(
+    bindings_cfg,
+    signing_script_path,
+    gpg_homedir_with_trusted_private_key,
+    signing_script_temp_dir,
+    pytestconfig,
+):
+    service_name = str(uuid.uuid4())
+    gpg, fingerprint, keyid = gpg_homedir_with_trusted_private_key
+
+    cmd = (
+        "pulpcore-manager",
+        "add-signing-service",
+        service_name,
+        str(signing_script_path),
+        fingerprint,
+        "--class",
+        "core:AsciiArmoredDetachedSigningService",
+        "--gnupghome",
+        str(signing_script_temp_dir),
+    )
+    completed_process = subprocess.run(
+        cmd,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+
+    assert completed_process.returncode == 0
+
+    yield service_name
+
+    cmd = (
+        "pulpcore-manager",
+        "shell",
+        "-c",
+        f'from pulpcore.app.models import AsciiArmoredDetachedSigningService;print(AsciiArmoredDetachedSigningService.objects.get(name="{service_name}").delete())',  # noqa: E501
+    )
+    subprocess.run(
+        cmd,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+
+
+@pytest.fixture
+def ascii_armored_detached_signing_service(
+    _ascii_armored_detached_signing_service_name, signing_service_api_client
+):
+    return signing_service_api_client.list(
+        name=_ascii_armored_detached_signing_service_name
+    ).results[0]


### PR DESCRIPTION
The new fixtures can be used to auto-setup-and-teardown an
`AsciiArmoredDetachedSigningService`. Pre-generated gpg public and
private keys are used temporarily configure the gpghome dir for use
during the test. Also "local" signing facilities are also available for
tests to produce signatures locally too.

[noissue]

