### PR TITLE
[noissue] update links to Django documentation

### DIFF
--- a/docs/authentication/other.rst
+++ b/docs/authentication/other.rst
@@ -6,7 +6,7 @@ Other
 Pulp is a Django app and Django Rest Framework (DRF) application, so additional authentication can
 be added as long as it's correctly configured for both Django and Django Rest Frameowork.
 
-See the `Django docs on configuring custom authentication <https://docs.djangoproject.com/en/2.2/
+See the `Django docs on configuring custom authentication <https://docs.djangoproject.com/en/3.2/
 topics/auth/customizing/#customizing-authentication-in-django>`_ and the `Django Rest Framework docs
 on configuring custom authentication <https://www.django-rest-framework.org/api-guide/authentication
 /#custom-authentication>`_.

--- a/docs/components.rst
+++ b/docs/components.rst
@@ -30,7 +30,7 @@ things:
       $ pulpcore-manager runserver 24817
 
 The REST API can be deployed with any any WSGI webserver like a normal Django application. See the
-`Django deployment docs <https://docs.djangoproject.com/en/2.1/howto/deployment/wsgi/>`_ for more
+`Django deployment docs <https://docs.djangoproject.com/en/3.2/howto/deployment/wsgi/>`_ for more
 information.
 
 Content Serving Application

--- a/docs/configuration/settings.rst
+++ b/docs/configuration/settings.rst
@@ -16,14 +16,14 @@ Django Settings
 ---------------
 
 Pulp is a Django project, so any Django `Django setting
-<https://docs.djangoproject.com/en/2.2/ref/settings/>`_ can also be set to configure your Pulp
+<https://docs.djangoproject.com/en/3.2/ref/settings/>`_ can also be set to configure your Pulp
 deployment.
 
 SECRET_KEY
 ^^^^^^^^^^
 
     In order to get a pulp server up and running a `Django SECRET_KEY
-    <https://docs.djangoproject.com/en/2.2/ref/settings/#secret-key>`_ *must* be
+    <https://docs.djangoproject.com/en/3.2/ref/settings/#secret-key>`_ *must* be
     provided.
 
     The following code snippet can be used to generate a random SECRET_KEY.
@@ -108,7 +108,7 @@ AUTHENTICATION_BACKENDS
    2. Webserver authentication that relies on the webserver to perform the authentication.
 
    To change the authentication types Pulp will use, modify the ``AUTHENTICATION_BACKENDS``
-   settings. See the `Django authentication documentation <https://docs.djangoproject.com/en/2.2/
+   settings. See the `Django authentication documentation <https://docs.djangoproject.com/en/3.2/
    topics/auth/customizing/#authentication-backends>`_ for more information.
 
 .. _redis-settings:
@@ -274,7 +274,7 @@ REMOTE_USER_ENVIRON_NAME
    .. warning::
 
       Configuring this has serious security implications. See the `Django warning at the end of this
-      section in their docs <https://docs.djangoproject.com/en/2.2/howto/auth-remote-user/
+      section in their docs <https://docs.djangoproject.com/en/3.2/howto/auth-remote-user/
       #configuration>`_ for more details.
 
    Defaults to ``'REMOTE_USER'``.

--- a/docs/plugins/plugin-writer/concepts/index.rst
+++ b/docs/plugins/plugin-writer/concepts/index.rst
@@ -185,7 +185,7 @@ GroupProgressReport needs to be updated.
 
         # .update(done=F('done') + 1)
 
-        # See: https://docs.djangoproject.com/en/3.0/ref/models/expressions/#f-expressions
+        # See: https://docs.djangoproject.com/en/3.2/ref/models/expressions/#f-expressions
         # Important: F() objects assigned to model fields persist after saving the model instance and
         # will be applied on each save(). Do not use save() and use update() instead, otherwise
         # refresh_from_db() should be called after each save()

--- a/docs/plugins/plugin-writer/concepts/rbac/overview.rst
+++ b/docs/plugins/plugin-writer/concepts/rbac/overview.rst
@@ -22,7 +22,7 @@ Pulp's authorization model has the following architecture:
 
 :Task Permissions Check: A permission check that occurs inside of Task code. This tends to use
     permission checking calls like `has_perm` or `has_perms` `provided by Django <https://
-    docs.djangoproject.com/en/2.2/ref/contrib/auth/#django.contrib.auth.models.User.has_perm>`_.
+    docs.djangoproject.com/en/3.2/ref/contrib/auth/#django.contrib.auth.models.User.has_perm>`_.
 
 :Permission Checking Machinery: A set of methods which can check various conditions such as if a
     requesting user has a given permission, or is a member of a group that has a given permission,

--- a/docs/plugins/plugin-writer/concepts/rbac/permissions.rst
+++ b/docs/plugins/plugin-writer/concepts/rbac/permissions.rst
@@ -26,7 +26,7 @@ The Model permissions are created automatically by Django, and receive a name li
 ``<app_name>.<action>_<model_name>``. For example to change file remote the permission is named
 ``file.change_fileremote``. You can view the Permissions on a system via the Django ORM with:
 ``Permission.objects.all()``. See the `Django Permissions Docs <https://docs.djangoproject.com/en/
-2.2/topics/auth/default/#permissions-and-authorization>`_ for more information on working with
+3.2/topics/auth/default/#permissions-and-authorization>`_ for more information on working with
 permissions.
 
 Here's an example of the Permissions automatically created for the ``FileRemote`` model:

--- a/docs/plugins/plugin-writer/concepts/subclassing/models.rst
+++ b/docs/plugins/plugin-writer/concepts/subclassing/models.rst
@@ -21,7 +21,7 @@ Adding Model Fields
 Each subclassed Model will typically store attributes that are specific to the content type. These
 attributes need to be added to the model as ``fields``. You can use any of Django's field types
 for your fields. See the `Django field documentation
-<https://docs.djangoproject.com/en/2.1/ref/models/fields/>`_, for more in-depth information on
+<https://docs.djangoproject.com/en/3.2/ref/models/fields/>`_, for more in-depth information on
 using these fields.
 
 

--- a/docs/plugins/reference/how-plugins-work.rst
+++ b/docs/plugins/reference/how-plugins-work.rst
@@ -8,7 +8,7 @@ Plugin Django Application
 
 Like the Pulp Core itself, all Pulp Plugins begin as Django Applications, started like any other
 with `pulpcore-manager startapp <your_plugin>`. However, instead of subclassing Django's
-`django.apps.AppConfig` as seen `in the Django documentation <https://docs.djangoproject.com/en/2.2
+`django.apps.AppConfig` as seen `in the Django documentation <https://docs.djangoproject.com/en/3.2
 /ref/applications/#for-application-authors>`_, Pulp Plugins identify themselves as plugins to
 pulpcore by subclassing :class:`pulpcore.plugin.PulpPluginAppConfig`.
 

--- a/pulpcore/app/models/__init__.py
+++ b/pulpcore/app/models/__init__.py
@@ -1,4 +1,4 @@
-# https://docs.djangoproject.com/en/dev/topics/db/models/#organizing-models-in-a-package
+# https://docs.djangoproject.com/en/3.2/topics/db/models/#organizing-models-in-a-package
 
 # Must be imported first as other models depend on it
 from .base import (  # noqa

--- a/pulpcore/app/models/base.py
+++ b/pulpcore/app/models/base.py
@@ -52,7 +52,7 @@ class BaseModel(LifecycleModel):
 
     References:
 
-        * https://docs.djangoproject.com/en/1.8/topics/db/models/#automatic-primary-key-fields
+        * https://docs.djangoproject.com/en/3.2/topics/db/models/#automatic-primary-key-fields
         * https://rsinger86.github.io/django-lifecycle/
 
     """

--- a/pulpcore/app/models/fields.py
+++ b/pulpcore/app/models/fields.py
@@ -106,7 +106,7 @@ class EncryptedTextField(TextField):
 
 @Field.register_lookup
 class NotEqualLookup(Lookup):
-    # this is copied from https://docs.djangoproject.com/en/3.0/howto/custom-lookups/
+    # this is copied from https://docs.djangoproject.com/en/3.2/howto/custom-lookups/
     lookup_name = "ne"
 
     def as_sql(self, compiler, connection):

--- a/pulpcore/app/models/generic.py
+++ b/pulpcore/app/models/generic.py
@@ -2,7 +2,7 @@
 Container for models using generic relations provided by Django's ContentTypes framework.
 
 References:
-    https://docs.djangoproject.com/en/1.8/ref/contrib/contenttypes/#generic-relations
+    https://docs.djangoproject.com/en/3.2/ref/contrib/contenttypes/#generic-relations
 """
 
 from django.contrib.contenttypes.fields import GenericForeignKey

--- a/pulpcore/app/models/progress.py
+++ b/pulpcore/app/models/progress.py
@@ -291,7 +291,7 @@ class GroupProgressReport(BaseModel):
 
     .update(done=F('done') + 1)
 
-    See: https://docs.djangoproject.com/en/3.0/ref/models/expressions/#f-expressions
+    See: https://docs.djangoproject.com/en/3.2/ref/models/expressions/#f-expressions
     Important: F() objects assigned to model fields persist after saving the model instance and
     will be applied on each save(). Do not use save() and use update() instead, otherwise
     refresh_from_db() should be called after each save()

--- a/pulpcore/app/settings.py
+++ b/pulpcore/app/settings.py
@@ -2,10 +2,10 @@
 Django settings for the Pulp Platform application
 
 Never import this module directly, instead `from django.conf import settings`, see
-https://docs.djangoproject.com/en/1.11/topics/settings/#using-settings-in-python-code
+https://docs.djangoproject.com/en/3.2/topics/settings/#using-settings-in-python-code
 
 For the full list of settings and their values, see
-https://docs.djangoproject.com/en/1.11/ref/settings/
+https://docs.djangoproject.com/en/3.2/ref/settings/
 """
 
 import sys
@@ -26,7 +26,7 @@ from pulpcore import constants
 BASE_DIR = Path(__file__).absolute().parent
 
 # Quick-start development settings - unsuitable for production
-# See https://docs.djangoproject.com/en/1.11/howto/deployment/checklist/
+# See https://docs.djangoproject.com/en/3.2/howto/deployment/checklist/
 
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = False
@@ -37,7 +37,7 @@ DEPLOY_ROOT = Path("/var/lib/pulp")
 MEDIA_ROOT = str(DEPLOY_ROOT / "media")  # Django 3.1 adds support for pathlib.Path
 
 # Static files (CSS, JavaScript, Images)
-# https://docs.djangoproject.com/en/1.11/howto/static-files/
+# https://docs.djangoproject.com/en/3.2/howto/static-files/
 
 STATIC_URL = "/assets/"
 STATIC_ROOT = DEPLOY_ROOT / STATIC_URL.strip("/")
@@ -155,7 +155,7 @@ REST_FRAMEWORK = {
 }
 
 # Password validation
-# https://docs.djangoproject.com/en/dev/ref/settings/#auth-password-validators
+# https://docs.djangoproject.com/en/3.2/ref/settings/#auth-password-validators
 
 AUTH_PASSWORD_VALIDATORS = [
     {"NAME": "django.contrib.auth.password_validation.UserAttributeSimilarityValidator"},
@@ -166,7 +166,7 @@ AUTH_PASSWORD_VALIDATORS = [
 
 
 # Internationalization
-# https://docs.djangoproject.com/en/1.11/topics/i18n/
+# https://docs.djangoproject.com/en/3.2/topics/i18n/
 
 LANGUAGE_CODE = "en-us"
 
@@ -182,7 +182,7 @@ USE_TZ = True
 # A set of default settings to use if the configuration file in
 # /etc/pulp/ is missing or if it does not have values for every setting
 
-# https://docs.djangoproject.com/en/1.11/ref/settings/#databases
+# https://docs.djangoproject.com/en/3.2/ref/settings/#databases
 DATABASES = {
     "default": {
         "ENGINE": "django.db.backends.postgresql",
@@ -201,7 +201,7 @@ REDIS_PASSWORD = None
 REDIS_SSL = False
 REDIS_SSL_CA_CERTS = None
 
-# https://docs.djangoproject.com/en/1.11/ref/settings/#logging and
+# https://docs.djangoproject.com/en/3.2/ref/settings/#logging and
 # https://docs.python.org/3/library/logging.config.html
 LOGGING = {
     "version": 1,

--- a/pulpcore/app/wsgi.py
+++ b/pulpcore/app/wsgi.py
@@ -4,7 +4,7 @@ WSGI config for pulp project.
 It exposes the WSGI callable as a module-level variable named ``application``.
 
 For more information on this file, see
-https://docs.djangoproject.com/en/1.9/howto/deployment/wsgi/
+https://docs.djangoproject.com/en/3.2/howto/deployment/wsgi/
 """
 
 import os

--- a/pulpcore/tests/unit/viewsets/test_base.py
+++ b/pulpcore/tests/unit/viewsets/test_base.py
@@ -24,7 +24,7 @@ class TestGetQuerySet(TestCase):
         expected = models.RepositoryVersion.objects.filter(repository__pk=repo.pk)
 
         # weird, stupid django quirk
-        # https://docs.djangoproject.com/en/2.0/topics/testing/tools/#django.test.TransactionTestCase.assertQuerysetEqual
+        # https://docs.djangoproject.com/en/3.2/topics/testing/tools/#django.test.TransactionTestCase.assertQuerysetEqual
         self.assertQuerysetEqual(queryset, map(repr, expected))
 
     def test_does_not_add_filters(self):
@@ -39,7 +39,7 @@ class TestGetQuerySet(TestCase):
         expected = models.Repository.objects.all()
 
         # weird, stupid django quirk
-        # https://docs.djangoproject.com/en/2.0/topics/testing/tools/#django.test.TransactionTestCase.assertQuerysetEqual
+        # https://docs.djangoproject.com/en/3.2/topics/testing/tools/#django.test.TransactionTestCase.assertQuerysetEqual
         self.assertQuerysetEqual(queryset, map(repr, expected))
 
 


### PR DESCRIPTION
Several references to the official Django documentation used links to a multitude of different versions. This commit makes sure all links to the documentation point to the currently used 3.2 LTS version of Django.

ref #2878