### PR TITLE
Revert "[noissue]: Update cryptography requirement from ~=37.0.2 to ~=37.0.3"

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ aiofiles==0.8.0
 aioredis~=2.0.1
 backoff~=2.1.2
 click<9.0
-cryptography~=37.0.3
+cryptography~=37.0.2
 Django~=3.2.13  # LTS version, switch only if we have a compelling reason to
 django-currentuser~=0.5.3
 django-filter~=22.1


### PR DESCRIPTION
Reverts pulp/pulpcore#2896

37.0.3 has been yanked
https://pypi.org/project/cryptography/#history