### PR TITLE
Changes yarl version requirement to ~=1.0

### DIFF
--- a/CHANGES/2856.misc
+++ b/CHANGES/2856.misc
@@ -1,0 +1,1 @@
+Changed yarl version requirement to ~=1.0.

--- a/requirements.txt
+++ b/requirements.txt
@@ -30,4 +30,4 @@ redis>=3.4.0,<4.2.0
 rq~=1.9.0
 setuptools>=39.2.0,<62.1.0
 whitenoise>=5.0.0,<5.4.0
-yarl~=1.0.0
+yarl~=1.0


### PR DESCRIPTION
fixes: #2856