### PR TITLE
Use published relative paths for FS Exporter

### DIFF
--- a/CHANGES/2933.bugfix
+++ b/CHANGES/2933.bugfix
@@ -1,0 +1,1 @@
+Use published relative paths for FS Exporter.


### PR DESCRIPTION
FS Exporter uses the relative_paths of the content_artifacts instead of
the actual publication's relative path when exporting publications.
This commit use published relative paths if a publication is available

Please be sure you have read our documentation on creating PRs:
https://docs.pulpproject.org/contributing/pull-request-walkthrough.html
