### PR TITLE
Serialize orphan cleanup tasks to prevent them from getting in each other's way

### DIFF
--- a/CHANGES/3030.bugfix
+++ b/CHANGES/3030.bugfix
@@ -1,0 +1,1 @@
+Serialized orphan cleanup tasks with respect to each other to prevent them from failing.

--- a/pulpcore/app/views/orphans.py
+++ b/pulpcore/app/views/orphans.py
@@ -19,6 +19,6 @@ class OrphansView(APIView):
         """
         Cleans up all the Content and Artifact orphans in the system
         """
-        task = dispatch(orphan_cleanup)
+        task = dispatch(orphan_cleanup, exclusive_resources=["/pulp/api/v3/orphans/cleanup/"])
 
         return OperationPostponedResponse(task, request)

--- a/pulpcore/app/viewsets/orphans.py
+++ b/pulpcore/app/viewsets/orphans.py
@@ -29,6 +29,7 @@ class OrphansCleanupViewset(ViewSet):
 
         task = dispatch(
             orphan_cleanup,
+            exclusive_resources=["/pulp/api/v3/orphans/cleanup/"],
             kwargs={"content_pks": content_pks, "orphan_protection_time": orphan_protection_time},
         )
 


### PR DESCRIPTION
Orphan cleanup tasks can get in each other's way by deleting things
before the other task gets a chance to do so. This pops up as a problem
primarily for the RPM plugin.

closes #3030
