### PR TITLE
fixes #3036 -Setup the SSL Context correctly for https proxies

### DIFF
--- a/CHANGES/3036.bugfix
+++ b/CHANGES/3036.bugfix
@@ -1,0 +1,1 @@
+Fixed setting up of default ssl context if the proxy is https


### PR DESCRIPTION
Setup the SSL Context correctly for HTTPS proxies. Look at the issue for more information
https://github.com/pulp/pulpcore/issues/3036