### PR TITLE
Serialize orphan cleanup tasks to prevent them from overlapping

### DIFF
--- a/CHANGES/3030.bugfix
+++ b/CHANGES/3030.bugfix
@@ -1,0 +1,1 @@
+Serialized orphan cleanup tasks with respect to each other to prevent them from failing.

--- a/pulpcore/app/views/orphans.py
+++ b/pulpcore/app/views/orphans.py
@@ -25,6 +25,6 @@ class OrphansView(APIView):
             "`POST /pulp/api/v3/orphans/cleanup/` instead."
         )
 
-        task = dispatch(orphan_cleanup)
+        task = dispatch(orphan_cleanup, exclusive_resources=["/pulp/api/v3/orphans/cleanup/"])
 
         return OperationPostponedResponse(task, request)

--- a/pulpcore/app/viewsets/orphans.py
+++ b/pulpcore/app/viewsets/orphans.py
@@ -26,6 +26,7 @@ class OrphansCleanupViewset(ViewSet):
 
         task = dispatch(
             orphan_cleanup,
+            exclusive_resources=["/pulp/api/v3/orphans/cleanup/"],
             kwargs={"content_pks": content_pks, "orphan_protection_time": orphan_protection_time},
         )
 


### PR DESCRIPTION
Orphan cleanup tasks can get in each other's way by deleting things
before the other task gets a chance to do so. This pops up as a problem
primarily for the RPM plugin.

closes #3030

(cherry picked from commit 5685e59b4c34a80d220c5d8c786d08b765e987b1)

Please be sure you have read our documentation on creating PRs:
https://docs.pulpproject.org/contributing/pull-request-walkthrough.html
