### PR TITLE
Fixes two bugs related to 'range' headers with 'on-demand' content

### DIFF
--- a/CHANGES/3052.bugfix
+++ b/CHANGES/3052.bugfix
@@ -1,0 +1,1 @@
+Fixed 500 error when 'range' header starts with a negative value for 'on-demand' content.

--- a/CHANGES/3054.bugfix
+++ b/CHANGES/3054.bugfix
@@ -1,0 +1,1 @@
+Fixed bug where 'range' header with a start value greater than size of on-demand content would produce an incomplete response.


### PR DESCRIPTION
Fixes 500 error when 'range' header is negative for 'on-demand' content.
Fixes an incomplete response error when 'range' header start value is greater than size of file.
    
fixes: #3052
fixes: #3054
