### PR TITLE
Changed routable on viewsets to be a classmethod

### DIFF
--- a/CHANGES/3056.bugfix
+++ b/CHANGES/3056.bugfix
@@ -1,0 +1,1 @@
+Fixed a bug in the routing logic, where generic base class viewsets were served on actual urls.

--- a/pulpcore/app/urls.py
+++ b/pulpcore/app/urls.py
@@ -62,7 +62,7 @@ class ViewSetNode:
             node (ViewSetNode): A node that represents a viewset and its decendents.
         """
         # Master viewsets do not have endpoints, so they do not need to be registered
-        if not node.viewset.routable:
+        if not node.viewset.routable():
             return
         # Non-nested viewsets are attached to the root node
         if not node.viewset.parent_viewset:

--- a/pulpcore/app/viewsets/base.py
+++ b/pulpcore/app/viewsets/base.py
@@ -261,10 +261,10 @@ class NamedModelViewSet(viewsets.GenericViewSet):
 
         return False
 
-    @property
-    def routable(self) -> bool:
+    @classmethod
+    def routable(cls) -> bool:
         # Determines if ViewSet should be added to router
-        return not self.is_master_viewset()
+        return not cls.is_master_viewset()
 
     @classmethod
     def view_name(cls):

--- a/pulpcore/app/viewsets/content.py
+++ b/pulpcore/app/viewsets/content.py
@@ -138,8 +138,8 @@ class ListContentViewSet(BaseContentViewSet, mixins.ListModelMixin):
         "queryset_scoping": {"function": "scope_queryset"},
     }
 
-    @property
-    def routable(self):
+    @classmethod
+    def routable(cls):
         """Do not hide from the routers."""
         return True
 

--- a/pulpcore/app/viewsets/publication.py
+++ b/pulpcore/app/viewsets/publication.py
@@ -102,8 +102,8 @@ class ListPublicationViewSet(NamedModelViewSet, mixins.ListModelMixin):
         "queryset_scoping": {"function": "scope_queryset"},
     }
 
-    @property
-    def routable(self):
+    @classmethod
+    def routable(cls):
         """Do not hide from the routers."""
         return True
 
@@ -152,8 +152,8 @@ class ListContentGuardViewSet(
         "queryset_scoping": {"function": "scope_queryset"},
     }
 
-    @property
-    def routable(self):
+    @classmethod
+    def routable(cls):
         """Do not hide from the routers."""
         return True
 
@@ -353,8 +353,8 @@ class ListDistributionViewSet(NamedModelViewSet, mixins.ListModelMixin):
         "queryset_scoping": {"function": "scope_queryset"},
     }
 
-    @property
-    def routable(self):
+    @classmethod
+    def routable(cls):
         """Do not hide from the routers."""
         return True
 

--- a/pulpcore/app/viewsets/repository.py
+++ b/pulpcore/app/viewsets/repository.py
@@ -73,8 +73,8 @@ class ListRepositoryViewSet(BaseRepositoryViewSet, mixins.ListModelMixin):
         "queryset_scoping": {"function": "scope_queryset"},
     }
 
-    @property
-    def routable(self):
+    @classmethod
+    def routable(cls):
         """Do not hide from the routers."""
         return True
 


### PR DESCRIPTION
The property that it was, was never evaluated, because the routing tree
is determinded with viewset classes and not instances.

fixes #3056