### PR TITLE
Allow uploading existing content

### DIFF
--- a/CHANGES/plugin_api/3081.feature
+++ b/CHANGES/plugin_api/3081.feature
@@ -1,0 +1,3 @@
+The upload feature was changed to accept already existing content. This allows multiple users
+to own identical content when working with plugins that implement the 'retrieve' method
+inside their ``ContentUpload`` serializers.

--- a/docs/plugins/plugin-writer/concepts/subclassing/viewsets.rst
+++ b/docs/plugins/plugin-writer/concepts/subclassing/viewsets.rst
@@ -124,7 +124,10 @@ To use that ViewSet, the serializer for the content type should inherit from
 ``SingleArtifactContentUploadSerializer``. By overwriting the ``deferred_validate`` method
 instead of ``validate``, this serializer can do detailed analysis of the given or uploaded Artifact
 in order to fill database fields of the content type like "name", "version", etc. This part of
-validation is only called in the task context.
+validation is only called in the task context. You can also overwrite the ``retrieve`` method
+if you want your content type to be compatible with the functionality that makes sure the
+``pulp_href`` of the already existing unit is returned and re-used when attempting to re-upload
+duplicate content. If the ``retrieve`` method is not implemented, an exception would be raised.
 
 If the uploaded content does not need to be stored, plugin writers may derive from the class
 ``NoArtifactContentUploadViewSet``. Again, the same analogy applies to this workflow. To use this


### PR DESCRIPTION
Attempting to upload existing content now returns the href of the
existing unit instead of raising an exception, possibly also adding
the content into a specified repository if it was not there already.

To make this work for a specific plugin, the retrieve() function
has to be implemented in the content serializer specific for the
given plugin. This commit does not break the behavior of plugins
not containing this implementation yet in any way.

closes #3081

Please be sure you have read our documentation on creating PRs:
https://docs.pulpproject.org/contributing/pull-request-walkthrough.html
