### PR TITLE
Reworked content_stages bulk_update() deadlock fix.

### DIFF
--- a/CHANGES/3111.bugfix
+++ b/CHANGES/3111.bugfix
@@ -1,0 +1,1 @@
+Fixed another rare deadlock for high-concurrency/overlapping-content syncs.


### PR DESCRIPTION
Note to Future Self: Nested atomic-transactions are more painful than
one might think.

fixes #3111.
[nocoverage]

