### PR TITLE
Log downloader URL

### DIFF
--- a/CHANGES/3088.feature
+++ b/CHANGES/3088.feature
@@ -1,0 +1,1 @@
+Add a debug log to see where is file downloaded from.

--- a/pulpcore/download/base.py
+++ b/pulpcore/download/base.py
@@ -159,6 +159,7 @@ class BaseDownloader:
         self._writer = None
         self.validate_digests()
         self.validate_size()
+        log.debug(f"Downloaded file from {self.url}")
 
     def fetch(self):
         """


### PR DESCRIPTION
Add ``debug`` log line to check which URL is used to download file.
Helpful to test ACS.

closes: #3088
https://github.com/pulp/pulpcore/issues/3088

Please be sure you have read our documentation on creating PRs:
https://docs.pulpproject.org/contributing/pull-request-walkthrough.html
