### PR TITLE
Enable telemetry for users

### DIFF
--- a/CHANGES/3115.feature
+++ b/CHANGES/3115.feature
@@ -1,0 +1,3 @@
+Introduces anonymous telemetry data posting to `<https://analytics.pulpproject.org/>`_. This is
+enabled by default, and can be disabled by setting the ``TELEMETRY`` setting to ``False``. See the
+:ref:`telemetry docs <telemetry>` for more info on exactly what is posted along with an example.

--- a/docs/components.rst
+++ b/docs/components.rst
@@ -80,6 +80,7 @@ started and stopped without notifying Pulp.
 All necessary information about tasks is stored in Pulp's Postgres database as a single source of
 truth. In case your tasking system get's jammed, there is a guide to help :ref:debugging_tasks.
 
+
 Static Content
 --------------
 
@@ -100,3 +101,43 @@ Collect all of the static content into place using the ``collectstatic`` command
 ``DJANGO_SETTINGS_MODULE="pulpcore.app.settings"``. Run ``collectstatic`` as follows::
 
     $ pulpcore-manager collectstatic
+
+
+
+.. _telemetry:
+
+Telemetry Collection
+--------------------
+
+By default, Pulp installations post anonymous telemetry data every 24 hours which is summarized on
+`<https://analytics.pulpproject.org/>`_ and aids in project decision making. This is enabled by
+default but can be disabled by setting ``TELEMETRY=False`` in your settings.
+
+Here is the list of exactly what is collected along with an example below:
+
+* The version of Pulp components installed
+* The number of worker processes and number of hosts (not hostnames) those workers run on
+* The number of content app processes and number of hosts (not hostnames) those content apps run on
+
+An example payload:
+
+.. code-block:: json
+
+    {
+        "systemId": "a6d91458-32e8-4528-b608-b2222ede994e",
+    	"onlineContentApps": {
+            "processes": 2,
+            "hosts": 1
+    	},
+    	"onlineWorkers": {
+            "processes": 2,
+            "hosts": 1
+	    },
+    	"components": [{
+            "name": "core",
+            "version": "3.21.0"
+	    }, {
+            "name": "file",
+            "version": "1.12.0"
+    	}]
+    }

--- a/docs/configuration/settings.rst
+++ b/docs/configuration/settings.rst
@@ -406,3 +406,15 @@ TASK_DIAGNOSTICS
     ``/var/tmp/pulp/<task_UUID>/``. This is ``False`` by default.
 
       * memory - the task's max resident set size in MB.
+
+
+.. _telemetry-setting:
+
+TELEMETRY
+^^^^^^^^^
+
+    If ``True``, Pulp will anonymously post telemetry information to
+    `<https://analytics.pulpproject.org/>`_ and aids in project decision making. See the
+    :ref:`telemetry docs <telemetry>` for more info on exactly what is posted along with an example.
+
+    Defaults to ``True``.

--- a/pulpcore/app/settings.py
+++ b/pulpcore/app/settings.py
@@ -289,6 +289,8 @@ DEFAULT_AUTO_FIELD = "django.db.models.AutoField"
 
 TASK_DIAGNOSTICS = False
 
+TELEMETRY = True
+
 # HERE STARTS DYNACONF EXTENSION LOAD (Keep at the very bottom of settings.py)
 # Read more at https://dynaconf.readthedocs.io/en/latest/guides/django.html
 from dynaconf import DjangoDynaconf, Validator  # noqa

--- a/pulpcore/app/tasks/telemetry.py
+++ b/pulpcore/app/tasks/telemetry.py
@@ -9,7 +9,6 @@ from asgiref.sync import sync_to_async
 from google.protobuf.json_format import MessageToJson
 
 from pulpcore.app.apps import pulp_plugin_configs
-from pulpcore.app.util import get_telemetry_posting_url
 from pulpcore.app.models import SystemID
 from pulpcore.app.models.status import ContentAppStatus
 from pulpcore.app.models.task import Worker
@@ -17,6 +16,18 @@ from pulpcore.app.protobuf.telemetry_pb2 import Telemetry
 
 
 logger = logging.getLogger(__name__)
+
+
+PRODUCTION_URL = "https://analytics.pulpproject.org/"
+DEV_URL = "https://dev.analytics.pulpproject.org/"
+
+
+def get_telemetry_posting_url():
+    for app in pulp_plugin_configs():
+        if ".dev" in app.version:
+            return DEV_URL
+
+    return PRODUCTION_URL
 
 
 async def _num_hosts(qs):


### PR DESCRIPTION
By default Pulp systems will now submit anonymous telemetry information
to https://analytics.pulpproject.org/. It documents exactly what is
submitted, and introduces the `TELEMETRY` setting which can be used to
disable anonymous telemetry submission entirely.
    
closes #3115