### PR TITLE
Remove the pull request template for reading the documentation

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,2 +1,0 @@
-Please be sure you have read our documentation on creating PRs:
-https://docs.pulpproject.org/contributing/pull-request-walkthrough.html


### PR DESCRIPTION
I observed that no one (including our contributors) does read the pull
request's walkthrough. Almost all of us ignore the paragraph and do not
remove it when publishing a pull request. When reviewing pull requests
of our contributors, we still have to explain to them our workflows (e.g.,
add [noissue], link an issue number) in order to proceed further.

[noissue]
