### PR TITLE
Endpoint for listing all Remote objects

### DIFF
--- a/CHANGES/2530.feature
+++ b/CHANGES/2530.feature
@@ -1,0 +1,1 @@
+New endpoint to list all Remote objects is now available at /pulp/api/v3/remotes/.

--- a/pulpcore/app/viewsets/__init__.py
+++ b/pulpcore/app/viewsets/__init__.py
@@ -61,6 +61,7 @@ from .repository import (  # noqa
     ReadOnlyRepositoryViewSet,
     RemoteFilter,
     RemoteViewSet,
+    ListRemoteViewSet,
     RepositoryViewSet,
     RepositoryVersionViewSet,
     ListRepositoryVersionViewSet,

--- a/pulpcore/app/viewsets/repository.py
+++ b/pulpcore/app/viewsets/repository.py
@@ -236,6 +236,29 @@ class RemoteFilter(BaseFilterSet):
         fields = {"name": NAME_FILTER_OPTIONS, "pulp_last_updated": DATETIME_FILTER_OPTIONS}
 
 
+class ListRemoteViewSet(NamedModelViewSet, mixins.ListModelMixin):
+    endpoint_name = "remotes"
+    queryset = Remote.objects.all()
+    serializer_class = RemoteSerializer
+    filterset_class = RemoteFilter
+
+    DEFAULT_ACCESS_POLICY = {
+        "statements": [
+            {
+                "action": ["list"],
+                "principal": "authenticated",
+                "effect": "allow",
+            },
+        ],
+        "queryset_scoping": {"function": "scope_queryset"},
+    }
+
+    @classmethod
+    def routable(cls):
+        """Do not hide from the routers."""
+        return True
+
+
 class RemoteViewSet(
     NamedModelViewSet,
     mixins.CreateModelMixin,


### PR DESCRIPTION
All remotes can now be listed at /pulp/api/v3/remotes/, which works
the same as listing distributions at /pulp/api/v3/distributions/.

closes #2530

Please be sure you have read our documentation on creating PRs:
https://docs.pulpproject.org/contributing/pull-request-walkthrough.html
