### PR TITLE
Add `write_only_fields` to RemoteSerializer

### DIFF
--- a/CHANGES/2825.feature
+++ b/CHANGES/2825.feature
@@ -1,0 +1,1 @@
+Create HiddenFieldsMixin serializer and add hidden_fields to RemoteSerializer and UserSerializer.

--- a/pulpcore/app/serializers/__init__.py
+++ b/pulpcore/app/serializers/__init__.py
@@ -16,6 +16,7 @@ from .base import (  # noqa
     TaskGroupOperationResponseSerializer,
     ValidateFieldsMixin,
     validate_unknown_fields,
+    HiddenFieldsMixin,
 )
 from .fields import (  # noqa
     BaseURLField,

--- a/pulpcore/app/serializers/repository.py
+++ b/pulpcore/app/serializers/repository.py
@@ -17,6 +17,7 @@ from pulpcore.app.serializers import (
     RepositoryVersionRelatedField,
     RepositoryVersionsIdentityFromRepositoryField,
     ValidateFieldsMixin,
+    HiddenFieldsMixin,
 )
 
 
@@ -70,7 +71,7 @@ class RepositorySerializer(ModelSerializer):
         )
 
 
-class RemoteSerializer(ModelSerializer):
+class RemoteSerializer(ModelSerializer, HiddenFieldsMixin):
     """
     Every remote defined by a plugin should have a Remote serializer that inherits from this
     class. Please import from `pulpcore.plugin.serializers` rather than from this module directly.
@@ -318,6 +319,7 @@ class RemoteSerializer(ModelSerializer):
             "sock_read_timeout",
             "headers",
             "rate_limit",
+            "hidden_fields",
         )
 
 

--- a/pulpcore/app/serializers/user.py
+++ b/pulpcore/app/serializers/user.py
@@ -18,8 +18,12 @@ from pulpcore.app.serializers import (
     IdentityField,
     ValidateFieldsMixin,
     ModelSerializer,
+    HiddenFieldsMixin,
 )
-from pulpcore.app.util import get_viewset_for_model, get_request_without_query_params
+from pulpcore.app.util import (
+    get_viewset_for_model,
+    get_request_without_query_params,
+)
 
 User = get_user_model()
 
@@ -87,7 +91,7 @@ class UserGroupSerializer(serializers.ModelSerializer):
         fields = ("name", "pulp_href")
 
 
-class UserSerializer(serializers.ModelSerializer):
+class UserSerializer(serializers.ModelSerializer, HiddenFieldsMixin):
     """Serializer for User."""
 
     pulp_href = IdentityField(view_name="users-detail")
@@ -143,6 +147,7 @@ class UserSerializer(serializers.ModelSerializer):
             "is_active",
             "date_joined",
             "groups",
+            "hidden_fields",
         )
 
 


### PR DESCRIPTION
fixes: [pulp#2825](https://github.com/pulp/pulpcore/issues/2825)

Please be sure you have read our documentation on creating PRs:
https://docs.pulpproject.org/contributing/pull-request-walkthrough.html
