### PR TITLE
Add stub implementation for pulp_uuid()

### DIFF
--- a/pulpcore/app/models/__init__.py
+++ b/pulpcore/app/models/__init__.py
@@ -5,6 +5,7 @@ from .base import (  # noqa
     BaseModel,
     Label,
     MasterModel,
+    pulp_uuid,
 )
 
 from .access_policy import (  # noqa

--- a/pulpcore/app/models/base.py
+++ b/pulpcore/app/models/base.py
@@ -9,8 +9,18 @@ from django.db.models.base import ModelBase
 from django_lifecycle import LifecycleModel
 
 
+def pulp_uuid():
+    """
+    Abstract wrapper for UUID generator.
+
+    Allows the implementation to be swapped without triggering migrations.
+    """
+    return uuid.uuid4()
+
+
 class Label(LifecycleModel):
-    """Model for handling resource labels.
+    """
+    Model for handling resource labels.
 
     Labels are key/value data that can be associated with any BaseModel.
 
@@ -38,7 +48,8 @@ class Label(LifecycleModel):
 
 
 class BaseModel(LifecycleModel):
-    """Base model class for all Pulp models.
+    """
+    Base model class for all Pulp models.
 
     This model inherits from `LifecycleModel` which allows all Pulp models to be used with
     `django-lifecycle`.
@@ -99,7 +110,8 @@ class MasterModelMeta(ModelBase):
 
 
 class MasterModel(BaseModel, metaclass=MasterModelMeta):
-    """Base model for the "Master" model in a "Master-Detail" relationship.
+    """
+    Base model for the "Master" model in a "Master-Detail" relationship.
 
     Provides methods for casting down to detail types, back up to the master type,
     as well as a model field for tracking the type.
@@ -179,7 +191,8 @@ class MasterModel(BaseModel, metaclass=MasterModelMeta):
 
     @property
     def master(self):
-        """The "Master" model instance of this master-detail pair
+        """
+        The "Master" model instance of this master-detail pair
 
         If this is already the master model instance, it will return itself.
         """


### PR DESCRIPTION
The other PR https://github.com/pulp/pulpcore/pull/3136 merges a change which which would result in some plugins desiring a new migration.  The migration isn't *necessary* for the plugin to work - it would work perfectly fine without it - but in terms of CI and development it might be annoying if not merged. 

The migration would reference this `pulp_uuid()` function provided by pulpcore 3.21, so in normal circumstances the plugin author would want to bump their minimum supported pulpcore version if they merged it, like we would with any other core feature that a plugin wants to leverage (e.g. RBAC).

However, since simply providing that function in pulpcore (without using it anywhere) only requires about 4 lines of absolutely trivial code and doesn't carry any risk (it would also be dead code, as far as existing pulpcore / plugins are concerned), it's something we could easily and safely backport, and if we did so, plugins could adopt that migration with less concern about the pulpcore version.  

[noissue]