### PR TITLE
Improves docs on settings

### DIFF
--- a/CHANGES/2417.doc
+++ b/CHANGES/2417.doc
@@ -1,0 +1,1 @@
+Improvements clarifying how to specify settings and which settings are required.

--- a/docs/configuration/applying.rst
+++ b/docs/configuration/applying.rst
@@ -3,63 +3,65 @@
 Applying Settings
 =================
 
-Pulp uses `dynaconf <https://dynaconf.readthedocs.io/en/latest/>`_ for its settings which allows you
-to configure Pulp in a few ways:
+Pulp uses `dynaconf <https://www.dynaconf.com/>`_ for its settings which allows you
+to configure Pulp settings using various ways:
 
 
-By Configuration File
+* :ref:`Environment Variables <env-var-settings>` - Enabled by default.
+
+* :ref:`Configuration File <config-file-settings>` - Disabled by default, but easy to enable.
+  Enabled by ``pulp_installer``.
+
+.. _env-var-settings:
+
+Environment Variables
 ---------------------
 
-To configure Pulp by settings file, you must set the format and location of the config file by
-specifying the ``PULP_SETTINGS`` environment variable. For example, if you wanted to use Python to
-specify your configuration, and provide it at ``/etc/pulp/settings.py`` you could::
+Configuration by specifying environment variables is enabled by default. Any
+:ref:`Setting <settings>` can be configured using Dynaconf by prepending ``PULP_`` to the setting
+name. For example :ref:`SECRET_KEY <secret-key-setting>` can be specified as the ``PULP_SECRET_KEY``
+environment variable. For example, in a shell you can use ``export`` to set this::
+
+    export PULP_SECRET_KEY="This should be a 50 chars or longer unique secret!"
+
+
+.. _config-file-settings:
+
+Configuration File
+------------------
+
+By default, Pulp does not read settings from a configuration file. Enable this by specifying the
+``PULP_SETTINGS`` environment variable with the path to your configuration file. For example::
 
     export PULP_SETTINGS=/etc/pulp/settings.py
 
+Then you can specify settings with Python variable assignment in the ``/etc/pulp/settings.py``. For
+example, you can specify :ref:`SECRET_KEY <secret-key-setting>` with::
 
-Or in a systemd file you could::
+    $ cat /etc/pulp/settings.py
+    SECRET_KEY="This should be a 50 chars or longer unique secret!"
 
-    Environment="PULP_SETTINGS=/etc/pulp/settings.py" as the Ansible Installer does.
+In this example the settings file ends in ".py" so it needs to be valid Python, but it could use any
+`dynaconf supported format <https://www.dynaconf.com/#supported-formats>`_.
+
+.. note::
+
+    The configuration file and directories containing the configuration file must be readable by the
+    user Pulp runs as. If using SELinux, assign the ``system_u:object_r:pulpcore_etc_t:s0`` label.
 
 
-Dynaconf supports `settings in multiple file formats <https://www.dynaconf.com/configuration/>`_
-Dynaconf also support `local settings file <https://www.dynaconf.com/settings_files/#local-settings-files>`_
+.. _pulp-installer-settings:
 
-This file should have permissions of:
+pulp_installer
+--------------
 
-* mode: 640
-* owner: root
-* group: pulp (the group of the account that pulp runs under)
-* SELinux context: system_u:object_r:etc_t:s0
+The `pulp_installer <https://docs.pulpproject.org/pulp_installer/>`_ enables configuration via a
+settings file that lives at ``/etc/pulp/settings.py``. It does this by having each systemd file that
+starts a Pulp service include::
 
-If it is in its own directory like ``/etc/pulp``, the directory should have permissions of:
+    Environment="PULP_SETTINGS=/etc/pulp/settings.py"
 
-* mode: 750
-* owner: root
-* group: pulp (the group of the account that pulp runs under)
-* SELinux context: unconfined_u:object_r:etc_t:s0
-
-An example of a minimal settings.py file is::
-
-    SECRET_KEY='50characterslongstring'
-    CONTENT_ORIGIN='http://localhost:24816'
-    CACHE_ENABLED=True
-    REDIS_HOST='localhost'
-    REDIS_PORT=6379
-
-Note that the single quotes are necessary.
-
-By Environment Variables
-------------------------
-
-Many users specify their Pulp settings entirely by Environment Variables. Each of the settings can
-be configured using Dynaconf by prepending ``PULP_`` to the name of the setting and specifying that
-as an Environment Variable. For example the ``SECRET_KEY`` can be specified by exporting the
-``PULP_SECRET_KEY`` variable.
-
-When using `pulp_installer`
----------------------------
-
-A Pulp upgrade using `pulp_installer` may override the original ``/etc/pulp/settings.py``.
-To keep your settings through an upgrade, use the `local settings` file located at
-``/etc/pulp/settings.local.py``.
+A Pulp upgrade using ``pulp_installer`` will override the original ``/etc/pulp/settings.py``.
+To keep your settings through an upgrade, use the "local settings" file located at
+``/etc/pulp/settings.local.py`` which takes precedence over ``/etc/pulp/settings.py`` on a
+setting-by-setting basis.

--- a/docs/configuration/settings.rst
+++ b/docs/configuration/settings.rst
@@ -3,6 +3,18 @@
 Settings
 ========
 
+There are only two required settings, although specific plugins may have additional required
+settings.
+
+* :ref:`SECRET_KEY <secret-key-setting>`
+* :ref:`CONTENT_ORIGIN <content-origin-setting>`
+
+.. note::
+
+    For more information on how to specify settings see the
+    :ref:`Applying Settings docs <applying-settings>`.
+
+
 Pulp uses three types of settings:
 
 * :ref:`Django settings <django-settings>` Pulp is configuring
@@ -15,9 +27,11 @@ Pulp uses three types of settings:
 Django Settings
 ---------------
 
-Pulp is a Django project, so any Django `Django setting
-<https://docs.djangoproject.com/en/3.2/ref/settings/>`_ can also be set to configure your Pulp
-deployment.
+Below is a list of the most common Django settings Pulp users typically use. Pulp is a Django
+project, so any `Django setting <https://docs.djangoproject.com/en/3.2/ref/settings/>`_ can be set.
+
+
+.. _secret-key-setting:
 
 SECRET_KEY
 ^^^^^^^^^^
@@ -36,6 +50,7 @@ SECRET_KEY
    chars = 'abcdefghijklmnopqrstuvwxyz0123456789!@#$%^&*(-_=+)'
    print(''.join(random.choice(chars) for i in range(50)))
 
+
 DB_ENCRYPTION_KEY
 ^^^^^^^^^^^^^^^^^
 
@@ -50,11 +65,13 @@ DB_ENCRYPTION_KEY
 
     openssl rand -base64 32 > /etc/pulp/certs/database_fields.symmetric.key
 
+
 DATABASES
 ^^^^^^^^^
 
    By default Pulp uses PostgreSQL on localhost. PostgreSQL is the only supported database. For
    instructions on how to configure the database, refer to :ref:`database installation <database-install>`.
+
 
 DEFAULT_FILE_STORAGE
 ^^^^^^^^^^^^^^^^^^^^
@@ -65,6 +82,7 @@ DEFAULT_FILE_STORAGE
    For more information about different Pulp storage options, see the
    :ref:`storage documentation <storage>`.
 
+
 REDIRECT_TO_OBJECT_STORAGE
 ^^^^^^^^^^^^^^^^^^^^^^^^^^
 
@@ -73,6 +91,7 @@ REDIRECT_TO_OBJECT_STORAGE
    artifacts are always served by the content app instead.
 
    Defaults to ``True``; ignored for local file storage.
+
 
 MEDIA_ROOT
 ^^^^^^^^^^
@@ -89,6 +108,7 @@ MEDIA_ROOT
    * group: pulp (the group of the account that pulp runs under)
    * SELinux context: system_u:object_r:pulpcore_var_lib_t:s0
 
+
 LOGGING
 ^^^^^^^
 
@@ -98,6 +118,7 @@ LOGGING
 
    Enabling DEBUG logging is a common troubleshooting step. See the :ref:`enabling-debug-logging`
    documentation for details on how to do that.
+
 
 AUTHENTICATION_BACKENDS
 ^^^^^^^^^^^^^^^^^^^^^^^
@@ -110,6 +131,7 @@ AUTHENTICATION_BACKENDS
    To change the authentication types Pulp will use, modify the ``AUTHENTICATION_BACKENDS``
    settings. See the `Django authentication documentation <https://docs.djangoproject.com/en/3.2/
    topics/auth/customizing/#authentication-backends>`_ for more information.
+
 
 .. _redis-settings:
 
@@ -130,15 +152,18 @@ The following Redis settings can be set in your Pulp config:
 
 Below are some common settings used for Redis configuration.
 
+
 REDIS_HOST
 ^^^^^^^^^^
 
    The hostname for Redis.
 
+
 REDIS_PORT
 ^^^^^^^^^^
 
    The port for Redis.
+
 
 REDIS_PASSWORD
 ^^^^^^^^^^^^^^
@@ -153,6 +178,7 @@ Pulp Settings
 
 Pulp defines the following settings itself:
 
+
 .. _api-root:
 
 API_ROOT
@@ -164,6 +190,7 @@ API_ROOT
 
    Defaults to ``/pulp/``. After the application appends ``api/v3/`` it makes the V3 API by default
    serve from ``/pulp/api/v3/``.
+
 
 WORKING_DIRECTORY
 ^^^^^^^^^^^^^^^^^
@@ -184,6 +211,7 @@ WORKING_DIRECTORY
     volume for performance reasons. Files are commonly staged in the ``WORKING_DIRECTORY`` and
     validated before being moved to their permanent home in ``MEDIA_ROOT``.
 
+
 CHUNKED_UPLOAD_DIR
 ^^^^^^^^^^^^^^^^^^
 
@@ -192,6 +220,9 @@ CHUNKED_UPLOAD_DIR
    option allows users to customize the actual place where chunked uploads should be stored within
    the declared storage. The default, ``upload``, is sufficient for most use cases. A change to
    this setting only applies to uploads created after the change.
+
+
+.. _content-origin-setting:
 
 CONTENT_ORIGIN
 ^^^^^^^^^^^^^^
@@ -243,6 +274,7 @@ CACHE_ENABLED
      The entire response is not stored in the cache. Only the location of the file needed to
      recreate the response is stored. This reduces database queries and allows for many
      responses to be stored inside the cache.
+
 
 CACHE_SETTINGS
 ^^^^^^^^^^^^^^


### PR DESCRIPTION
This improves (and shortens) the documentation on:

* Applying settings in various ways using dynaconf (with examples).
* Which settings are required

closes #2417