### PR TITLE
Addressed another deadlock-window in overlapping-content-syncs path.

### DIFF
--- a/CHANGES/3284.bugfix
+++ b/CHANGES/3284.bugfix
@@ -1,0 +1,1 @@
+Another step on closing the deadlock-window when syncing overlapping content.


### PR DESCRIPTION
In this episode, we teach content_stages to not do updates that aren't changing anything. This removes an entire class of potential-deadlocks from the overlapping-content path - we don't deadlock, because we have stopped acquiring locks for rows we don't actually need to change.

fixes #3284.
[nocoverage]