### PR TITLE
[noissue] Moves some tasks tests from pulp_file into pulpcore.

### DIFF
--- a/pulpcore/tests/functional/api/test_tasking.py
+++ b/pulpcore/tests/functional/api/test_tasking.py
@@ -1,11 +1,16 @@
 """Tests related to the tasking system."""
+import json
 import pytest
 import subprocess
 import time
+from aiohttp import BasicAuth
+from urllib.parse import urljoin
 from uuid import uuid4
 
-from pulp_smash.pulp3.bindings import monitor_task
+from pulpcore.constants import TASK_FINAL_STATES
 from pulpcore.client.pulpcore import ApiException
+
+from pulpcore.tests.functional.utils import download_file, monitor_task
 
 
 @pytest.fixture
@@ -31,8 +36,23 @@ def dispatch_task(cid):
     return _dispatch_task
 
 
+@pytest.fixture
+def task(dispatch_task, tasks_api_client):
+    """Fixture containing a Task."""
+    task_href = dispatch_task("time.sleep", args=(0,))
+    task = tasks_api_client.read(task_href)
+
+    yield task
+
+    if task.state not in TASK_FINAL_STATES:
+        cancelling_task = tasks_api_client.tasks_cancel(task_href, {"state": "canceled"})
+        monitor_task(cancelling_task.pulp_href)
+
+    tasks_api_client.delete(task_href)
+
+
 @pytest.mark.parallel
-def test_multi_resource_locking(tasks_api_client, dispatch_task):
+def test_multi_resource_locking(dispatch_task):
     task_href1 = dispatch_task(
         "time.sleep", args=(1,), exclusive_resources=["AAAA"], shared_resources=["BBBB"]
     )
@@ -88,9 +108,11 @@ def test_delete_cancel_waiting_task(dispatch_task, tasks_api_client):
     assert task.state == "canceled"
 
 
-@pytest.mark.parallel
+@pytest.mark.skip(
+    reason="This is a flaky test that fails from time to time. Probably gonna be fixed by 3319"
+)
 def test_delete_cancel_running_task(dispatch_task, tasks_api_client):
-    task_href = dispatch_task("time.sleep", args=(600,))
+    task_href = dispatch_task("time.sleep", args=(6000,))
 
     for i in range(10):
         task = tasks_api_client.read(task_href)
@@ -141,3 +163,108 @@ def test_cancel_nonexistent_task(pulp_api_v3_path, tasks_api_client):
     with pytest.raises(ApiException) as ctx:
         tasks_api_client.tasks_cancel(task_href, {"state": "canceled"})
     assert ctx.value.status == 404
+
+
+@pytest.mark.parallel
+def test_retriving_limited_task_fields(task, bindings_cfg):
+    """Verify for specific fields retrieve in the payload."""
+    expected_fields = set(("pulp_href", "state", "worker"))
+
+    auth = BasicAuth(login=bindings_cfg.username, password=bindings_cfg.password)
+    full_href = urljoin(bindings_cfg.host, task.pulp_href)
+
+    response = download_file(f"{full_href}?fields={','.join(expected_fields)}", auth=auth)
+    parsed_response = json.loads(response.body)
+
+    returned_fields = set(parsed_response.keys())
+
+    assert expected_fields == returned_fields
+
+
+@pytest.mark.parallel
+def test_retrieve_task_without_specific_fields(task, bindings_cfg):
+    """Verify if some fields are excluded from the response."""
+    unexpected_fields = set(("state", "worker"))
+
+    auth = BasicAuth(login=bindings_cfg.username, password=bindings_cfg.password)
+    full_href = urljoin(bindings_cfg.host, task.pulp_href)
+
+    response = download_file(f"{full_href}?exclude_fields={','.join(unexpected_fields)}", auth=auth)
+    parsed_response = json.loads(response.body)
+
+    returned_fields = set(parsed_response.keys())
+
+    assert unexpected_fields.isdisjoint(returned_fields)
+
+
+@pytest.mark.parallel
+def test_retrieve_task_with_minimal_fields(task, bindings_cfg):
+    """Verify if some fields doesn't show when retrieving the minimal payload."""
+    unexpected_fields = set(("progress_reports", "parent_task", "error"))
+
+    auth = BasicAuth(login=bindings_cfg.username, password=bindings_cfg.password)
+    full_href = urljoin(bindings_cfg.host, task.pulp_href)
+
+    response = download_file(f"{full_href}?minimal=true", auth=auth)
+    parsed_response = json.loads(response.body)
+
+    returned_fields = set(parsed_response.keys())
+
+    assert unexpected_fields.isdisjoint(returned_fields)
+
+
+@pytest.mark.parallel
+def test_retrieve_task_using_invalid_worker(tasks_api_client):
+    """Expects to raise an exception when using invalid worker value as filter."""
+
+    with pytest.raises(ApiException) as ctx:
+        tasks_api_client.list(worker=str(uuid4()))
+
+    assert ctx.value.status == 400
+
+
+@pytest.mark.parallel
+def test_retrieve_task_using_valid_worker(task, tasks_api_client):
+    """Expects to retrieve a task using a valid worker URI as filter."""
+
+    response = tasks_api_client.list(worker=task.worker)
+
+    assert response.results and response.count
+
+
+@pytest.mark.parallel
+def test_retrieve_task_using_invalid_date(tasks_api_client):
+    """Expects to raise an exception when using invalid dates as filters"""
+    with pytest.raises(ApiException) as ctx:
+        tasks_api_client.list(finished_at=str(uuid4()), started_at=str(uuid4()))
+
+    assert ctx.value.status == 400
+
+
+@pytest.mark.parallel
+def test_retrieve_task_using_valid_date(task, tasks_api_client):
+    """Expects to retrieve a task using a valid date."""
+
+    response = tasks_api_client.list(started_at=task.started_at)
+
+    assert response.results and response.count
+
+
+@pytest.mark.parallel
+def test_search_task_by_name(task, tasks_api_client):
+    task_name = task.name
+    search_results = tasks_api_client.list(name=task.name).results
+
+    assert search_results
+    assert all([task.name == task_name for task in search_results])
+
+
+@pytest.mark.parallel
+def test_search_task_using_an_invalid_name(tasks_api_client):
+    """Expect to return an empty results array when searching using an invalid
+    task name.
+    """
+
+    search_results = tasks_api_client.list(name=str(uuid4()))
+
+    assert not search_results.results and not search_results.count

--- a/pulpcore/tests/functional/utils.py
+++ b/pulpcore/tests/functional/utils.py
@@ -1,5 +1,7 @@
 """Utilities for Pulpcore tests."""
 import aiohttp
+import asyncio
+from dataclasses import dataclass
 
 from functools import partial
 from time import sleep
@@ -92,3 +94,32 @@ def monitor_task_group(tg_href):
         raise PulpTaskGroupError(task_group=tg)
 
     return tg
+
+
+@dataclass
+class Download:
+    """Class for representing a downloaded file."""
+
+    body: bytes
+    response_obj: aiohttp.ClientResponse
+
+    def __init__(self, body, response_obj):
+        self.body = body
+        self.response_obj = response_obj
+
+
+def download_file(url, auth=None, headers=None):
+    """Download a file.
+
+    :param url: str URL to the file to download
+    :param auth: `aiohttp.BasicAuth` containing basic auth credentials
+    :param headers: dict of headers to send with the GET request
+    :return: Download
+    """
+    return asyncio.run(_download_file(url, auth=auth, headers=headers))
+
+
+async def _download_file(url, auth=None, headers=None):
+    async with aiohttp.ClientSession(auth=auth, raise_for_status=True) as session:
+        async with session.get(url, verify_ssl=False, headers=headers) as response:
+            return Download(body=await response.read(), response_obj=response)


### PR DESCRIPTION
Since we found that some tests from `pulp_file` not only needed a fixture from `pulpcore` but also make sense to be here, we decided to move those tests and a `download_file` utility into `pulpcore`.

You can follow the discussion that ended up into this PR [here](https://github.com/pulp/pulp_file/pull/845#pullrequestreview-1144801290)

And `pulp_smash` no more.