### PR TITLE
Ensure that pulp-export correctly locks repos-being-exported.

### DIFF
--- a/CHANGES/3370.bugfix
+++ b/CHANGES/3370.bugfix
@@ -1,0 +1,1 @@
+Insured that pulp-export correctly locks repos-being-exported.

--- a/pulpcore/app/viewsets/exporter.py
+++ b/pulpcore/app/viewsets/exporter.py
@@ -146,6 +146,7 @@ class PulpExportViewSet(ExportViewSet):
         task = dispatch(
             pulp_export,
             exclusive_resources=[exporter],
+            shared_resources=exporter.repositories.all(),
             kwargs={"exporter_pk": str(exporter.pk), "params": request.data},
         )
 


### PR DESCRIPTION
Tests handled in pulp_file.

fixes #3370.
[nocoverage]