### PR TITLE
Adjust cryptography dependency

### DIFF
--- a/CHANGES/3269.bugfix
+++ b/CHANGES/3269.bugfix
@@ -1,0 +1,1 @@
+Adjust the dependency on ``cryptography`` to suite more versions of ``pulp-certguard``.

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ aiofiles==22.1.0
 aioredis~=2.0.1
 backoff~=2.1.2
 click<9.0
-cryptography~=37.0.4
+cryptography>=37.0.4,<38.1.0
 Django~=3.2.15  # LTS version, switch only if we have a compelling reason to
 django-currentuser~=0.5.3
 django-filter~=22.1


### PR DESCRIPTION
This should allow to work around an issue of pip-compile failing to find possible combinations of python packages to install when requesting pulpcore and pulp-certguard.

fixes #3269