### PR TITLE
Zero downtime upgrade docs for plugin writers

### DIFF
--- a/CHANGES/plugin_api/3368.doc
+++ b/CHANGES/plugin_api/3368.doc
@@ -1,0 +1,1 @@
+Adds docs that plugin writers tasks must be backwards compatible until the next major Pulp version.

--- a/CHANGES/plugin_api/3443.doc
+++ b/CHANGES/plugin_api/3443.doc
@@ -1,0 +1,2 @@
+Adds docs on the need and possible options for writing migrations in a way that they could be
+applied to a running Pulp system.


### PR DESCRIPTION
This adds docs for two situations:

* Guidance for zero downtime migrations
* tasking backwards compatibility requirements

closes #3368
closes #3443