### PR TITLE
Fixed import-failure due to pulp_labels.

### DIFF
--- a/CHANGES/3461.misc
+++ b/CHANGES/3461.misc
@@ -1,0 +1,1 @@
+Taught Repository to not export pulp_labels.

--- a/pulpcore/app/modelresource.py
+++ b/pulpcore/app/modelresource.py
@@ -59,6 +59,7 @@ class RepositoryResource(QueryModelResource):
             "next_version",
             "repository_ptr",
             "remote",
+            "pulp_labels",
         )
 
 


### PR DESCRIPTION
Testing is covered by test_pulpimport in pulp_file and pulp_rpm.

fixes #3461.
[nocoverage]