### PR TITLE
Remove plugin dependencies from labels migration

### DIFF
--- a/pulpcore/app/apps.py
+++ b/pulpcore/app/apps.py
@@ -8,6 +8,7 @@ from django.conf import settings
 from django import apps
 from django.core.exceptions import ImproperlyConfigured
 from django.db import transaction
+from django.db.models.expressions import OuterRef, RawSQL
 from django.db.models.signals import post_migrate
 from django.utils.module_loading import module_has_submodule
 
@@ -223,6 +224,11 @@ class PulpAppConfig(PulpPluginAppConfig):
             sender=self,
             dispatch_uid="populate_artifact_serving_distribution_identifier",
         )
+        post_migrate.connect(
+            _migrate_remaining_labels,
+            sender=self,
+            dispatch_uid="migrate_remaining_labels_identifier",
+        )
 
 
 def _populate_access_policies(sender, apps, verbosity, **kwargs):
@@ -361,3 +367,53 @@ def _populate_artifact_serving_distribution(sender, apps, verbosity, **kwargs):
                     pulp_type="core.artifact",
                     defaults={"base_path": name, "content_guard": content_guard},
                 )
+
+
+def _migrate_remaining_labels(sender, apps, verbosity, **kwargs):
+    try:
+        Label = apps.get_model("core", "label")
+        ContentType = apps.get_model("contenttypes", "ContentType")
+    except LookupError:
+        if verbosity >= 1:
+            print("No db table for labels available.")
+        return
+
+    labeled_ctypes = [
+        ContentType.objects.get(pk=pk)
+        for pk in Label.objects.values_list("content_type", flat=True).distinct()
+    ]
+    for ctype in labeled_ctypes:
+        model = apps.get_model(ctype.app_label, ctype.model)
+
+        if not hasattr(model, "pulp_labels"):
+            if verbosity >= 1:
+                print(
+                    _(
+                        "Warning! "
+                        "Labels for content_type {app_label}.{model} could not be migrated. "
+                        "Model has no labels."
+                    ).format(app_label=ctype.app_label, model=ctype.model)
+                )
+            continue
+
+        if verbosity >= 1:
+            print(
+                _("Migrate labels for content_type {app_label}.{model}.").format(
+                    app_label=ctype.app_label, model=ctype.model
+                )
+            )
+        with transaction.atomic():
+            label_subq = (
+                Label.objects.filter(content_type=ctype, object_id=OuterRef("pulp_id"))
+                .annotate(label_data=RawSQL("hstore(array_agg(key), array_agg(value))", []))
+                .values("label_data")
+            )
+            model.objects.update(pulp_labels=label_subq)
+            Label.objects.filter(content_type=ctype).delete()
+
+    if Label.objects.count():
+        if verbosity >= 1:
+            print(
+                "Some labels could not be migrated. "
+                "Please try to run `pulpcore-manager datarepair-labels`."
+            )

--- a/pulpcore/app/management/commands/datarepair-labels.py
+++ b/pulpcore/app/management/commands/datarepair-labels.py
@@ -37,7 +37,7 @@ class Command(BaseCommand):
         try:
             Label = apps.get_model("core", "label")
         except LookupError:
-            print("Nothing todo.")
+            print("Nothing to do.")
             return
 
         labeled_ctypes = [
@@ -55,7 +55,7 @@ class Command(BaseCommand):
                         "Model has no labels."
                     ).format(app_label=ctype.app_label, model=ctype.model)
                 )
-                break
+                continue
 
             print(
                 _("Migrate labels for content_type {app_label}.{model}.").format(

--- a/pulpcore/app/migrations/0098_pulp_labels.py
+++ b/pulpcore/app/migrations/0098_pulp_labels.py
@@ -3,69 +3,14 @@
 import django.contrib.postgres.fields.hstore
 from django.db import migrations
 
-import os
 from django.contrib.postgres.operations import HStoreExtension
-from django.db.models.expressions import OuterRef, RawSQL
-from django.apps import apps as global_apps
-from pulpcore.app.apps import PulpPluginAppConfig
-
-
-KNOWN_CONTENT_PLUGINS = [
-    "ansible",
-    "container",
-    "cookbook",
-    "deb",
-    "file",
-    "gem",
-    "maven",
-    "npm",
-    "ostree",
-    "python",
-    "rpm",
-]
-
-
-def copy_labels_up(apps, schema_editor):
-    ContentType = apps.get_model("contenttypes", "ContentType")
-    Label = apps.get_model("core", "Label")
-
-    labeled_ctypes = [ContentType.objects.get(pk=pk) for pk in Label.objects.values_list("content_type", flat=True).distinct()]
-    for ctype in labeled_ctypes:
-        if ctype.app_label not in KNOWN_CONTENT_PLUGINS + ["core"]:
-            print(f"Warning! Labels for content_type {ctype.app_label}.{ctype.model} could not be migrated. Plugin unknown.")
-            break
-        try:
-            model = apps.get_model(ctype.app_label, ctype.model)
-        except LookupError:
-            print(f"Warning! Labels for content_type {ctype.app_label}.{ctype.model} could not be migrated. Model not available.")
-            break
-        if not hasattr(model, "pulp_labels"):
-            print(f"Warning! Labels for content_type {ctype.app_label}.{ctype.model} could not be migrated. Model has no labels.")
-            break
-
-        label_subq = Label.objects.filter(
-            content_type=ctype, object_id=OuterRef("pulp_id")
-        ).annotate(
-            label_data=RawSQL("hstore(array_agg(key), array_agg(value))", [])
-        ).values("label_data")
-        model.objects.update(pulp_labels=label_subq)
-        Label.objects.filter(content_type=ctype).delete()
-
-    if Label.objects.count():
-        print("Some labels could not be migrated. Please try to run `pulpcore-manager datarepair-labels`.")
 
 
 class Migration(migrations.Migration):
 
     dependencies = [
         ('core', '0097_remove_telemetry_task_schedule'),
-        ('contenttypes', '0002_remove_content_type_name'),
     ]
-    # Depend on all installed plugins containing migrations to be able to use their models.
-    for plugin_config in global_apps.app_configs.values():
-        # To avoid circular dependencies, try to depend only on known plugins predating this migration.
-        if plugin_config.label in KNOWN_CONTENT_PLUGINS:
-            dependencies.append((plugin_config.label, '0001_initial'))
 
     operations = [
         HStoreExtension(),
@@ -84,5 +29,4 @@ class Migration(migrations.Migration):
             name='pulp_labels',
             field=django.contrib.postgres.fields.hstore.HStoreField(default=dict),
         ),
-        migrations.RunPython(code=copy_labels_up, elidable=True),
     ]


### PR DESCRIPTION
Pulpcore migrations can never depend on any migration from a plugin. It will lead to either circular dependencies or inconsistent history if a plugin is installed later.
To make the miration as smooth as possible, a post migrate hook was added to repair the labels as well as possible.

[noissue]