### PR TITLE
Add TaskSerializer to pulpcore.plugin.serializers

### DIFF
--- a/CHANGES/plugin_api/3506.feature
+++ b/CHANGES/plugin_api/3506.feature
@@ -1,0 +1,1 @@
+Exported ``TaskSerializer`` in ``pulpcore.plugin.serializers``

--- a/pulpcore/plugin/serializers/__init__.py
+++ b/pulpcore/plugin/serializers/__init__.py
@@ -33,6 +33,7 @@ from pulpcore.app.serializers import (  # noqa
     RepositoryAddRemoveContentSerializer,
     ValidateFieldsMixin,
     validate_unknown_fields,
+    TaskSerializer,
 )
 
 from .content import (  # noqa


### PR DESCRIPTION
fixes: https://github.com/pulp/pulpcore/issues/3506


For Galaxy_ng repo management feature, in `pulp_ansible/CollectionRemoteSerializer`, we need to expose `last_sync_status` task. For that, we could reuse ~~`MinimalTaskSerializer`, but it's missing `error`~~ `TaskSerializer` field and it's not exposed in `pulpcore.plugin.serializers`

Related PR for `last_sync_status`: https://github.com/pulp/pulp_ansible/pull/1317
(see discussion: https://github.com/pulp/pulp_ansible/pull/1317#issuecomment-1375767586)

AAH issue: [AAH-2076](https://issues.redhat.com/browse/AAH-2076)