### PR TITLE
Fix the label migration code

### DIFF
--- a/CHANGES/3495.bugfix
+++ b/CHANGES/3495.bugfix
@@ -1,0 +1,2 @@
+Fixed the label migration code for not null constraint errors when objects with and without labels
+are migrated.

--- a/pulpcore/app/apps.py
+++ b/pulpcore/app/apps.py
@@ -408,7 +408,9 @@ def _migrate_remaining_labels(sender, apps, verbosity, **kwargs):
                 .annotate(label_data=RawSQL("hstore(array_agg(key), array_agg(value))", []))
                 .values("label_data")
             )
-            model.objects.update(pulp_labels=label_subq)
+            model.objects.annotate(old_labels=label_subq).exclude(old_labels={}).update(
+                pulp_labels=label_subq
+            )
             Label.objects.filter(content_type=ctype).delete()
 
     if Label.objects.count():

--- a/pulpcore/app/management/commands/datarepair-labels.py
+++ b/pulpcore/app/management/commands/datarepair-labels.py
@@ -69,7 +69,9 @@ class Command(BaseCommand):
                         .annotate(label_data=RawSQL("hstore(array_agg(key), array_agg(value))", []))
                         .values("label_data")
                     )
-                    model.objects.update(pulp_labels=label_subq)
+                    model.objects.annotate(old_labels=label_subq).exclude(old_labels={}).update(
+                        pulp_labels=label_subq
+                    )
                     Label.objects.filter(content_type=ctype).delete()
 
         if Label.objects.count() and purge and not dry_run:


### PR DESCRIPTION
A not null constraint exception was risen when objects with and without labels of the same type existed. The fix will limit the update to only those objects that actually had labels.

fixes #3495