### PR TITLE
Don't save temporary files to object storage, use local storage

### DIFF
--- a/pulpcore/app/models/content.py
+++ b/pulpcore/app/models/content.py
@@ -385,6 +385,10 @@ class PulpTemporaryFile(HandleTempFilesMixin, BaseModel):
             It also accepts `class:django.core.files.File`.
     """
 
+    def __init__(self, *args, **kwargs):
+        """Init"""
+        super().__init__(self, *args, storage=default_storage, **kwargs)
+
     def storage_path(self, name):
         """
         Callable used by FileField to determine where the uploaded file should be stored.


### PR DESCRIPTION
The general issue is that Pulp uses temporary files, storage backends like S3 or Azure require you to pay for usage, so using those services for short lived and often small files is not an efficient use of resources.

[noissue]