### PR TITLE
Enables FilesystemExporter to incrementally export rpms

### DIFF
--- a/CHANGES/3413.bugfix
+++ b/CHANGES/3413.bugfix
@@ -1,0 +1,3 @@
+Added a ``start_repository_version`` parameter to the file system exporter.
+
+If specified, it will export only content units that differed between two repository versions.

--- a/pulpcore/app/serializers/exporter.py
+++ b/pulpcore/app/serializers/exporter.py
@@ -294,6 +294,12 @@ class FilesystemExportSerializer(ExportSerializer):
         write_only=True,
     )
 
+    start_repository_version = RepositoryVersionRelatedField(
+        help_text=_("The URI of the last-exported-repo-version."),
+        required=False,
+        write_only=True,
+    )
+
     def validate(self, data):
         if ("publication" not in data and "repository_version" not in data) or (
             "publication" in data and "repository_version" in data
@@ -305,7 +311,11 @@ class FilesystemExportSerializer(ExportSerializer):
 
     class Meta:
         model = models.FilesystemExport
-        fields = ExportSerializer.Meta.fields + ("publication", "repository_version")
+        fields = ExportSerializer.Meta.fields + (
+            "publication",
+            "repository_version",
+            "start_repository_version",
+        )
 
 
 class FilesystemExporterSerializer(ExporterSerializer):

--- a/pulpcore/app/tasks/export.py
+++ b/pulpcore/app/tasks/export.py
@@ -105,7 +105,7 @@ def _export_to_file_system(path, relative_paths_to_artifacts, method=FS_EXPORT_M
 
 
 def _export_publication_to_file_system(
-    path, publication, method=FS_EXPORT_METHODS.WRITE, allow_missing=False
+    path, publication, start_repo_version=None, method=FS_EXPORT_METHODS.WRITE, allow_missing=False
 ):
     """
     Export a publication to the file system.
@@ -114,9 +114,19 @@ def _export_publication_to_file_system(
         path (str): Path to place the exported data
         publication_pk (str): Publication pk
     """
+    difference_content_artifacts = []
     content_artifacts = ContentArtifact.objects.filter(
         pk__in=publication.published_artifact.values_list("content_artifact__pk", flat=True)
     )
+    if start_repo_version:
+        start_version_content_artifacts = ContentArtifact.objects.filter(
+            artifact__in=start_repo_version.artifacts
+        )
+        difference_content_artifacts = set(
+            content_artifacts.difference(start_version_content_artifacts).values_list(
+                "pk", flat=True
+            )
+        )
 
     if publication.pass_through:
         content_artifacts |= ContentArtifact.objects.filter(
@@ -138,8 +148,11 @@ def _export_publication_to_file_system(
         "content_artifact", "content_artifact__artifact"
     ).iterator():
         # Artifact isn't guaranteed to be present
-        if pa.content_artifact.artifact:
+        if pa.content_artifact.artifact and (
+            start_repo_version is None or pa.content_artifact.pk in difference_content_artifacts
+        ):
             relative_path_to_artifacts[pa.relative_path] = pa.content_artifact.artifact
+
     _export_to_file_system(path, relative_path_to_artifacts, method)
 
 
@@ -160,7 +173,7 @@ def _export_location_is_clean(path):
     return True
 
 
-def fs_publication_export(exporter_pk, publication_pk):
+def fs_publication_export(exporter_pk, publication_pk, start_repo_version_pk=None):
     """
     Export a publication to the file system using an exporter.
 
@@ -170,25 +183,41 @@ def fs_publication_export(exporter_pk, publication_pk):
     """
     exporter = Exporter.objects.get(pk=exporter_pk).cast()
     publication = Publication.objects.get(pk=publication_pk).cast()
+
+    start_repo_version = None
+    if start_repo_version_pk:
+        start_repo_version = RepositoryVersion.objects.get(pk=start_repo_version_pk)
+
+    params = {"publication": publication_pk}
+    if start_repo_version:
+        params["start_repository_version"] = start_repo_version_pk
+
     export = FilesystemExport.objects.create(
         exporter=exporter,
-        params={"publication": publication_pk},
+        params=params,
         task=Task.current(),
     )
     ExportedResource.objects.create(export=export, content_object=publication)
     CreatedResource.objects.create(content_object=export)
-
     log.info(
-        "Exporting: file_system_exporter={exporter}, publication={publication}, path={path}".format(
-            exporter=exporter.name, publication=publication.pk, path=exporter.path
+        "Exporting: file_system_exporter={exporter}, publication={publication}, "
+        "start_repo_version={start_repo_version}, path={path}".format(
+            exporter=exporter.name,
+            publication=publication.pk,
+            start_repo_version=start_repo_version_pk,
+            path=exporter.path,
         )
     )
+
     if not _export_location_is_clean(exporter.path):
         raise RuntimeError(_("Cannot export to directories that contain existing data."))
-    _export_publication_to_file_system(exporter.path, publication, exporter.method)
+
+    _export_publication_to_file_system(
+        exporter.path, publication, start_repo_version=start_repo_version, method=exporter.method
+    )
 
 
-def fs_repo_version_export(exporter_pk, repo_version_pk):
+def fs_repo_version_export(exporter_pk, repo_version_pk, start_repo_version_pk=None):
     """
     Export a repository version to the file system using an exporter.
 
@@ -198,9 +227,17 @@ def fs_repo_version_export(exporter_pk, repo_version_pk):
     """
     exporter = Exporter.objects.get(pk=exporter_pk).cast()
     repo_version = RepositoryVersion.objects.get(pk=repo_version_pk)
+    start_repo_version = None
+    if start_repo_version_pk:
+        start_repo_version = RepositoryVersion.objects.get(pk=start_repo_version_pk)
+
+    params = {"repository_version": repo_version_pk}
+    if start_repo_version:
+        params["start_repository_version"] = start_repo_version_pk
+
     export = FilesystemExport.objects.create(
         exporter=exporter,
-        params={"repository_version": repo_version_pk},
+        params=params,
         task=Task.current(),
     )
     ExportedResource.objects.create(export=export, content_object=repo_version)
@@ -208,18 +245,31 @@ def fs_repo_version_export(exporter_pk, repo_version_pk):
 
     log.info(
         "Exporting: file_system_exporter={exporter}, repo_version={repo_version}, "
-        "path={path}".format(
-            exporter=exporter.name, repo_version=repo_version.pk, path=exporter.path
+        "start_repo_version={start_repo_version}, path={path}".format(
+            exporter=exporter.name,
+            repo_version=repo_version.pk,
+            start_repo_version=start_repo_version_pk,
+            path=exporter.path,
         )
     )
 
     content_artifacts = ContentArtifact.objects.filter(content__in=repo_version.content)
     _validate_fs_export(content_artifacts)
+    difference_content_artifacts = []
+    if start_repo_version:
+        start_version_content_artifacts = ContentArtifact.objects.filter(
+            artifact__in=start_repo_version.artifacts
+        )
+        difference_content_artifacts = set(
+            content_artifacts.difference(start_version_content_artifacts).values_list(
+                "pk", flat=True
+            )
+        )
 
-    relative_path_to_artifacts = {
-        ca.relative_path: ca.artifact
-        for ca in content_artifacts.select_related("artifact").iterator()
-    }
+    relative_path_to_artifacts = {}
+    for ca in content_artifacts.select_related("artifact").iterator():
+        if start_repo_version is None or ca.pk in difference_content_artifacts:
+            relative_path_to_artifacts[ca.relative_path] = ca.artifact
 
     _export_to_file_system(exporter.path, relative_path_to_artifacts, exporter.method)
 

--- a/pulpcore/app/viewsets/exporter.py
+++ b/pulpcore/app/viewsets/exporter.py
@@ -159,13 +159,22 @@ class FilesystemExportViewSet(ExportViewSet):
         serializer = FilesystemExportSerializer(data=request.data, context={"exporter": exporter})
         serializer.is_valid(raise_exception=True)
 
+        start_repository_version_pk = None
+        if request.data.get("start_repository_version"):
+            start_repository_version_pk = self.get_resource(
+                request.data["start_repository_version"], RepositoryVersion
+            ).pk
+
         if request.data.get("publication"):
             publication = self.get_resource(request.data["publication"], Publication)
-
             task = dispatch(
                 fs_publication_export,
                 exclusive_resources=[exporter],
-                kwargs={"exporter_pk": exporter.pk, "publication_pk": publication.pk},
+                kwargs={
+                    "exporter_pk": exporter.pk,
+                    "publication_pk": publication.pk,
+                    "start_repo_version_pk": start_repository_version_pk,
+                },
             )
         else:
             repo_version = self.get_resource(request.data["repository_version"], RepositoryVersion)
@@ -173,7 +182,11 @@ class FilesystemExportViewSet(ExportViewSet):
             task = dispatch(
                 fs_repo_version_export,
                 exclusive_resources=[exporter],
-                kwargs={"exporter_pk": str(exporter.pk), "repo_version_pk": repo_version.pk},
+                kwargs={
+                    "exporter_pk": str(exporter.pk),
+                    "repo_version_pk": repo_version.pk,
+                    "start_repo_version_pk": start_repository_version_pk,
+                },
             )
 
         return OperationPostponedResponse(task, request)


### PR DESCRIPTION
It accepts a start repository version and calculates what content artifacts need to get copied over.