### PR TITLE
Bump dynaconf version

### DIFF
--- a/CHANGES/3310.bugfix
+++ b/CHANGES/3310.bugfix
@@ -1,0 +1,1 @@
+Bump dynaconf version to 3.1.12 given it fixes a bug to handle failures when pwd does not exist.

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,7 +16,7 @@ djangorestframework-queryfields>=1.0,<=1.0.0
 drf-access-policy>=1.1.2,<1.5.1
 drf-nested-routers>=0.93.4,<=0.93.4
 drf-spectacular==0.25.1  # We monkeypatch this so we need a very narrow requirement string
-dynaconf>=3.1.9,<=3.1.12
+dynaconf>=3.1.12,<3.1.13
 gunicorn>=20.1,<=20.1.0
 jinja2>=3.1,<=3.1.2
 naya>=1.1.1,<=1.1.1


### PR DESCRIPTION
Bumping dynaconf version for the given fix:
* Handle all failures when pwd does not exist. (https://github.com/dynaconf/dynaconf/pull/857)

Close #3310 and pulp/pulp-oci-images#404
