### PR TITLE
Fix invalid date-time field format in PurgeSerializer

### DIFF
--- a/CHANGES/3585.bugfix
+++ b/CHANGES/3585.bugfix
@@ -1,0 +1,1 @@
+Fixed default date-time format for ``finished_before`` DateTimeField in ``PurgeSerializer``.

--- a/pulpcore/app/serializers/purge.py
+++ b/pulpcore/app/serializers/purge.py
@@ -10,9 +10,9 @@ from pulpcore.constants import TASK_FINAL_STATES
 class PurgeSerializer(serializers.Serializer, ValidateFieldsMixin):
     finished_before = serializers.DateTimeField(
         help_text=_(
-            "Purge tasks completed earlier than this timestamp. Format '%Y-%m-%d[T%H:%M:%S]'"
+            "Purge tasks completed earlier than this timestamp. Format '%Y-%m-%dT%H:%M:%SZ'"
         ),
-        default=(datetime.now(timezone.utc) - timedelta(days=30)).strftime("%Y-%m-%d"),
+        default=(datetime.now(timezone.utc) - timedelta(days=30)).strftime("%Y-%m-%dT%H:%M:%SZ"),
     )
     states = serializers.MultipleChoiceField(
         choices=TASK_FINAL_STATES,


### PR DESCRIPTION
fixes: https://github.com/pulp/pulpcore/issues/3585

Galaxy_ng integration tests fail with invalid openapi format, I'm not really sure why it started showing now 
```
=================================== FAILURES ===================================
________________________ test_galaxy_openapi_validation ________________________
galaxy_ng/tests/integration/api/test_openapi.py:65: in test_galaxy_openapi_validation
    validate_spec(galaxy_spec)
/tmp/gng_testing/lib/python3.10/site-packages/openapi_spec_validator/shortcuts.py:17: in validate_spec
    return validator.validate(spec, spec_url=spec_url)
/tmp/gng_testing/lib/python3.10/site-packages/openapi_spec_validator/validation/proxies.py:28: in validate
    raise err
E   openapi_spec_validator.validation.exceptions.OpenAPIValidationError: '2023-01-14' is not a 'date-time'
E   
E   Failed validating 'format' in schema:
E       {'default': '2023-01-14',
E        'description': 'Purge tasks completed earlier than this timestamp. '
E                       "Format '%Y-%m-%d[T%H:%M:%S]'",
E        'format': 'date-time',
E        'type': 'string'}
E   
E   On instance:
E       '2023-01-14'
=========================== short test summary info ============================
FAILED galaxy_ng/tests/integration/api/test_openapi.py::test_galaxy_openapi_validation - openapi_spec_validator.validation.exceptions.OpenAPIValidationError: '2023-01-14' is not a 'date-time'
```
