### PR TITLE
SFTP storage warning

### DIFF
--- a/docs/installation/storage.rst
+++ b/docs/installation/storage.rst
@@ -16,6 +16,11 @@ Storage
 SFTP
 ^^^^
 
+.. warning::
+    Using SFTP storage is not recommended in Pulp's current state, and doing so can lead to file corruption.
+    This is because Pulp currently uses coroutines that seem to be incompatible with Django's ``SFTPStorage``
+    implementation.
+
 Configuring Pulp to use SFTP storage
 ------------------------------------
 


### PR DESCRIPTION
Added a warning to the docs that advises against
using the SFTP storage option, since it can lead to data corruption.

[noissue]