### PR TITLE
[noissue] Bump django to 4.1 branch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,8 +81,8 @@ jobs:
       - name: Check for gettext problems
         run: sh .ci/scripts/check_gettext.sh
 
-      - name: Verify upper bound requirements
-        run: python .ci/scripts/upper_bound.py
+      # - name: Verify upper bound requirements
+      #   run: python .ci/scripts/upper_bound.py
 
   test:
     runs-on: ubuntu-latest

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,8 +5,9 @@ aiofiles>=22.1,<23.2.0
 backoff>=2.1.2,<2.2.2
 click>=8.1.0,<=8.1.3
 cryptography>=38.0.1,<39.0.3
-Django~=3.2.18  # LTS version, switch only if we have a compelling reason to
-django-currentuser>=0.5.3,<=0.5.3
+Django~=4.1.7  # LTS version, switch only if we have a compelling reason to
+# django-currentuser>=0.5.3,<=0.5.3
+django-currentuser @ https://github.com/PaesslerAG/django-currentuser/archive/refs/heads/master.zip
 django-filter>=22.1,<=22.1
 django-guid>=3.3,<=3.3.0
 django-import-export>=2.9,<3.2.0


### PR DESCRIPTION
This is just an experiment to see what's gonna fail if we move to the 4.x branch. Since 4.2 is not released yet, we're using the 4.1 branch.

But yet, this is just an experiment. We SHOULD NOT MERGE THIS PR, AT ALL!
