### PR TITLE
Allow customizing the field name on LabelFilter

### DIFF
--- a/CHANGES/plugin_api/3631.feature
+++ b/CHANGES/plugin_api/3631.feature
@@ -1,0 +1,2 @@
+Add ``label_field_name`` arg to ``LabelFilter()`` filter that allows plugin devs to
+customize the model field that ``LabelFilter`` filters on.


### PR DESCRIPTION
This allows for plugins to define a custom field to filter pulp labels on. For example, a distribution filterset could add a filter for repository labels like so:

```
class MyFilterset(Filterset):
    repository__label_select = LabelFilter(label_field_name="repository__pulp_labels")
```

closes #3631