### PR TITLE
Properly access artifacts of a generic content in handler.py

### DIFF
--- a/CHANGES/3654.bugfix
+++ b/CHANGES/3654.bugfix
@@ -1,0 +1,1 @@
+Fixed bug related to pulpcore-content serving content from a remote (pull-through-cache).

--- a/pulpcore/content/handler.py
+++ b/pulpcore/content/handler.py
@@ -802,7 +802,7 @@ class Handler:
                     # There is already content for this Artifact
                     content = c_type.objects.get(content.q())
                     artifacts = content._artifacts
-                    if artifact.sha256 != artifacts[0].sha256:
+                    if artifact.sha256 != artifacts.get().sha256:
                         raise RuntimeError(
                             "The Artifact downloaded during pull-through does not "
                             "match the Artifact already stored for the same "


### PR DESCRIPTION
closes: #3654