### PR TITLE
Reworked the task purge feature

### DIFF
--- a/CHANGES/3530.bugfix
+++ b/CHANGES/3530.bugfix
@@ -1,0 +1,2 @@
+Task purge now continues when encountering a task that could not be deleted. The user is informed
+about any such tasks.


### PR DESCRIPTION
When an object could not be deleted, the purge task would fail. This has been reworked  so that the purge continues to delete other tasks and informs the user about tasks that could not be deleted.

fixes: #3530 