### PR TITLE
Optimize queries for task list endpoint

### DIFF
--- a/CHANGES/3711.bugfix
+++ b/CHANGES/3711.bugfix
@@ -1,0 +1,1 @@
+Optimized queries needed when listing Tasks.


### PR DESCRIPTION
fixes: #3711

`http /pulp/api/v3/tasks/?limit=100` with roughly ~200 tasks in the system (left optimized, right current):

![task-optimization](https://user-images.githubusercontent.com/28039189/230444951-b71287d1-e424-486c-8fc7-e8408f94f739.png)

`http /pulp/api/v3/tasks/sync_task_href/` (left optimized, right current):

![task-individual-optimization](https://user-images.githubusercontent.com/28039189/230448613-e02d96d0-77af-4f08-ba30-42ef118509e3.png)

The number of queries we are currently doing is greatly dependent on the number and type of created resources made during the task. Each repository-version made during a task adds roughly 9-10 queries to the endpoint. For systems performing many syncs & uploads browsing the task endpoint would cause serious hammering of the database. 