### PR TITLE
Optimized DB queries for list endpoints

### DIFF
--- a/CHANGES/3714.bugfix
+++ b/CHANGES/3714.bugfix
@@ -1,0 +1,1 @@
+Optimized DB queries for content, distribution, publication, remote, repository, and repository-version list endpoints.

--- a/pulpcore/app/models/base.py
+++ b/pulpcore/app/models/base.py
@@ -7,6 +7,7 @@ from django.db import models
 from django.db.models import options
 from django.db.models.base import ModelBase
 from django_lifecycle import LifecycleModel
+from functools import lru_cache
 
 from pulpcore.app.loggers import deprecation_logger
 
@@ -86,6 +87,11 @@ class BaseModel(LifecycleModel):
 
     class Meta:
         abstract = True
+
+    @classmethod
+    @lru_cache
+    def get_field_names(cls):
+        return [f.name for f in cls._meta.fields]
 
     def __str__(self):
         try:

--- a/pulpcore/app/viewsets/content.py
+++ b/pulpcore/app/viewsets/content.py
@@ -111,6 +111,14 @@ class BaseContentViewSet(NamedModelViewSet):
     queryset = Content.objects.all().exclude(pulp_type=PublishedMetadata.get_pulp_type())
     serializer_class = MultipleArtifactContentSerializer
 
+    def get_queryset(self):
+        """Apply optimizations for list endpoint."""
+        qs = super().get_queryset()
+        if getattr(self, "action", "") == "list":
+            # Fetch info for artifacts (ContentArtifactsField)
+            qs = qs.prefetch_related("contentartifact_set")
+        return qs
+
     def scope_queryset(self, qs):
         """Scope the content based on repositories the user has permission to see."""
         # This has been optimized, see ListRepositoryVersions for more generic version


### PR DESCRIPTION
This ensures that when listing resources (for content, distributions, publications, remotes, and repositories) the number of DB queries does not increase as the number of objects increases. The optimization comes with two parts: one `select/prefetch_relating` the related fields & two using a utility function `get_model_for_pulp_type` (that I am also using in https://github.com/pulp/pulpcore/pull/3712/) to quickly find the appropriate viewset for the related object without having to call `cast`.

Here's an example of what these two optimizations achieve for `http /pulp/api/v3/content/?limit=100`:
(both optimizations, just the new utility optimization, original)
![content-optimize](https://user-images.githubusercontent.com/28039189/231019611-dd0569f0-c8d9-4bc6-8fff-524cbcf89915.png)

The `cast` calls for `DetailIdentityField` or `DetailRelatedField` were the biggest culprit for DB performance when doing large list calls.

fixes: #3714