### PR TITLE
Fix a race condition in content creation

### DIFF
--- a/CHANGES/3754.bugfix
+++ b/CHANGES/3754.bugfix
@@ -1,0 +1,1 @@
+Closed the window for a race condition in content creation.


### PR DESCRIPTION
When two (or more) processes try to create the same content only one can call the "create" successfully so the other one needs to attempt the "retrieve" a second time.

fixes #3754