### PR TITLE
Add multiple key support to db encryption

### DIFF
--- a/CHANGES/2048.feature
+++ b/CHANGES/2048.feature
@@ -1,0 +1,1 @@
+Added commands and documentation for db encryption key rotation.

--- a/docs/configuration/settings.rst
+++ b/docs/configuration/settings.rst
@@ -65,6 +65,25 @@ DB_ENCRYPTION_KEY
 
     openssl rand -base64 32 > /etc/pulp/certs/database_fields.symmetric.key
 
+  This file can contain multiple such keys (one per line). The key in the first line will be used
+  for encryption but all others will still be attempted to decrypt old tokens. This can help you to
+  rotate this key in the following way:
+
+  1. Shut down all Pulp services (api, content and worker processes).
+  2. Add a new key at the top of the key file.
+  3. Call `pulpcore-manager rotate-db-key`.
+  4. Remove the old key (on the second line) from the key file.
+  5. Start the Pulp services again.
+
+  For a zero downtime key rotation you can follow the slightly more complex recipe:
+  1. Add a new key at the bottom of the key file.
+  2. Restart the Pulp services in the usual phased manner.
+  3. Swap the keys in the key file.
+  4. Restart the Pulp services again.
+  5. Call `pulpcore-manager rotate-db-key`.
+  6. Remove the old key (on the second line) from the key file.
+  7. Restart the Pulp services for the last time.
+
 
 DATABASES
 ^^^^^^^^^

--- a/pulpcore/app/management/commands/rotate-db-key.py
+++ b/pulpcore/app/management/commands/rotate-db-key.py
@@ -1,0 +1,72 @@
+from contextlib import suppress
+from gettext import gettext as _
+
+from django.apps import apps
+from django.core.management import BaseCommand
+from django.db import connection, transaction
+
+from pulpcore.app.models import MasterModel
+from pulpcore.app.models.fields import EncryptedTextField, EncryptedJSONField
+
+
+class DryRun(Exception):
+    pass
+
+
+class Command(BaseCommand):
+    """
+    Django management command for db key rotation.
+    """
+
+    help = _(
+        "Rotate the db encryption key. "
+        "This command will re-encrypt all values in instances of EncryptedTextField and "
+        "EncryptedJSONField with the first key in the file refereced by "
+        "settings.DB_ENCRYPTION_KEY. You need to make sure that all running instances of the "
+        "application already loaded this key for proper functioning. Refer to the docs for zero "
+        "downtime key rotation."
+        "It is safe to abort and resume or rerun this operation."
+    )
+
+    def add_arguments(self, parser):
+        """Set up arguments."""
+        parser.add_argument(
+            "--dry-run",
+            action="store_true",
+            help=_("Don't modify anything."),
+        )
+
+    def handle(self, *args, **options):
+        dry_run = options["dry_run"]
+
+        for model in apps.get_models():
+            if issubclass(model, MasterModel) and model._meta.master_model is None:
+                # This is a master model, and we will handle all it's descendents.
+                continue
+            field_names = [
+                field.name
+                for field in model._meta.get_fields()
+                if isinstance(field, (EncryptedTextField, EncryptedJSONField))
+            ]
+            if field_names:
+                print(
+                    _("Updating {fields} on {model}.").format(
+                        model=model.__name__, fields=",".join(field_names)
+                    )
+                )
+                exclude_filters = {f"{field_name}": None for field_name in field_names}
+                qs = model.objects.exclude(**exclude_filters).only(*field_names)
+                with suppress(DryRun), transaction.atomic():
+                    batch = []
+                    for item in qs.iterator():
+                        batch.append(item)
+                        if len(batch) >= 1024:
+                            model.objects.bulk_update(batch, field_names)
+                            batch = []
+                    if batch:
+                        model.objects.bulk_update(batch, field_names)
+                        batch = []
+                    if dry_run:
+                        with connection.cursor() as cursor:
+                            cursor.execute("SET CONSTRAINTS ALL IMMEDIATE")
+                        raise DryRun()


### PR DESCRIPTION
Every line in the file referenced by settings.DB_ENCRYPTION_KEY will be available for decrypting encrypted database fields. Only the on in the first line (at the time of service startup) will be used for encryption. A rotate-db-key management command was added to help key rotation, as well as recipies in the documentation.

fixes #2048