### PR TITLE
Refactored async unittests to use pytest-async

### DIFF
--- a/pulpcore/tests/unit/conftest.py
+++ b/pulpcore/tests/unit/conftest.py
@@ -1,0 +1,11 @@
+import pytest
+from uuid import uuid4
+
+from pulpcore.app.models import Domain
+from pulpcore.app.util import set_domain
+
+
+@pytest.fixture
+def fake_domain():
+    """A fixture to prevent `get_domain` to call out to the database."""
+    set_domain(Domain(pk=uuid4(), name=uuid4()))

--- a/pulpcore/tests/unit/download/test_factory.py
+++ b/pulpcore/tests/unit/download/test_factory.py
@@ -1,35 +1,32 @@
-from django.test import TestCase
-from asgiref.sync import sync_to_async
+import pytest
 
 from pulpcore.download.factory import DownloaderFactory
 from pulpcore.plugin.models import Remote
 
 
-class DownloaderFactoryHeadersTestCase(TestCase):
-    async def test_user_agent_header(self):
-        remote = await sync_to_async(Remote.objects.create)(url="http://example.org/", name="foo")
-        factory = DownloaderFactory(remote)
-        downloader = factory.build(remote.url)
-        default_user_agent = DownloaderFactory.user_agent()
-        self.assertEqual(downloader.session.headers["User-Agent"], default_user_agent)
-        await sync_to_async(remote.delete)()
+@pytest.mark.asyncio
+async def test_user_agent_header():
+    remote = Remote(url="http://example.org/", name="foo")
+    factory = DownloaderFactory(remote)
+    downloader = factory.build(remote.url)
+    default_user_agent = DownloaderFactory.user_agent()
+    assert downloader.session.headers["User-Agent"] == default_user_agent
 
-    async def test_custom_user_agent_header(self):
-        remote = await sync_to_async(Remote.objects.create)(
-            url="http://example.org/", headers=[{"User-Agent": "foo"}], name="foo"
-        )
-        factory = DownloaderFactory(remote)
-        downloader = factory.build(remote.url)
-        default_user_agent = DownloaderFactory.user_agent()
-        expected_user_agent = f"{default_user_agent}, foo"
-        self.assertEqual(downloader.session.headers["User-Agent"], expected_user_agent)
-        await sync_to_async(remote.delete)()
 
-    async def test_custom_headers(self):
-        remote = await sync_to_async(Remote.objects.create)(
-            url="http://example.org/", headers=[{"Connection": "keep-alive"}], name="foo"
-        )
-        factory = DownloaderFactory(remote)
-        downloader = factory.build(remote.url)
-        self.assertEqual(downloader.session.headers["Connection"], "keep-alive")
-        await sync_to_async(remote.delete)()
+@pytest.mark.asyncio
+async def test_custom_user_agent_header():
+    remote = Remote(url="http://example.org/", headers=[{"User-Agent": "foo"}], name="foo")
+    factory = DownloaderFactory(remote)
+    downloader = factory.build(remote.url)
+    default_user_agent = DownloaderFactory.user_agent()
+    expected_user_agent = f"{default_user_agent}, foo"
+    assert downloader.session.headers["User-Agent"] == expected_user_agent
+
+
+@pytest.mark.asyncio
+@pytest.mark.django_db
+async def test_custom_headers():
+    remote = Remote(url="http://example.org/", headers=[{"Connection": "keep-alive"}], name="foo")
+    factory = DownloaderFactory(remote)
+    downloader = factory.build(remote.url)
+    assert downloader.session.headers["Connection"] == "keep-alive"

--- a/pulpcore/tests/unit/stages/test_artifactdownloader.py
+++ b/pulpcore/tests/unit/stages/test_artifactdownloader.py
@@ -1,11 +1,16 @@
 import asyncio
-
-import asynctest
-from unittest import mock
+import pytest
+import pytest_asyncio
 from uuid import uuid4
+from contextlib import suppress
+from aiotools.timer import VirtualClock
+
+from unittest import mock
 
 from pulpcore.plugin.stages import DeclarativeContent, DeclarativeArtifact
 from pulpcore.plugin.stages.artifact_stages import ArtifactDownloader
+
+pytestmark = pytest.mark.usefixtures("fake_domain")
 
 
 class MockException(Exception):
@@ -22,61 +27,67 @@ class DownloaderMock:
     URLs are expected to be the delay to wait to simulate downloading,
     e.g `url='5'` will wait for 5 seconds. Negative numbers will raise
     an exception after waiting for the absolute value, e.g. `url=-5` fails
-    after 5 seconds. `DownloaderMock` manages _global_ statistics about the
-    downloads.
+    after 5 seconds.
     """
 
-    running = 0
-    downloads = 0
-    canceled = 0
+    def __init__(self, **kwargs):
+        self.running = 0
+        self.downloads = 0
+        self.canceled = 0
 
-    def __init__(self, url, **kwargs):
-        self.url = url
+    def __call__(self, url, **kwargs):
+        class _DownloaderMock:
+            def __init__(this, url, **kwargs):
+                this.url = url
 
-    @classmethod
-    def reset(cls):
-        cls.running = 0
-        cls.downloads = 0
-        cls.canceled = 0
+            async def run(this, extra_data=None):
+                self.running += 1
+                try:
+                    duration = int(this.url)
+                    await asyncio.sleep(abs(duration))
+                    if duration < 0:
+                        raise MockException("Download Failed")
+                except asyncio.CancelledError:
+                    self.running -= 1
+                    self.canceled += 1
+                    raise
+                self.running -= 1
+                self.downloads += 1
+                result = mock.Mock()
+                result.url = this.url
+                result.artifact_attributes = {}
+                return result
 
-    async def run(self, extra_data=None):
-        DownloaderMock.running += 1
-        try:
-            duration = int(self.url)
-            await asyncio.sleep(abs(duration))
-            if duration < 0:
-                raise MockException("Download Failed")
-        except asyncio.CancelledError:
-            DownloaderMock.running -= 1
-            DownloaderMock.canceled += 1
-            raise
-        DownloaderMock.running -= 1
-        DownloaderMock.downloads += 1
-        result = mock.Mock()
-        result.url = self.url
-        result.artifact_attributes = {}
-        return result
+        return _DownloaderMock(url, **kwargs)
 
 
-class TestArtifactDownloader(asynctest.ClockedTestCase):
-    def setUp(self):
-        super().setUp()
-        DownloaderMock.reset()
-        self.now = 0
-        self.in_q = asyncio.Queue()
-        self.out_q = asyncio.Queue()
+@pytest_asyncio.fixture
+async def advance():
+    async def _advance(sec):
+        await asyncio.sleep(sec)
 
-    async def advance_to(self, now):
-        delta = now - self.now
-        assert delta >= 0
-        await self.advance(delta)
-        self.now = now
+    with VirtualClock().patch_loop():
+        yield _advance
 
-    async def advance(self, delta):
-        await super().advance(delta)
-        self.now += delta
 
-    def queue_dc(self, delays=[], artifact_path=None):
+@pytest.fixture
+def in_q():
+    return asyncio.Queue()
+
+
+@pytest.fixture
+def out_q():
+    return asyncio.Queue()
+
+
+@pytest.fixture
+def downloader_mock():
+    return DownloaderMock()
+
+
+@pytest.fixture
+def queue_dc(in_q, downloader_mock):
+    def _queue_dc(delays=[], artifact_path=None):
         """Put a DeclarativeContent instance into `in_q`
 
         For each `delay` in `delays`, associate a DeclarativeArtifact
@@ -94,16 +105,21 @@ class TestArtifactDownloader(asynctest.ClockedTestCase):
             artifact.DIGEST_FIELDS = []
             artifact.file = artifact_path
             remote = mock.Mock()
-            remote.get_downloader = DownloaderMock
+            remote.get_downloader = downloader_mock
             das.append(
                 DeclarativeArtifact(
                     artifact=artifact, url=str(delay), relative_path="path", remote=remote
                 )
             )
         dc = DeclarativeContent(content=mock.Mock(), d_artifacts=das)
-        self.in_q.put_nowait(dc)
+        in_q.put_nowait(dc)
 
-    async def download_task(self, max_concurrent_content=3):
+    return _queue_dc
+
+
+@pytest_asyncio.fixture
+async def download_task(event_loop, in_q, out_q):
+    async def _download_task():
         """
         A coroutine running the downloader stage with a mocked ProgressReport.
 
@@ -112,257 +128,286 @@ class TestArtifactDownloader(asynctest.ClockedTestCase):
         """
         with mock.patch("pulpcore.plugin.stages.artifact_stages.ProgressReport") as pb:
             pb.return_value.__aenter__.return_value.done = 0
-            ad = ArtifactDownloader(max_concurrent_content=max_concurrent_content)
-            ad._connect(self.in_q, self.out_q)
+            ad = ArtifactDownloader(max_concurrent_content=3)
+            ad._connect(in_q, out_q)
             await ad()
         return pb.return_value.__aenter__.return_value.done
 
-    def assertQueued(self, num):
-        self.assertEqual(self.in_q.qsize(), num)
+    task = event_loop.create_task(_download_task())
+    yield task
+    if not task.done():
+        task.cancel()
+    with suppress(asyncio.CancelledError, MockException):
+        await task
 
-    def assertHandled(self, num):
-        self.assertEqual(self.out_q.qsize(), num)
 
-    async def test_downloads(self):
-        download_task = self.loop.create_task(self.download_task())
+@pytest.mark.asyncio
+async def test_downloads(advance, downloader_mock, download_task, in_q, out_q, queue_dc):
+    # Create 28 content units, every third one must be downloaded.
+    # The downloads take 0, 3, 6,..., 27 seconds; content units
+    # 1, 2, 4, 5, ..., 26 do not need downloads.
+    for i in range(28):
+        queue_dc(delays=[i if not i % 3 else None])
+    in_q.put_nowait(None)
 
-        # Create 28 content units, every third one must be downloaded.
-        # The downloads take 0, 3, 6,..., 27 seconds; content units
-        # 1, 2, 4, 5, ..., 26 do not need downloads.
-        for i in range(28):
-            self.queue_dc(delays=[i if not i % 3 else None])
-        self.in_q.put_nowait(None)
+    # At 0.5 seconds
+    await advance(0.5)
+    # 3, 6 and 9 are running. 0 is finished
+    assert downloader_mock.running == 3
+    # non-downloads 1, 2, 4, 5, 7, 8 are forwarded
+    assert out_q.qsize() == 7
+    # 9 - 26, None are waiting to be picked up
+    assert in_q.qsize() == 19
 
-        # At 0.5 seconds
-        await self.advance_to(0.5)
-        # 3, 6 and 9 are running. 0 is finished
-        self.assertEqual(DownloaderMock.running, 3)
-        # non-downloads 1, 2, 4, 5, 7, 8 are forwarded
-        self.assertHandled(7)
-        # 9 - 26 + None are waiting to be picked up
-        self.assertQueued(19)
+    # Two downloads run in parallel. The most asymmetric way
+    # to schedule the remaining downloads is:
+    # 3, 12, 21: finished after 36 seconds
+    # 6, 15, 24: finished after 45 seconds
+    # 9, 18, 27: finished after 54 seconds
+    # until 35.5 seconds three downloads must run
+    for t in range(35):
+        await advance(1.0)
+        assert downloader_mock.running == 3
 
-        # Two downloads run in parallel. The most asymmetric way
-        # to schedule the remaining downloads is:
-        # 3 + 12 + 21: finished after 36 seconds
-        # 6 + 15 + 24: finished after 45 seconds
-        # 9 + 18 + 27: finished after 54 seconds
-        for t in range(1, 36):  # until 35.5 seconds three downloads must run
-            await self.advance_to(t + 0.5)
-            self.assertEqual(DownloaderMock.running, 3)
+    # At 54.5 seconds, the stage is done at the latest
+    await advance(19.0)
+    assert downloader_mock.running == 0
+    assert downloader_mock.downloads == 10
+    assert download_task.result() == downloader_mock.downloads
+    assert in_q.qsize() == 0
+    assert out_q.qsize() == 29
+    assert download_task.result() == 10
 
-        # At 54.5 seconds, the stage is done at the latest
-        await self.advance_to(54.5)
-        self.assertEqual(DownloaderMock.running, 0)
-        self.assertEqual(DownloaderMock.downloads, 10)
-        self.assertEqual(download_task.result(), DownloaderMock.downloads)
-        self.assertQueued(0)
-        self.assertHandled(29)
 
-    async def test_multi_artifact_downloads(self):
-        # Content units should fill the slot like
-        #
-        # 0   1   2   3 s
-        # .   .   .   .
-        # +---+-------+
-        # | 1 |   4   |
-        # +---+---+---+
-        # |   2   |
-        # +-------+
-        # |   3   |
-        # +-------+
-        #
-        download_task = self.loop.create_task(self.download_task())
-        self.queue_dc(delays=[])  # must be forwarded to next stage immediately
-        self.queue_dc(delays=[1])
-        self.queue_dc(delays=[2, 2])
-        self.queue_dc(delays=[2])
-        self.queue_dc(delays=[2, None])  # schedules only one download
-        self.in_q.put_nowait(None)
-        # At 0.5 seconds, three content units are downloading with four
-        # downloads overall
-        await self.advance_to(0.5)
-        self.assertEqual(DownloaderMock.running, 4)
-        self.assertHandled(1)
-        # At 1.5 seconds, the download for the first content unit has completed.
-        # At 1 second, the download of the forth content unit is started
-        await self.advance_to(1.5)
-        self.assertEqual(DownloaderMock.running, 4)
-        self.assertHandled(2)
-        # At 2.5 seconds, the downloads for the second and the third content unit
-        # have completed
-        await self.advance_to(2.5)
-        self.assertEqual(DownloaderMock.running, 1)
-        self.assertHandled(4)
+@pytest.mark.asyncio
+async def test_multi_artifact_downloads(
+    advance, downloader_mock, download_task, in_q, out_q, queue_dc
+):
+    # Content units should fill the slot like
+    #
+    # 0   1   2   3 s
+    # .   .   .   .
+    # +---+-------+
+    # | 1 |   4   |
+    # +---+---+---+
+    # |   2   |
+    # +-------+
+    # |   3   |
+    # +-------+
+    #
 
-        # At 3.5 seconds, stage must de done
-        await self.advance_to(3.5)
-        self.assertEqual(DownloaderMock.running, 0)
-        self.assertEqual(DownloaderMock.downloads, 5)
-        self.assertEqual(download_task.result(), DownloaderMock.downloads)
-        self.assertQueued(0)
-        self.assertHandled(6)
+    queue_dc(delays=[])  # must be forwarded to next stage immediately
+    queue_dc(delays=[1])
+    queue_dc(delays=[2, 2])
+    queue_dc(delays=[2])
+    queue_dc(delays=[2, None])  # schedules only one download
+    in_q.put_nowait(None)
 
-    async def test_sparse_batches_dont_block_stage(self):
-        """Regression test for issue https://pulp.plan.io/issues/4018."""
+    # At 0.5 seconds, three content units are downloading with four
+    # downloads overall
+    await advance(0.5)
+    assert downloader_mock.running == 4
+    assert out_q.qsize() == 1
 
-        def queue_content_with_a_single_download(batchsize=100, delay=100):
-            """
-            Queue a batch of `batchsize` declarative_content instances. Only the
-            first one triggers a download of duration `delay`.
-            """
-            self.queue_dc(delays=[delay])
-            for i in range(batchsize - 1):
-                self.queue_dc([None])
+    # At 1.5 seconds, the download for the first content unit has completed.
+    # At 1 second, the download of the forth content unit is started
+    await advance(1.0)
+    assert downloader_mock.running == 4
+    assert out_q.qsize() == 2
 
-        download_task = self.loop.create_task(self.download_task())
+    # At 2.5 seconds, the downloads for the second and the third content unit
+    # have completed
+    await advance(1.0)
+    assert downloader_mock.running == 1
+    assert out_q.qsize() == 4
 
-        queue_content_with_a_single_download()
+    # At 3.5 seconds, stage must de done
+    await advance(1.0)
+    assert downloader_mock.running == 0
+    assert downloader_mock.downloads == 5
+    assert in_q.qsize() == 0
+    assert out_q.qsize() == 6
 
-        # At 0.5 seconds, the first content unit is downloading
-        await self.advance_to(0.5)
-        self.assertEqual(DownloaderMock.running, 1)
-        self.assertHandled(99)
+    assert download_task.result() == 5
 
-        # at 0.5 seconds next batch arrives (last batch)
-        queue_content_with_a_single_download()
-        self.in_q.put_nowait(None)
 
-        # at 1.0 seconds, two downloads are running
-        await self.advance_to(1)
-        self.assertEqual(DownloaderMock.running, 2)
-        self.assertHandled(2 * 99)
+@pytest.mark.asyncio
+async def test_sparse_batches_dont_block_stage(
+    advance, downloader_mock, download_task, in_q, out_q, queue_dc
+):
+    """Regression test for issue https://pulp.plan.io/issues/4018."""
 
-        # at 101 seconds, stage should have completed
-        await self.advance_to(101)
+    def queue_content_with_a_single_download(batchsize=100, delay=100):
+        """
+        Queue a batch of `batchsize` declarative_content instances. Only the
+        first one triggers a download of duration `delay`.
+        """
+        queue_dc(delays=[delay])
+        for i in range(batchsize - 1):
+            queue_dc([None])
 
-        self.assertEqual(DownloaderMock.running, 0)
-        self.assertEqual(DownloaderMock.downloads, 2)
-        self.assertEqual(download_task.result(), DownloaderMock.downloads)
-        self.assertQueued(0)
-        self.assertHandled(201)
+    queue_content_with_a_single_download()
 
-    async def test_cancel(self):
-        download_task = self.loop.create_task(self.download_task())
-        for i in range(4):
-            self.queue_dc(delays=[100])
-        self.in_q.put_nowait(None)
+    # At 0.5 seconds, the first content unit is downloading
+    await advance(0.5)
+    assert downloader_mock.running == 1
+    assert out_q.qsize() == 99
 
-        # After 0.5 seconds, the three downloads must have started
-        await self.advance_to(0.5)
-        self.assertEqual(DownloaderMock.running, 3)
+    # at 0.5 seconds next batch arrives (last batch)
+    queue_content_with_a_single_download()
+    in_q.put_nowait(None)
 
-        download_task.cancel()
+    # at 1.0 seconds, two downloads are running
+    await advance(0.5)
+    assert downloader_mock.running == 2
+    assert out_q.qsize() == 2 * 99
 
-        await self.advance_to(1.0)
+    # at 101 seconds, stage should have completed
+    await advance(100)
 
-        with self.assertRaises(asyncio.CancelledError):
-            download_task.result()
-        self.assertEqual(DownloaderMock.running, 0)
-        self.assertEqual(DownloaderMock.canceled, 3)
+    assert downloader_mock.running == 0
+    assert downloader_mock.downloads == 2
+    assert in_q.qsize() == 0
+    assert out_q.qsize() == 201
 
-    async def test_exception_with_empty_in_q(self):
-        download_task = self.loop.create_task(self.download_task())
+    assert download_task.result() == 2
 
-        # Create three content units with 1 downloads, followed by one thowing an exception.
-        self.queue_dc(delays=[1])
-        self.queue_dc(delays=[2])
-        self.queue_dc(delays=[2])
-        self.queue_dc(delays=[-1])
 
-        # At 0.5 seconds
-        await self.advance_to(0.5)
-        # 3 downloads are running. No unit is finished
-        self.assertEqual(DownloaderMock.running, 3)
-        self.assertHandled(0)
-        self.assertQueued(1)
+@pytest.mark.asyncio
+async def test_cancel(advance, downloader_mock, download_task, in_q, out_q, queue_dc):
+    for i in range(4):
+        queue_dc(delays=[100])
+    in_q.put_nowait(None)
 
-        # At 1.5 seconds
-        await self.advance_to(1.5)
-        # 3 downloads are running. One unit is finished.
-        self.assertEqual(DownloaderMock.running, 3)
-        self.assertHandled(1)
-        self.assertQueued(0)
+    # After 0.5 seconds, the three downloads must have started
+    await advance(0.5)
+    assert downloader_mock.running == 3
 
-        # At 2.5 seconds, the exception must have been triggered
-        await self.advance_to(2.5)
-        self.assertTrue(download_task.done())
-        self.assertIsInstance(download_task.exception(), MockException)
+    download_task.cancel()
 
-    async def test_exception_finished_in_q(self):
-        download_task = self.loop.create_task(self.download_task())
+    await advance(0.5)
 
-        # Create three content units with 1 downloads, followed by one thowing an exception.
-        self.queue_dc(delays=[1])
-        self.queue_dc(delays=[2])
-        self.queue_dc(delays=[2])
-        self.queue_dc(delays=[-1])
-        await self.in_q.put(None)
+    with pytest.raises(asyncio.CancelledError):
+        download_task.result()
+    assert downloader_mock.running == 0
+    assert downloader_mock.canceled == 3
 
-        # At 0.5 seconds
-        await self.advance_to(0.5)
-        # 3 downloads are running. No unit is finished
-        self.assertEqual(DownloaderMock.running, 3)
-        self.assertHandled(0)
-        self.assertQueued(2)
 
-        # At 1.5 seconds
-        await self.advance_to(1.5)
-        # 3 downloads are running. One unit is finished.
-        self.assertEqual(DownloaderMock.running, 3)
-        self.assertHandled(1)
-        self.assertQueued(1)
+@pytest.mark.asyncio
+async def test_exception_with_empty_in_q(
+    advance, downloader_mock, download_task, in_q, out_q, queue_dc
+):
+    # Create three content units with 1 downloads, followed by one thowing an exception.
+    queue_dc(delays=[1])
+    queue_dc(delays=[2])
+    queue_dc(delays=[2])
+    queue_dc(delays=[-1])
 
-        # At 2.5 seconds, the exception must have been triggered
-        await self.advance_to(2.5)
-        self.assertTrue(download_task.done())
-        self.assertIsInstance(download_task.exception(), MockException)
+    # At 0.5 seconds
+    await advance(0.5)
+    # 3 downloads are running. No unit is finished
+    assert downloader_mock.running == 3
+    assert in_q.qsize() == 1
+    assert out_q.qsize() == 0
 
-    async def test_exception_with_saturated_content_slots(self):
-        download_task = self.loop.create_task(self.download_task())
+    # At 1.5 seconds
+    await advance(1.0)
+    # 3 downloads are running. One unit is finished.
+    assert downloader_mock.running == 3
+    assert in_q.qsize() == 0
+    assert out_q.qsize() == 1
 
-        # Create three content units with 1 downloads, followed by one thowing an exception.
-        self.queue_dc(delays=[1])
-        self.queue_dc(delays=[3])
-        self.queue_dc(delays=[3])
-        self.queue_dc(delays=[-1])
-        self.queue_dc(delays=[1])  # This unit will be waiting for a free slot
+    # At 2.5 seconds, the exception must have been triggered
+    await advance(1.0)
+    assert download_task.done()
+    assert isinstance(download_task.exception(), MockException)
 
-        # At 0.5 seconds
-        await self.advance_to(0.5)
-        # 3 downloads are running. No unit is finished
-        self.assertEqual(DownloaderMock.running, 3)
-        self.assertHandled(0)
-        self.assertQueued(2)
 
-        # At 1.5 seconds
-        await self.advance_to(1.5)
-        # 3 downloads are running. One unit is finished.
-        self.assertEqual(DownloaderMock.running, 3)
-        self.assertHandled(1)
-        self.assertQueued(1)
+@pytest.mark.asyncio
+async def test_exception_finished_in_q(
+    advance, downloader_mock, download_task, in_q, out_q, queue_dc
+):
+    # Create three content units with 1 downloads, followed by one thowing an exception.
+    queue_dc(delays=[1])
+    queue_dc(delays=[2])
+    queue_dc(delays=[2])
+    queue_dc(delays=[-1])
+    await in_q.put(None)
 
-        # At 2.5 seconds, the exception must have been triggered
-        await self.advance_to(2.5)
-        self.assertTrue(download_task.done())
-        self.assertIsInstance(download_task.exception(), MockException)
+    # At 0.5 seconds
+    await advance(0.5)
+    # 3 downloads are running. No unit is finished
+    assert downloader_mock.running == 3
+    assert in_q.qsize() == 2
+    assert out_q.qsize() == 0
 
-    async def test_download_artifact_with_file(self):
-        download_task = self.loop.create_task(self.download_task())
+    # At 1.5 seconds
+    await advance(1.0)
+    # 3 downloads are running. One unit is finished.
+    assert downloader_mock.running == 3
+    assert in_q.qsize() == 1
+    assert out_q.qsize() == 1
 
-        # Create 3 downloads with Artifacts that already have a file
-        self.queue_dc(delays=[1, 2, 3], artifact_path="/foo/bar")
-        # Create 3 downloads with Artifacts that don't have a file
-        self.queue_dc(delays=[1, 2, 3], artifact_path=None)
-        self.in_q.put_nowait(None)
+    # At 2.5 seconds, the exception must have been triggered
+    await advance(1.0)
+    assert download_task.done()
+    assert isinstance(download_task.exception(), MockException)
 
-        # At 0.5 seconds only 3 should be running and 0 done
-        await self.advance_to(0.5)
-        self.assertEqual(DownloaderMock.downloads, 0)
-        self.assertEqual(DownloaderMock.running, 3)
 
-        # At 10 seconds all 3 should be done
-        await self.advance_to(3)
-        self.assertEqual(DownloaderMock.downloads, 3)
-        self.assertEqual(DownloaderMock.running, 0)
-        self.assertEqual(download_task.result(), DownloaderMock.downloads)
+@pytest.mark.asyncio
+async def test_exception_with_saturated_content_slots(
+    advance, downloader_mock, download_task, in_q, out_q, queue_dc
+):
+    # Create three content units with 1 downloads, followed by one thowing an exception.
+    queue_dc(delays=[1])
+    queue_dc(delays=[3])
+    queue_dc(delays=[3])
+    queue_dc(delays=[-1])
+    queue_dc(delays=[1])  # This unit will be waiting for a free slot
+
+    # At 0.5 seconds
+    await advance(0.5)
+    # 3 downloads are running. No unit is finished
+    assert downloader_mock.running == 3
+    assert in_q.qsize() == 2
+    assert out_q.qsize() == 0
+
+    # At 1.5 seconds
+    await advance(1.0)
+    # 3 downloads are running. One unit is finished.
+    assert downloader_mock.running == 3
+    assert in_q.qsize() == 1
+    assert out_q.qsize() == 1
+
+    # At 2.5 seconds, the exception must have been triggered
+    await advance(1.0)
+    assert download_task.done()
+    assert isinstance(download_task.exception(), MockException)
+
+    # At 3.5 seconds, the task should be done
+    await advance(1.0)
+    assert download_task.done()
+    assert isinstance(download_task.exception(), MockException)
+
+
+@pytest.mark.asyncio
+async def test_download_artifact_with_file(
+    advance, downloader_mock, download_task, in_q, out_q, queue_dc
+):
+    # Create 3 downloads with Artifacts that already have a file
+    queue_dc(delays=[1, 2, 3], artifact_path="/foo/bar")
+    # Create 3 downloads with Artifacts that don't have a file
+    queue_dc(delays=[1, 2, 3], artifact_path=None)
+    in_q.put_nowait(None)
+
+    # At 0.5 seconds only 3 should be running and 0 done
+    await advance(0.5)
+    assert downloader_mock.downloads == 0
+    assert downloader_mock.running == 3
+
+    # At 3.5 seconds all 3 should be done
+    await advance(3.0)
+    assert downloader_mock.downloads == 3
+    assert downloader_mock.running == 0
+
+    assert download_task.result() == 3

--- a/pulpcore/tests/unit/stages/test_stages.py
+++ b/pulpcore/tests/unit/stages/test_stages.py
@@ -1,139 +1,156 @@
 import asyncio
+import pytest
 
-import asynctest
 import mock
 
 from pulpcore.plugin.stages import Stage, EndStage, DeclarativeContent
 
 
-class TestStage(asynctest.TestCase):
-    def setUp(self):
-        self.in_q = asyncio.Queue()
-        self.stage = Stage()
-        self.stage._connect(self.in_q, None)
-
-    async def test_none_only(self):
-        self.in_q.put_nowait(None)
-        batch_it = self.stage.batches(minsize=1)
-        with self.assertRaises(StopAsyncIteration):
-            await batch_it.__anext__()
-
-    async def test_single_batch_and_none(self):
-        c1 = mock.Mock()
-        c2 = mock.Mock()
-        self.in_q.put_nowait(c1)
-        self.in_q.put_nowait(c2)
-        self.in_q.put_nowait(None)
-        batch_it = self.stage.batches(minsize=1)
-        self.assertEqual([c1, c2], await batch_it.__anext__())
-        with self.assertRaises(StopAsyncIteration):
-            await batch_it.__anext__()
-
-    async def test_batch_and_single_none(self):
-        c1 = mock.Mock()
-        c2 = mock.Mock()
-        self.in_q.put_nowait(c1)
-        self.in_q.put_nowait(c2)
-        batch_it = self.stage.batches(minsize=1)
-        self.assertEqual([c1, c2], await batch_it.__anext__())
-        self.in_q.put_nowait(None)
-        with self.assertRaises(StopAsyncIteration):
-            await batch_it.__anext__()
-
-    async def test_two_batches(self):
-        c1 = mock.Mock()
-        c2 = mock.Mock()
-        c3 = mock.Mock()
-        c4 = mock.Mock()
-        self.in_q.put_nowait(c1)
-        self.in_q.put_nowait(c2)
-        batch_it = self.stage.batches(minsize=1)
-        self.assertEqual([c1, c2], await batch_it.__anext__())
-        self.in_q.put_nowait(c3)
-        self.in_q.put_nowait(c4)
-        self.in_q.put_nowait(None)
-        self.assertEqual([c3, c4], await batch_it.__anext__())
-        with self.assertRaises(StopAsyncIteration):
-            await batch_it.__anext__()
-
-    async def test_thaw_queue(self):
-        # Test that awaiting `resolved` on DeclarativeContent does not dead lock
-        c1 = DeclarativeContent(mock.Mock())
-        c2 = DeclarativeContent(mock.Mock())
-        c3 = DeclarativeContent(mock.Mock())
-        c4 = DeclarativeContent(mock.Mock())
-        batch_it = self.stage.batches(minsize=4)
-        fetch_task = asyncio.ensure_future(batch_it.__anext__())
-        fetch_task.add_done_callback(lambda _: c2.resolve())
-        self.in_q.put_nowait(c1)
-        self.in_q.put_nowait(c2)
-        self.in_q.put_nowait(c3)
-        wait_task = asyncio.ensure_future(c2.resolution())
-        wait_task.add_done_callback(lambda _: self.in_q.put_nowait(c4))
-        batch, c2_res = await asyncio.gather(fetch_task, wait_task)
-        self.assertEqual([c1, c2, c3], batch)
-        self.assertEqual(c2.content, c2_res)
-        self.in_q.put_nowait(None)
-        self.assertEqual([c4], await batch_it.__anext__())
-        with self.assertRaises(StopAsyncIteration):
-            await batch_it.__anext__()
+pytestmark = pytest.mark.usefixtures("fake_domain")
 
 
-class TestMultipleStages(asynctest.TestCase):
-    class FirstStage(Stage):
-        def __init__(self, num, minsize, test_case, *args, **kwargs):
-            super().__init__(*args, **kwargs)
-            self.num = num
-            self.minsize = minsize
-            self.test_case = test_case
+@pytest.fixture
+def in_q():
+    return asyncio.Queue()
 
-        async def run(self):
-            for i in range(self.num):
-                await asyncio.sleep(0)  # Force reschedule
-                await self.put(mock.Mock())
 
-    class MiddleStage(Stage):
-        def __init__(self, num, minsize, test_case, *args, **kwargs):
-            super().__init__(*args, **kwargs)
-            self.num = num
-            self.minsize = minsize
-            self.test_case = test_case
+@pytest.fixture
+def stage(in_q):
+    stage = Stage()
+    stage._connect(in_q, None)
+    return stage
 
-        async def run(self):
-            async for batch in self.batches(self.minsize):
-                self.test_case.assertTrue(batch)
-                self.test_case.assertGreaterEqual(len(batch), min(self.minsize, self.num))
-                self.num -= len(batch)
-                for b in batch:
-                    await self.put(b)
-            self.test_case.assertEqual(self.num, 0)
 
-    class LastStage(Stage):
-        def __init__(self, num, minsize, test_case, *args, **kwargs):
-            super().__init__(*args, **kwargs)
-            self.num = num
-            self.minsize = minsize
-            self.test_case = test_case
+@pytest.mark.asyncio
+async def test_single_batch_and_none(stage, in_q):
+    c1 = mock.Mock()
+    c2 = mock.Mock()
+    in_q.put_nowait(c1)
+    in_q.put_nowait(c2)
+    in_q.put_nowait(None)
+    batch_it = stage.batches(minsize=1)
+    assert [c1, c2] == await batch_it.__anext__()
+    with pytest.raises(StopAsyncIteration):
+        await batch_it.__anext__()
 
-        async def run(self):
-            async for batch in self.batches(self.minsize):
-                self.test_case.assertTrue(batch)
-                self.test_case.assertGreaterEqual(len(batch), min(self.minsize, self.num))
-                self.num -= len(batch)
-            self.test_case.assertEqual(self.num, 0)
 
-    async def test_batch_queue_and_min_sizes(self):
-        """Test batches iterator in a small stages setting with various sizes"""
-        for num in range(10):
-            for minsize in range(1, 5):
-                for qsize in range(1, num + 1):
-                    queues = [asyncio.Queue(maxsize=qsize) for i in range(3)]
-                    first_stage = self.FirstStage(num, minsize, self)
-                    middle_stage = self.MiddleStage(num, minsize, self)
-                    last_stage = self.LastStage(num, minsize, self)
-                    end_stage = EndStage()
-                    first_stage._connect(None, queues[0])
-                    middle_stage._connect(queues[0], queues[1])
-                    last_stage._connect(queues[1], queues[2])
-                    end_stage._connect(queues[2], None)
-                    await asyncio.gather(last_stage(), middle_stage(), first_stage(), end_stage())
+@pytest.mark.asyncio
+async def test_none_only(stage, in_q):
+    in_q.put_nowait(None)
+    batch_it = stage.batches(minsize=1)
+    with pytest.raises(StopAsyncIteration):
+        await batch_it.__anext__()
+
+
+@pytest.mark.asyncio
+async def test_batch_and_single_none(stage, in_q):
+    c1 = mock.Mock()
+    c2 = mock.Mock()
+    in_q.put_nowait(c1)
+    in_q.put_nowait(c2)
+    batch_it = stage.batches(minsize=1)
+    assert [c1, c2] == await batch_it.__anext__()
+    in_q.put_nowait(None)
+    with pytest.raises(StopAsyncIteration):
+        await batch_it.__anext__()
+
+
+@pytest.mark.asyncio
+async def test_two_batches(stage, in_q):
+    c1 = mock.Mock()
+    c2 = mock.Mock()
+    c3 = mock.Mock()
+    c4 = mock.Mock()
+    in_q.put_nowait(c1)
+    in_q.put_nowait(c2)
+    batch_it = stage.batches(minsize=1)
+    assert [c1, c2] == await batch_it.__anext__()
+    in_q.put_nowait(c3)
+    in_q.put_nowait(c4)
+    in_q.put_nowait(None)
+    assert [c3, c4] == await batch_it.__anext__()
+    with pytest.raises(StopAsyncIteration):
+        await batch_it.__anext__()
+
+
+@pytest.mark.asyncio
+async def test_thaw_queue(stage, in_q):
+    # Test that awaiting `resolved` on DeclarativeContent does not dead lock
+    c1 = DeclarativeContent(mock.Mock())
+    c2 = DeclarativeContent(mock.Mock())
+    c3 = DeclarativeContent(mock.Mock())
+    c4 = DeclarativeContent(mock.Mock())
+    batch_it = stage.batches(minsize=4)
+    fetch_task = asyncio.ensure_future(batch_it.__anext__())
+    fetch_task.add_done_callback(lambda _: c2.resolve())
+    in_q.put_nowait(c1)
+    in_q.put_nowait(c2)
+    in_q.put_nowait(c3)
+    wait_task = asyncio.ensure_future(c2.resolution())
+    wait_task.add_done_callback(lambda _: in_q.put_nowait(c4))
+    batch, c2_res = await asyncio.gather(fetch_task, wait_task)
+    assert [c1, c2, c3] == batch
+    assert c2.content == c2_res
+    in_q.put_nowait(None)
+    assert [c4] == await batch_it.__anext__()
+    with pytest.raises(StopAsyncIteration):
+        await batch_it.__anext__()
+
+
+class FirstStage(Stage):
+    def __init__(self, num, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.num = num
+
+    async def run(self):
+        for i in range(self.num):
+            await asyncio.sleep(0)  # Force reschedule
+            await self.put(mock.Mock())
+
+
+class MiddleStage(Stage):
+    def __init__(self, num, minsize, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.num = num
+        self.minsize = minsize
+
+    async def run(self):
+        async for batch in self.batches(self.minsize):
+            assert batch
+            assert len(batch) >= min(self.minsize, self.num)
+            self.num -= len(batch)
+            for b in batch:
+                await self.put(b)
+        assert self.num == 0
+
+
+class LastStage(Stage):
+    def __init__(self, num, minsize, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.num = num
+        self.minsize = minsize
+
+    async def run(self):
+        async for batch in self.batches(self.minsize):
+            assert batch
+            assert len(batch) >= min(self.minsize, self.num)
+            self.num -= len(batch)
+        assert self.num == 0
+
+
+@pytest.mark.asyncio
+async def test_batch_queue_and_min_sizes():
+    """Test batches iterator in a small stages setting with various sizes"""
+    for num in range(10):
+        for minsize in range(1, 5):
+            for qsize in range(1, num + 1):
+                queues = [asyncio.Queue(maxsize=qsize) for i in range(3)]
+                first_stage = FirstStage(num)
+                middle_stage = MiddleStage(num, minsize)
+                last_stage = LastStage(num, minsize)
+                end_stage = EndStage()
+                first_stage._connect(None, queues[0])
+                middle_stage._connect(queues[0], queues[1])
+                last_stage._connect(queues[1], queues[2])
+                end_stage._connect(queues[2], None)
+                await asyncio.gather(last_stage(), middle_stage(), first_stage(), end_stage())

--- a/unittest_requirements.txt
+++ b/unittest_requirements.txt
@@ -1,4 +1,5 @@
 # Unit test requirements
-asynctest
 mock
+aiotools
 pytest-django
+pytest-asyncio


### PR DESCRIPTION
This fixes some warnings from the seemingly unmaintained asynctest library, whose dependency thereby got removed.

[noissue]