### PR TITLE
Small fix for task list optimization

### DIFF
--- a/pulpcore/app/viewsets/task.py
+++ b/pulpcore/app/viewsets/task.py
@@ -151,7 +151,7 @@ class TaskViewSet(
         # "swagger_fake_view" is set when drf_spectacular is building the OpenAPI spec
         if (
             self.action in ("list", "retrieve")
-            and isinstance(serializer, TaskSerializer)
+            and self.get_serializer_class() == TaskSerializer
             and not getattr(self, "swagger_fake_view", False)
         ):
             task_list = args[0] if many else [args[0]]


### PR DESCRIPTION
Missed this when I merged the task optimization. DRF returns a ListSerializer when using `many=True`, so my optimization fix wasn't being applied to the list endpoint.