### PR TITLE
Redirects user to a path that ends in /

### DIFF
--- a/CHANGES/3173.feature
+++ b/CHANGES/3173.feature
@@ -1,0 +1,1 @@
+Content app now redirects requests without a trailing slash to a path with the trailing slash. 

--- a/CHANGES/plugin_api/3459.feature
+++ b/CHANGES/plugin_api/3459.feature
@@ -1,0 +1,2 @@
+Added a flag ``REDIRECT_ON_MISSING_SLASH`` for plugin distribution models to opt out of automatic
+redirecting if a path should end in a slash but does not.

--- a/CHANGES/plugin_api/3459.removal
+++ b/CHANGES/plugin_api/3459.removal
@@ -1,0 +1,5 @@
+Starting with this release, pulpcore will default to redirect clients of the content app when
+given path locations without the trailing slash. 
+
+A plugin must set ``REDIRECT_ON_MISSING_SLASH=False`` on distribution models for content types
+where this is inappropriate.

--- a/pulpcore/app/models/publication.py
+++ b/pulpcore/app/models/publication.py
@@ -529,8 +529,11 @@ class Distribution(MasterModel):
         pulp_domain (models.ForeignKey): The domain the Distribution is a part of.
     """
 
-    # If distribution serves publications, set by subclasses for proper handling in content app
+    # If distribution serves publications, set by subclasses for proper handling in content app.
     SERVE_FROM_PUBLICATION = False
+
+    # Plugins can opt out of redirecting by settings this to False.
+    REDIRECT_ON_MISSING_SLASH = True
 
     name = models.TextField(db_index=True)
     pulp_labels = HStoreField(default=dict)


### PR DESCRIPTION
This patch returns a 301 redirect when a requested path does not end in a / but should end in a /.

Changes the order in which pulpcore-content looks for published artifacts The handler now looks for a published artifact before it tries to look for an index.html or listing the directory.

fixes: #3173
fixes: #3459