### PR TITLE
Pin sphinx to fix docs build

### DIFF
--- a/doc_requirements.txt
+++ b/doc_requirements.txt
@@ -1,6 +1,6 @@
 -r requirements.txt
 plantuml
-sphinx
+sphinx~=6.2.1
 sphinx-rtd-theme==1.2.0
 sphinxcontrib-jquery
 sphinxcontrib-openapi


### PR DESCRIPTION
Not sure why but the docs test is failing in the release CI and pinning this requirement seems to fix it.

[noissue]
