### PR TITLE
Provide async version of latest_version

### DIFF
--- a/CHANGES/plugin_api/3798.misc
+++ b/CHANGES/plugin_api/3798.misc
@@ -1,0 +1,1 @@
+Provided asynchronous version of the latest_version function (repository model).

--- a/pulpcore/app/models/repository.py
+++ b/pulpcore/app/models/repository.py
@@ -225,6 +225,21 @@ class Repository(MasterModel):
             model = self.versions.complete().latest()
             return model
 
+    async def alatest_version(self):
+        """
+        Get the latest RepositoryVersion on a repository asynchronously
+
+        Args:
+            repository (pulpcore.app.models.Repository): to get the latest version of
+
+        Returns:
+            pulpcore.app.models.RepositoryVersion: The latest RepositoryVersion
+
+        """
+        with suppress(RepositoryVersion.DoesNotExist):
+            model = await self.versions.complete().alatest()
+            return model
+
     def natural_key(self):
         """
         Get the model's natural key.

--- a/pulpcore/content/handler.py
+++ b/pulpcore/content/handler.py
@@ -569,7 +569,7 @@ class Handler:
                     pass
 
             if not repo_version:
-                repo_version = await sync_to_async(repository.latest_version)()
+                repo_version = await repository.alatest_version()
 
         if publication:
             if rel_path == "" or rel_path[-1] == "/":


### PR DESCRIPTION
The repository model's latest_version function now has a separate asynchronous version called alatest_version.

fixes: #3798