### PR TITLE
Add pull-through caching support for streaming metadata & multi-artifact content types

### DIFF
--- a/CHANGES/plugin_api/3817.feature
+++ b/CHANGES/plugin_api/3817.feature
@@ -1,0 +1,5 @@
+Added support to pull-through caching for streaming metadata files.
+
+``Remote.get_remote_artifact_content_type`` can now return ``None`` to inform the content app that
+the requested path is a metadata file that should be streamed and not saved for the pull-through
+caching feature.

--- a/CHANGES/plugin_api/3818.feature
+++ b/CHANGES/plugin_api/3818.feature
@@ -1,0 +1,4 @@
+Added support to pull-through caching for plugins with multi-artifact content types.
+
+``Content.init_from_artifact_and_relative_path`` can now return a tuple of the new content unit
+and a dict containing the mapping of that content's artifacts and their relative paths.

--- a/docs/plugin_dev/plugin-writer/concepts/index.rst
+++ b/docs/plugin_dev/plugin-writer/concepts/index.rst
@@ -38,6 +38,7 @@ the box.
    subclassing/viewsets
    subclassing/import-export
    subclassing/replication
+   subclassing/pull-through
 
 
 .. _master-detail-models:

--- a/docs/plugin_dev/plugin-writer/concepts/subclassing/pull-through.rst
+++ b/docs/plugin_dev/plugin-writer/concepts/subclassing/pull-through.rst
@@ -1,0 +1,36 @@
+Pull-Through Caching
+====================
+
+Pull-through caching enables plugins to use remotes on their distributions that will act as an
+upstream fallback source when an user requests content from Pulp. The content will be streamed from
+the remote and saved in Pulp to be served again in future requests. This feature requires plugins to
+provide implementations for the methods below on the subclasses of their Remote and Content objects.
+
+.. automethod:: pulpcore.app.models.Remote::get_remote_artifact_url
+
+.. automethod:: pulpcore.app.models.Remote::get_remote_artifact_content_type
+
+.. automethod:: pulpcore.app.models.Content::init_from_artifact_and_relative_path
+
+Finally, plugin writers need to expose the ``remote`` field on their distribution serializer to allow
+users to add their remotes to their distributions. The ``remote`` field is already present on the base
+distribution model, so no new migration is needed.
+
+.. code-block:: python
+
+    class GemDistributionSerializer(DistributionSerializer):
+        """A Serializer for GemDistribution."""
+
+        ...
+
+        remote = DetailRelatedField(
+            required=False,
+            help_text=_("Remote that can be used to fetch content when using pull-through caching."),
+            view_name_pattern=r"remotes(-.*/.*)?-detail",
+            queryset=Remote.objects.all(),
+            allow_null=True,
+        )
+
+        class Meta:
+            fields = DistributionSerializer.Meta.fields + ("publication", "remote")
+            model = GemDistribution

--- a/pulpcore/app/models/content.py
+++ b/pulpcore/app/models/content.py
@@ -588,7 +588,9 @@ class Content(MasterModel, QueryMixin):
         Return an instance of the specific content by inspecting an artifact.
 
         Plugin writers are expected to override this method with an implementation for a specific
-        content type.
+        content type. If the content type is stored with multiple artifacts plugin writers can
+        instead return a tuple of the unsaved content instance and a dictionary of the content's
+        artifacts by their relative paths.
 
         For example::
 
@@ -604,7 +606,9 @@ class Content(MasterModel, QueryMixin):
             ValueError: If relative_path starts with a '/'.
 
         Returns:
-            An un-saved instance of :class:`~pulpcore.plugin.models.Content` sub-class.
+            An un-saved instance of :class:`~pulpcore.plugin.models.Content` sub-class. Or a
+            tuple of an un-saved instance of :class:`~pulpcore.plugin.models.Content` and a dict
+            of form [relative_path:str, Optional[artifact:`~pulpcore.plugin.models.Artifact`]]
         """
         raise NotImplementedError()
 

--- a/pulpcore/app/models/repository.py
+++ b/pulpcore/app/models/repository.py
@@ -517,13 +517,15 @@ class Remote(MasterModel):
         """
         Get the type of content that should be available at the relative path.
 
-        Plugin writers are expected to implement this method.
+        Plugin writers are expected to implement this method. This method can return None if the
+        relative path is for metadata that should only be streamed from the remote and not saved.
 
         Args:
             relative_path (str): The relative path of a RemoteArtifact
 
         Returns:
-            Class: The Class of the content type that should be available at the relative path.
+            Optional[Class]: The optional Class of the content type that should be available at the
+                relative path.
         """
         raise NotImplementedError()
 

--- a/pulpcore/tests/unit/content/test_handler.py
+++ b/pulpcore/tests/unit/content/test_handler.py
@@ -1,10 +1,17 @@
 import pytest
 import uuid
 
-from unittest.mock import Mock
+from unittest.mock import Mock, AsyncMock
 
 from pulpcore.content import Handler
-from pulpcore.plugin.models import Artifact, Content, ContentArtifact
+from pulpcore.plugin.models import (
+    Artifact,
+    Content,
+    ContentArtifact,
+    Distribution,
+    Remote,
+    RemoteArtifact,
+)
 
 
 @pytest.fixture
@@ -67,3 +74,196 @@ def test_save_artifact_artifact_already_exists(c2, ra1, ra2, download_result_moc
     c2 = Content.objects.get(pk=c2.pk)
     assert existing_artifact.pk == new_artifact.pk
     assert c2._artifacts.get().pk == existing_artifact.pk
+
+
+# Test pull through features
+@pytest.fixture
+def remote123(db):
+    return Remote.objects.create(name="123", url="https://123")
+
+
+@pytest.fixture
+def request123():
+    return Mock(match_info={"path": "c123"})
+
+
+# pytest-django fixtures does not work when testing async code
+async def create_artifact(tmp_path):
+    tmp_file = tmp_path / str(uuid.uuid4())
+    tmp_file.write_text(str(tmp_file))
+    artifact = Artifact.init_and_validate(str(tmp_file))
+    await artifact.asave()
+    return artifact
+
+
+async def create_content():
+    return await Content.objects.acreate()
+
+
+async def create_content_artifact(content):
+    return await ContentArtifact.objects.acreate(
+        artifact=None, content=content, relative_path="c123"
+    )
+
+
+async def create_remote():
+    return await Remote.objects.acreate(name=str(uuid.uuid4()), url="https://123")
+
+
+async def create_remote_artifact(remote, ca):
+    return await RemoteArtifact.objects.acreate(
+        remote=remote, url="https://123/c123", content_artifact=ca
+    )
+
+
+async def create_distribution(remote):
+    name = str(uuid.uuid4())
+    return await Distribution.objects.acreate(name=name, base_path=name, remote=remote)
+
+
+@pytest.mark.asyncio
+@pytest.mark.django_db
+async def test_pull_through_remote_artifact_exists(request123, tmp_path):
+    """Remote Artifact already exists, stream or serve associated content."""
+    handler = Handler()
+    handler._stream_content_artifact = AsyncMock()
+
+    # Setup content w/ remote artifact
+    content = await create_content()
+    ca = await create_content_artifact(content)
+    remote = await create_remote()
+    await create_remote_artifact(remote, ca)
+    distro = await create_distribution(remote)
+
+    # Check that the handler finds the on-demand CA and calls the stream method
+    try:
+        await handler._match_and_stream(f"{distro.base_path}/c123", request123)
+        handler._stream_content_artifact.assert_called_once()
+        assert ca in handler._stream_content_artifact.call_args[0]
+
+        # Manually save artifact for content_artifact
+        tmp_file = tmp_path / str(uuid.uuid4())
+        tmp_file.write_text(str(tmp_file))
+        artifact = Artifact.init_and_validate(str(tmp_file))
+        await artifact.asave()
+
+        ca.artifact = artifact
+        await ca.asave()
+        handler._serve_content_artifact = AsyncMock()
+
+        # Check that the handler finds the CA and calls the serve method
+        await handler._match_and_stream(f"{distro.base_path}/c123", request123)
+        handler._serve_content_artifact.assert_called_once()
+        assert ca in handler._serve_content_artifact.call_args[0]
+    finally:
+        # Cleanup since this test isn't using fixtures
+        await content.adelete()
+        await remote.adelete()
+        await distro.adelete()
+
+
+@pytest.mark.asyncio
+@pytest.mark.django_db
+async def test_pull_through_new_remote_artifacts(request123, monkeypatch):
+    """Remote Artifact doesn't exist, create and stream content."""
+    handler = Handler()
+    handler._stream_remote_artifact = AsyncMock()
+
+    remote = await create_remote()
+    monkeypatch.setattr(Remote, "get_remote_artifact_content_type", Mock(return_value=Content))
+    distro = await create_distribution(remote)
+
+    try:
+        await handler._match_and_stream(f"{distro.base_path}/c123", request123)
+        remote.get_remote_artifact_content_type.assert_called_once_with("c123")
+        handler._stream_remote_artifact.assert_called_once()
+
+        args, kwargs = handler._stream_remote_artifact.call_args
+        assert kwargs.get("save_artifact", None) is True
+        ra = args[2]
+        assert isinstance(ra, RemoteArtifact)
+        assert ra.remote == remote
+        assert ra.url == f"{remote.url}/c123"
+        assert ra.content_artifact.relative_path == "c123"
+    finally:
+        await remote.adelete()
+        await distro.adelete()
+
+
+@pytest.mark.asyncio
+@pytest.mark.django_db
+async def test_pull_through_metadata_file(request123, monkeypatch):
+    """Requested path is for a metadata file. Don't save response."""
+    handler = Handler()
+    handler._stream_remote_artifact = AsyncMock()
+
+    remote = await create_remote()
+    monkeypatch.setattr(Remote, "get_remote_artifact_content_type", Mock(return_value=None))
+    distro = await create_distribution(remote)
+
+    try:
+        await handler._match_and_stream(f"{distro.base_path}/c123", request123)
+        remote.get_remote_artifact_content_type.assert_called_once_with("c123")
+        handler._stream_remote_artifact.assert_called_once()
+
+        _, kwargs = handler._stream_remote_artifact.call_args
+        assert kwargs.get("save_artifact", None) is False
+    finally:
+        await remote.adelete()
+        await distro.adelete()
+
+
+def test_pull_through_save_single_artifact_content(
+    remote123, request123, download_result_mock, monkeypatch
+):
+    """Ensure single-artifact content is properly saved on pull-through."""
+    handler = Handler()
+    remote123.get_remote_artifact_content_type = Mock(return_value=Content)
+    content_init_mock = Mock(return_value=Content())
+    monkeypatch.setattr(Content, "init_from_artifact_and_relative_path", content_init_mock)
+    ca = ContentArtifact(relative_path="c123")
+    ra = RemoteArtifact(url=f"{remote123.url}/c123", remote=remote123, content_artifact=ca)
+
+    # Content is saved during handler._save_artifact
+    artifact = handler._save_artifact(download_result_mock, ra, request=request123)
+
+    remote123.get_remote_artifact_content_type.assert_called_once_with("c123")
+    content_init_mock.assert_called_once_with(artifact, "c123")
+
+    # Assert the CA and RA are properly saved
+    ca = artifact.content_memberships.first()
+    assert ca.content is not None
+    assert ca.relative_path == "c123"
+    ra = RemoteArtifact.objects.filter(
+        url=f"{remote123.url}/c123", remote=remote123, content_artifact=ca
+    ).first()
+    assert ra is not None
+
+
+def test_pull_through_save_multi_artifact_content(
+    remote123, request123, download_result_mock, monkeypatch, tmp_path
+):
+    """Ensure multi-artifact content is properly saved on pull-through."""
+    handler = Handler()
+    remote123.get_remote_artifact_content_type = Mock(return_value=Content)
+
+    tmp_file = tmp_path / str(uuid.uuid4())
+    tmp_file.write_text(str(tmp_file))
+    artifact123 = Artifact.init_and_validate(str(tmp_file))
+    artifact123.save()
+
+    def content_init(art, path):
+        return Content(), {path: artifact123, path + "abc": art}
+
+    monkeypatch.setattr(Content, "init_from_artifact_and_relative_path", content_init)
+    ca = ContentArtifact(relative_path="c123")
+    ra = RemoteArtifact(url=f"{remote123.url}/c123", remote=remote123, content_artifact=ca)
+
+    artifact = handler._save_artifact(download_result_mock, ra, request123)
+
+    ca = artifact.content_memberships.first()
+    assert ca.content is not None
+
+    artifacts = set(ca.content._artifacts.all())
+    assert len(artifacts) == 2
+    assert {artifact, artifact123} == artifacts


### PR DESCRIPTION
fixes: #3817
fixes: #3818

TODO:

- [x] Tests (unit tests? pulp_file doesn't support pull-through caching. Currently I am manually testing this against pulp_gem (whom the feature is being added for) and pulp_python)
- [x] Plugin writer docs (pull-through caching is not very easy to understand/implement)