### PR TITLE
Adds basic worker metrics

### DIFF
--- a/CHANGES/3821.feature
+++ b/CHANGES/3821.feature
@@ -1,0 +1,2 @@
+Adds the "task_count" metric to each worker. This reports the cumulative number of tasks executed
+since the worker has been started.


### PR DESCRIPTION
The following metrics are added:
* `task_count` - The cumulative number of tasks a worker has executed since it was started.

closes #3821