### PR TITLE
EXPERIMENT: Simplify mirror sync

### DIFF
--- a/pulpcore/plugin/stages/content_stages.py
+++ b/pulpcore/plugin/stages/content_stages.py
@@ -273,30 +273,19 @@ class ContentAssociation(Stage):
     """
     A Stages API stage that associates content units with `new_version`.
 
-    This stage stores all content unit primary keys in memory before running. This is done to
-    compute the units already associated but not received from `self._in_q`. These units are passed
-    via `self._out_q` to the next stage as a :class:`django.db.models.query.QuerySet`.
-
     This stage creates a ProgressReport named 'Associating Content' that counts the number of units
     associated. Since it's a stream the total count isn't known until it's finished.
-
-    If `mirror` was enabled, then content units may also be un-assocated (removed) from
-    `new_version`. A ProgressReport named 'Un-Associating Content' is created that counts the number
-    of units un-associated.
 
     Args:
         new_version (:class:`~pulpcore.plugin.models.RepositoryVersion`): The repo version this
             stage associates content with.
-        mirror (bool): Whether or not to "mirror" the stream of DeclarativeContent - whether content
-            not in the stream should be removed from the repository.
         args: unused positional arguments passed along to :class:`~pulpcore.plugin.stages.Stage`.
         kwargs: unused keyword arguments passed along to :class:`~pulpcore.plugin.stages.Stage`.
     """
 
-    def __init__(self, new_version, mirror, *args, **kwargs):
+    def __init__(self, new_version, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.new_version = new_version
-        self.allow_delete = mirror
 
     async def run(self):
         """
@@ -306,34 +295,13 @@ class ContentAssociation(Stage):
             The coroutine for this stage.
         """
         async with ProgressReport(message="Associating Content", code="associating.content") as pb:
-            to_delete = {
-                i
-                async for i in sync_to_async_iterable(
-                    self.new_version.content.values_list("pk", flat=True)
-                )
-            }
-
             async for batch in self.batches():
-                to_add = set()
-                for d_content in batch:
-                    try:
-                        to_delete.remove(d_content.content.pk)
-                    except KeyError:
-                        to_add.add(d_content.content.pk)
-                        await self.put(d_content)
-
+                to_add = {d_content.content.pk for d_content in batch}
                 if to_add:
                     await sync_to_async(self.new_version.add_content)(
                         Content.objects.filter(pk__in=to_add)
                     )
                     await pb.aincrease_by(len(to_add))
 
-            if self.allow_delete:
-                async with ProgressReport(
-                    message="Un-Associating Content", code="unassociating.content"
-                ) as pb:
-                    if to_delete:
-                        await sync_to_async(self.new_version.remove_content)(
-                            Content.objects.filter(pk__in=to_delete)
-                        )
-                        await pb.aincrease_by(len(to_delete))
+                for d_content in batch:
+                    await self.put(d_content)

--- a/pulpcore/plugin/stages/declarative_version.py
+++ b/pulpcore/plugin/stages/declarative_version.py
@@ -153,9 +153,12 @@ class DeclarativeVersion:
         """
         with tempfile.TemporaryDirectory(dir="."):
             with self.repository.new_version() as new_version:
+                if self.mirror:
+                    # Delete all existing content; start out clean
+                    new_version.clear_content()
                 loop = asyncio.get_event_loop()
                 stages = self.pipeline_stages(new_version)
-                stages.append(ContentAssociation(new_version, self.mirror))
+                stages.append(ContentAssociation(new_version))
                 stages.append(EndStage())
                 pipeline = create_pipeline(stages)
                 loop.run_until_complete(pipeline)


### PR DESCRIPTION
Just start with a clean repository version for a mirror sync. This way, there is no need to keep e record of all existing content in memory at any time. This should reduce the memory pressure on the task worker (yet to be confirmed).

[noissue]