### PR TITLE
Extensions to give plugins a chance to set specific content-headers.

### DIFF
--- a/CHANGES/plugin_api/3897.feature
+++ b/CHANGES/plugin_api/3897.feature
@@ -1,0 +1,5 @@
+Added Distribution.content_headers_for() to let plugins affect content-app response headers.
+
+This can be useful, for example, when it's desirable for specific files to
+be served with Cache-control: no-cache.
+

--- a/pulpcore/app/models/publication.py
+++ b/pulpcore/app/models/publication.py
@@ -574,6 +574,17 @@ class Distribution(MasterModel):
         """
         return set()
 
+    def content_headers_for(self, path):
+        """
+        Opportunity for Distribution to specify response-headers for a specific path
+
+        Args:
+            path (str): The path being requested
+        Returns:
+            Empty dictionary, or a dictionary with HTTP Response header/value pairs.
+        """
+        return {}
+
     @hook(BEFORE_DELETE)
     @hook(
         AFTER_UPDATE,


### PR DESCRIPTION
Added Distribution.content_headers_for() and call it from inside Handler.response_headers().

This is in support of https://github.com/pulp/pulp_rpm/issues/2947

[noissue]