### PR TITLE
Fix the use of content_artifact_set in handler

### DIFF
--- a/CHANGES/3945.bugfix
+++ b/CHANGES/3945.bugfix
@@ -1,0 +1,1 @@
+Fixed error when downloading pull-through content that already exists in Pulp.

--- a/pulpcore/content/handler.py
+++ b/pulpcore/content/handler.py
@@ -844,7 +844,7 @@ class Handler:
                     # There is already content saved
                     content = c_type.objects.get(content.q())
                     created_artifact_digests = {rp: a.sha256 for rp, a in artifacts.items() if a}
-                    cas = list(content.contentartifact_set().select_related("artifact"))
+                    cas = list(content.contentartifact_set.select_related("artifact"))
                     found_artifact_digests = {
                         ca.relative_path: ca.artifact.sha256 for ca in cas if ca.artifact
                     }


### PR DESCRIPTION
```
File "/usr/local/lib/python3.8/site-packages/pulpcore/content/handler.py", line 847, in _save_artifact
  cas = list(content.contentartifact_set().select_related("artifact"))
TypeError: __call__() missing 1 required keyword-only argument: 'manager'
```

[noissue]