### PR TITLE
Add cleanup tasks to remove stale objects

### DIFF
--- a/CHANGES/3949.feature
+++ b/CHANGES/3949.feature
@@ -1,0 +1,2 @@
+Added periodically executed cleanup tasks for uploads and temporary files. Configure a time
+interval in ``UPLOAD_PROTECTION_TIME`` or ``TMPFILE_PROTECTION_TIME`` to activate.

--- a/docs/configuration/settings.rst
+++ b/docs/configuration/settings.rst
@@ -442,6 +442,17 @@ ORPHAN_PROTECTION_TIME
     up before the task finishes. Default is 1440 minutes (24 hours).
 
 
+.. _upload_protection_time:
+.. _tmpfile_protection_time:
+
+UPLOAD_PROTECTION_TIME and TMPFILE_PROTECTION_TIME
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+    Pulp uses ``uploads`` and ``pulp temporary files`` to pass data from the api to worker tasks.
+    These options allow to specify a timeinterval in minutes used for cleaning up stale entries. If
+    set to 0, automatic cleanup is disabled, which is the default.
+
+
 .. _task_diagnostics:
 
 TASK_DIAGNOSTICS

--- a/pulpcore/app/settings.py
+++ b/pulpcore/app/settings.py
@@ -240,8 +240,10 @@ CONTENT_APP_TTL = 30
 
 WORKER_TTL = 30
 
-# how long to protect orphan content in minutes
+# how long to protect ephemeral items in minutes
 ORPHAN_PROTECTION_TIME = 24 * 60
+UPLOAD_PROTECTION_TIME = 0
+TMPFILE_PROTECTION_TIME = 0
 
 REMOTE_USER_ENVIRON_NAME = "REMOTE_USER"
 

--- a/pulpcore/tasking/pulpcore_worker.py
+++ b/pulpcore/tasking/pulpcore_worker.py
@@ -24,6 +24,7 @@ from pulpcore.app.models import Worker, Task
 
 from pulpcore.app.util import (
     configure_analytics,
+    configure_cleanup,
     set_domain,
     set_current_user,
 )
@@ -57,6 +58,7 @@ TASK_SCHEDULING_LOCK = 42
 
 def startup_hook():
     configure_analytics()
+    configure_cleanup()
 
 
 class PGAdvisoryLock:


### PR DESCRIPTION
Uploads and PulpTemporaryFiles are cleaned up. Set the *_PROTECTION_TIME settings to None in order to disable this behaviour.

fixes #3949