### PR TITLE
Bridge gaps between content serializer features

### DIFF
--- a/CHANGES/plugin_api/3951.feature
+++ b/CHANGES/plugin_api/3951.feature
@@ -1,0 +1,2 @@
+Added ``retrieve`` logic to ``MultipleArtifactContentSerializer``. Allow to use uploads with
+``NoArtifactContentSerializer``.


### PR DESCRIPTION
Refactor the content serializers to reuse more code and share more features.
* Allow to implement 'retrieve' on all content serializers for multiple upload.
* Allow adding all content to a repository on creation.
* Validate that the content type matches the provided repository.

fixes #3951