### PR TITLE
Incremental export for file exporter will now include published metadata

### DIFF
--- a/CHANGES/3941.bugfix
+++ b/CHANGES/3941.bugfix
@@ -1,0 +1,1 @@
+Made the incremental file export include all published metadata.

--- a/pulpcore/app/tasks/export.py
+++ b/pulpcore/app/tasks/export.py
@@ -143,12 +143,17 @@ def _export_publication_to_file_system(
             for ca in content_artifacts.select_related("artifact").iterator()
         }
 
+    publication_metadata_paths = set(
+        publication.published_metadata.values_list("relative_path", flat=True)
+    )
     for pa in publication.published_artifact.select_related(
         "content_artifact", "content_artifact__artifact"
     ).iterator():
         # Artifact isn't guaranteed to be present
         if pa.content_artifact.artifact and (
-            start_repo_version is None or pa.content_artifact.pk in difference_content_artifacts
+            start_repo_version is None
+            or pa.relative_path in publication_metadata_paths
+            or pa.content_artifact.pk in difference_content_artifacts
         ):
             relative_path_to_artifacts[pa.relative_path] = pa.content_artifact.artifact
 


### PR DESCRIPTION
Look at https://github.com/pulp/pulpcore/issues/3941#issuecomment-1601977276 for more information

The initial approach was here https://github.com/pulp/pulpcore/pull/3942 where the code ended up looking exclusively  at the repodata directory which is not ideal in pulpcore. 

This PR tries to address the same issue by saying  all published metadata in a publication should get included automatically. 