### PR TITLE
Fix api schema for `upstream_pulps_replicate`

### DIFF
--- a/CHANGES/3995.bugfix
+++ b/CHANGES/3995.bugfix
@@ -1,0 +1,1 @@
+Fix api schema of the `upstream_pulp_replicate` operation requiring no body.

--- a/pulpcore/app/viewsets/replica.py
+++ b/pulpcore/app/viewsets/replica.py
@@ -33,6 +33,7 @@ class UpstreamPulpViewSet(
         summary="Replicate",
         description="Trigger an asynchronous repository replication task group. This API is "
         "provided as a tech preview.",
+        request=None,
         responses={202: AsyncOperationResponseSerializer},
     )
     @action(detail=True, methods=["post"])


### PR DESCRIPTION
This operation requires no body.

fixes #3995