### PR TITLE
Fix the import path for pulp-hashlib

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -7,6 +7,8 @@
 [flake8]
 exclude = ./docs/*,*/migrations/*,./pulpcore/app/protobuf/*
 
+per-file-ignores = */__init__.py: F401
+
 ignore = E203,W503,Q000,Q003,D100,D104,D106,D200,D205,D400,D401,D402
 max-line-length = 100
 

--- a/CHANGES/plugin_api/4006.bugfix
+++ b/CHANGES/plugin_api/4006.bugfix
@@ -1,0 +1,1 @@
+Fixed the import path for ``pulpcore.plugin.pulp_hashlib``.

--- a/pulpcore/app/models/__init__.py
+++ b/pulpcore/app/models/__init__.py
@@ -1,23 +1,23 @@
 # https://docs.djangoproject.com/en/3.2/topics/db/models/#organizing-models-in-a-package
 
 # Must be imported first as other models depend on it
-from .base import (  # noqa
+from .base import (
     BaseModel,
     MasterModel,
     pulp_uuid,
 )
 
-from .access_policy import (  # noqa
+from .access_policy import (
     AccessPolicy,
     AutoAddObjPermsMixin,
     Group,
 )
 
-from .domain import Domain  # noqa
+from .domain import Domain
 
-from .acs import AlternateContentSource, AlternateContentSourcePath  # noqa
+from .acs import AlternateContentSource, AlternateContentSourcePath
 
-from .content import (  # noqa
+from .content import (
     Artifact,
     AsciiArmoredDetachedSigningService,
     Content,
@@ -29,9 +29,9 @@ from .content import (  # noqa
     UnsupportedDigestValidationError,
 )
 
-from .generic import GenericRelationModel  # noqa
+from .generic import GenericRelationModel
 
-from .exporter import (  # noqa
+from .exporter import (
     Export,
     ExportedResource,
     Exporter,
@@ -41,14 +41,14 @@ from .exporter import (  # noqa
     PulpExporter,
 )
 
-from .importer import (  # noqa
+from .importer import (
     Import,
     Importer,
     PulpImport,
     PulpImporter,
 )
 
-from .publication import (  # noqa
+from .publication import (
     ContentGuard,
     Distribution,
     Publication,
@@ -59,7 +59,7 @@ from .publication import (  # noqa
     ArtifactDistribution,
 )
 
-from .repository import (  # noqa
+from .repository import (
     Remote,
     Repository,
     RepositoryContent,
@@ -67,17 +67,9 @@ from .repository import (  # noqa
     RepositoryVersionContentDetails,
 )
 
-# This can lead to circular imports with a custom user model depending on this very module
-# Moved to plugin/models/role.py to avoid the circular import.
-# from .role import (  # noqa
-#     GroupRole,
-#     Role,
-#     UserRole,
-# )
+from .status import ContentAppStatus
 
-from .status import ContentAppStatus  # noqa
-
-from .task import (  # noqa
+from .task import (
     CreatedResource,
     Task,
     TaskGroup,
@@ -85,15 +77,15 @@ from .task import (  # noqa
     Worker,
 )
 
-from .analytics import SystemID  # noqa
+from .analytics import SystemID
 
-from .upload import (  # noqa
+from .upload import (
     Upload,
     UploadChunk,
 )
 
 # Moved here to avoid a circular import with Task
-from .progress import GroupProgressReport, ProgressReport  # noqa
+from .progress import GroupProgressReport, ProgressReport
 
 # Moved here to avoid a circular import with GroupProgressReport
-from .replica import UpstreamPulp  # noqa
+from .replica import UpstreamPulp

--- a/pulpcore/app/serializers/__init__.py
+++ b/pulpcore/app/serializers/__init__.py
@@ -2,7 +2,7 @@
 # - fields can import directly from base if needed
 # - all can import directly from base and fields if needed
 
-from .base import (  # noqa
+from .base import (
     AsyncOperationResponseSerializer,
     DetailIdentityField,
     DetailRelatedField,
@@ -19,7 +19,7 @@ from .base import (  # noqa
     validate_unknown_fields,
     HiddenFieldsMixin,
 )
-from .fields import (  # noqa
+from .fields import (
     BaseURLField,
     ExportsIdentityFromExporterField,
     ExportRelatedField,
@@ -36,12 +36,12 @@ from .fields import (  # noqa
     TaskGroupStatusCountField,
     pulp_labels_validator,
 )
-from .access_policy import AccessPolicySerializer  # noqa
-from .acs import (  # noqa
+from .access_policy import AccessPolicySerializer
+from .acs import (
     AlternateContentSourcePathSerializer,
     AlternateContentSourceSerializer,
 )
-from .content import (  # noqa
+from .content import (
     ArtifactSerializer,
     ContentChecksumSerializer,
     MultipleArtifactContentSerializer,
@@ -49,8 +49,8 @@ from .content import (  # noqa
     SigningServiceSerializer,
     SingleArtifactContentSerializer,
 )
-from .domain import DomainSerializer  # noqa
-from .exporter import (  # noqa
+from .domain import DomainSerializer
+from .exporter import (
     ExporterSerializer,
     ExportSerializer,
     FilesystemExportSerializer,
@@ -58,7 +58,7 @@ from .exporter import (  # noqa
     PulpExporterSerializer,
     PulpExportSerializer,
 )
-from .importer import (  # noqa
+from .importer import (
     EvaluationSerializer,
     ImporterSerializer,
     ImportSerializer,
@@ -67,9 +67,9 @@ from .importer import (  # noqa
     PulpImporterSerializer,
     PulpImportSerializer,
 )
-from .orphans import OrphansCleanupSerializer  # noqa
-from .progress import GroupProgressReportSerializer, ProgressReportSerializer  # noqa
-from .publication import (  # noqa
+from .orphans import OrphansCleanupSerializer
+from .progress import GroupProgressReportSerializer, ProgressReportSerializer
+from .publication import (
     ContentGuardSerializer,
     DistributionSerializer,
     PublicationSerializer,
@@ -78,17 +78,17 @@ from .publication import (  # noqa
     ContentRedirectContentGuardSerializer,
     ArtifactDistributionSerializer,
 )
-from .purge import PurgeSerializer  # noqa
-from .repository import (  # noqa
+from .purge import PurgeSerializer
+from .repository import (
     RemoteSerializer,
     RepositorySerializer,
     RepositorySyncURLSerializer,
     RepositoryAddRemoveContentSerializer,
     RepositoryVersionSerializer,
 )
-from .repair import RepairSerializer  # noqa
-from .reclaim import ReclaimSpaceSerializer  # noqa
-from .task import (  # noqa
+from .repair import RepairSerializer
+from .reclaim import ReclaimSpaceSerializer
+from .task import (
     MinimalTaskSerializer,
     TaskCancelSerializer,
     TaskScheduleSerializer,
@@ -96,13 +96,13 @@ from .task import (  # noqa
     TaskGroupSerializer,
     WorkerSerializer,
 )
-from .upload import (  # noqa
+from .upload import (
     UploadChunkSerializer,
     UploadCommitSerializer,
     UploadSerializer,
     UploadDetailSerializer,
 )
-from .user import (  # noqa
+from .user import (
     GroupRoleSerializer,
     GroupSerializer,
     GroupUserSerializer,
@@ -111,4 +111,4 @@ from .user import (  # noqa
     UserRoleSerializer,
     UserSerializer,
 )
-from .replica import UpstreamPulpSerializer  # noqa
+from .replica import UpstreamPulpSerializer

--- a/pulpcore/app/serializers/purge.py
+++ b/pulpcore/app/serializers/purge.py
@@ -3,7 +3,7 @@ from gettext import gettext as _
 
 from rest_framework import serializers
 
-from pulpcore.app.serializers import ValidateFieldsMixin  # noqa
+from pulpcore.app.serializers import ValidateFieldsMixin
 from pulpcore.constants import TASK_FINAL_STATES
 
 

--- a/pulpcore/app/tasks/__init__.py
+++ b/pulpcore/app/tasks/__init__.py
@@ -1,6 +1,6 @@
-from pulpcore.app.tasks import base, repository, upload  # noqa
+from pulpcore.app.tasks import base, repository, upload
 
-from .base import (  # noqa
+from .base import (
     general_create,
     general_create_from_temp_file,
     general_delete,
@@ -8,18 +8,18 @@ from .base import (  # noqa
     general_update,
 )
 
-from .export import fs_publication_export, fs_repo_version_export  # noqa
+from .export import fs_publication_export, fs_repo_version_export
 
-from .importer import pulp_import  # noqa
+from .importer import pulp_import
 
-from .orphan import orphan_cleanup  # noqa
+from .orphan import orphan_cleanup
 
-from .purge import purge  # noqa
+from .purge import purge
 
-from .reclaim_space import reclaim_space  # noqa
+from .reclaim_space import reclaim_space
 
-from .replica import replicate_distributions  # noqa
+from .replica import replicate_distributions
 
-from .repository import repair_all_artifacts  # noqa
+from .repository import repair_all_artifacts
 
-from .analytics import post_analytics  # noqa
+from .analytics import post_analytics

--- a/pulpcore/app/views/__init__.py
+++ b/pulpcore/app/views/__init__.py
@@ -1,4 +1,4 @@
-from .orphans import OrphansView  # noqa
-from .status import StatusView  # noqa
-from .repair import RepairView  # noqa
-from .importer import PulpImporterImportCheckView  # noqa
+from .orphans import OrphansView
+from .status import StatusView
+from .repair import RepairView
+from .importer import PulpImporterImportCheckView

--- a/pulpcore/app/viewsets/__init__.py
+++ b/pulpcore/app/viewsets/__init__.py
@@ -1,4 +1,4 @@
-from .base import (  # noqa
+from .base import (
     AsyncCreateMixin,
     AsyncRemoveMixin,
     AsyncUpdateMixin,
@@ -8,11 +8,11 @@ from .base import (  # noqa
     NULLABLE_NUMERIC_FILTER_OPTIONS,
 )
 
-from .access_policy import AccessPolicyViewSet  # noqa
+from .access_policy import AccessPolicyViewSet
 
-from .acs import AlternateContentSourceViewSet  # noqa
+from .acs import AlternateContentSourceViewSet
 
-from .content import (  # noqa
+from .content import (
     ArtifactFilter,
     ArtifactViewSet,
     ContentFilter,
@@ -21,12 +21,12 @@ from .content import (  # noqa
     ReadOnlyContentViewSet,
     SigningServiceViewSet,
 )
-from .custom_filters import (  # noqa
+from .custom_filters import (
     RepoVersionHrefFilter,
     RepositoryVersionFilter,
 )
-from .domain import DomainViewSet  # noqa
-from .exporter import (  # noqa
+from .domain import DomainViewSet
+from .exporter import (
     ExportViewSet,
     ExporterViewSet,
     FilesystemExporterViewSet,
@@ -34,14 +34,14 @@ from .exporter import (  # noqa
     PulpExporterViewSet,
     PulpExportViewSet,
 )
-from .importer import (  # noqa
+from .importer import (
     ImportViewSet,
     ImporterViewSet,
     PulpImportViewSet,
     PulpImporterViewSet,
 )
-from .orphans import OrphansCleanupViewset  # noqa
-from .publication import (  # noqa
+from .orphans import OrphansCleanupViewset
+from .publication import (
     ContentGuardFilter,
     ContentGuardViewSet,
     DistributionFilter,
@@ -55,8 +55,8 @@ from .publication import (  # noqa
     ContentRedirectContentGuardViewSet,
     ArtifactDistributionViewSet,
 )
-from .reclaim import ReclaimSpaceViewSet  # noqa
-from .repository import (  # noqa
+from .reclaim import ReclaimSpaceViewSet
+from .repository import (
     ImmutableRepositoryViewSet,
     ListRepositoryViewSet,
     ReadOnlyRepositoryViewSet,
@@ -67,9 +67,9 @@ from .repository import (  # noqa
     RepositoryVersionViewSet,
     ListRepositoryVersionViewSet,
 )
-from .task import TaskViewSet, TaskGroupViewSet, TaskScheduleViewSet, WorkerViewSet  # noqa
-from .upload import UploadViewSet  # noqa
-from .user import (  # noqa
+from .task import TaskViewSet, TaskGroupViewSet, TaskScheduleViewSet, WorkerViewSet
+from .upload import UploadViewSet
+from .user import (
     GroupViewSet,
     GroupRoleViewSet,
     GroupUserViewSet,
@@ -77,4 +77,4 @@ from .user import (  # noqa
     UserViewSet,
     UserRoleViewSet,
 )
-from .replica import UpstreamPulpViewSet  # noqa
+from .replica import UpstreamPulpViewSet

--- a/pulpcore/cache/__init__.py
+++ b/pulpcore/cache/__init__.py
@@ -1,4 +1,4 @@
-from .cache import (  # noqa
+from .cache import (
     AsyncCache,
     AsyncContentCache,
     Cache,

--- a/pulpcore/download/__init__.py
+++ b/pulpcore/download/__init__.py
@@ -1,4 +1,4 @@
-from .base import BaseDownloader, DownloadResult  # noqa
-from .factory import DownloaderFactory  # noqa
-from .file import FileDownloader  # noqa
-from .http import HttpDownloader  # noqa
+from .base import BaseDownloader, DownloadResult
+from .factory import DownloaderFactory
+from .file import FileDownloader
+from .http import HttpDownloader

--- a/pulpcore/exceptions/__init__.py
+++ b/pulpcore/exceptions/__init__.py
@@ -1,11 +1,11 @@
-from .base import (  # noqa
+from .base import (
     AdvisoryLockError,
     PulpException,
     ResourceImmutableError,
     TimeoutException,
     exception_to_dict,
 )
-from .validation import (  # noqa
+from .validation import (
     DigestValidationError,
     InvalidSignatureError,
     SizeValidationError,

--- a/pulpcore/plugin/__init__.py
+++ b/pulpcore/plugin/__init__.py
@@ -1,2 +1,2 @@
 # plugins declare that they are a pulp plugin by subclassing PulpPluginAppConfig
-from pulpcore.app.apps import PulpPluginAppConfig  # noqa
+from pulpcore.app.apps import PulpPluginAppConfig

--- a/pulpcore/plugin/access_policy.py
+++ b/pulpcore/plugin/access_policy.py
@@ -1,1 +1,1 @@
-from pulpcore.app.access_policy import AccessPolicyFromDB  # noqa
+from pulpcore.app.access_policy import AccessPolicyFromDB  # noqa: F401

--- a/pulpcore/plugin/apps.py
+++ b/pulpcore/plugin/apps.py
@@ -1,1 +1,1 @@
-from pulpcore.app.apps import adjust_roles  # noqa
+from pulpcore.app.apps import adjust_roles  # noqa: F401

--- a/pulpcore/plugin/authentication/__init__.py
+++ b/pulpcore/plugin/authentication/__init__.py
@@ -1,1 +1,1 @@
-from pulpcore.app.authentication import PulpRemoteUserAuthentication  # noqa
+from pulpcore.app.authentication import PulpRemoteUserAuthentication

--- a/pulpcore/plugin/cache/__init__.py
+++ b/pulpcore/plugin/cache/__init__.py
@@ -1,1 +1,1 @@
-from pulpcore.cache import CacheKeys, AsyncContentCache, SyncContentCache  # noqa
+from pulpcore.cache import CacheKeys, AsyncContentCache, SyncContentCache

--- a/pulpcore/plugin/constants.py
+++ b/pulpcore/plugin/constants.py
@@ -1,4 +1,4 @@
-from pulpcore.constants import (  # noqa
+from pulpcore.constants import (  # noqa: F401
     ALL_KNOWN_CONTENT_CHECKSUMS,
     SYNC_MODES,
     SYNC_CHOICES,

--- a/pulpcore/plugin/content.py
+++ b/pulpcore/plugin/content.py
@@ -1,3 +1,3 @@
-from pulpcore.content import app  # noqa
-from pulpcore.content.handler import Handler, PathNotResolved  # noqa
-from pulpcore.responses import ArtifactResponse  # noqa
+from pulpcore.content import app  # noqa: F401
+from pulpcore.content.handler import Handler, PathNotResolved  # noqa: F401
+from pulpcore.responses import ArtifactResponse  # noqa: F401

--- a/pulpcore/plugin/download/__init__.py
+++ b/pulpcore/plugin/download/__init__.py
@@ -1,4 +1,4 @@
-from pulpcore.download import (  # noqa
+from pulpcore.download import (
     BaseDownloader,
     DownloadResult,
     DownloaderFactory,

--- a/pulpcore/plugin/exceptions.py
+++ b/pulpcore/plugin/exceptions.py
@@ -1,4 +1,4 @@
-from pulpcore.exceptions import (  # noqa
+from pulpcore.exceptions import (  # noqa: F401
     DigestValidationError,
     InvalidSignatureError,
     PulpException,

--- a/pulpcore/plugin/files.py
+++ b/pulpcore/plugin/files.py
@@ -1,1 +1,1 @@
-from pulpcore.app.files import PulpTemporaryUploadedFile  # noqa
+from pulpcore.app.files import PulpTemporaryUploadedFile  # noqa: F401

--- a/pulpcore/plugin/modelresources.py
+++ b/pulpcore/plugin/modelresources.py
@@ -1,1 +1,1 @@
-from pulpcore.app.modelresource import RepositoryResource  # noqa
+from pulpcore.app.modelresource import RepositoryResource  # noqa: F401

--- a/pulpcore/plugin/models/__init__.py
+++ b/pulpcore/plugin/models/__init__.py
@@ -1,7 +1,7 @@
 # Models are exposed selectively in the versioned plugin API.
 # Any models defined in the pulpcore.plugin namespace should probably be proxy models.
 
-from pulpcore.app.models import (  # noqa
+from pulpcore.app.models import (
     AlternateContentSource,
     AlternateContentSourcePath,
     AccessPolicy,
@@ -43,4 +43,4 @@ from pulpcore.app.models import (  # noqa
 )
 
 
-from pulpcore.app.models.fields import EncryptedTextField  # noqa
+from pulpcore.app.models.fields import EncryptedTextField

--- a/pulpcore/plugin/models/role.py
+++ b/pulpcore/plugin/models/role.py
@@ -1,7 +1,7 @@
 # Models are exposed selectively in the versioned plugin API.
 # Any models defined in the pulpcore.plugin namespace should probably be proxy models.
 
-from pulpcore.app.models.role import (  # noqa
+from pulpcore.app.models.role import (  # noqa: F401
     GroupRole,
     Role,
     UserRole,

--- a/pulpcore/plugin/pulp_hashlib.py
+++ b/pulpcore/plugin/pulp_hashlib.py
@@ -1,3 +1,3 @@
 """A wrapper around `hashlib` providing only hashers named in settings.ALLOWED_CONTENT_CHECKSUMS"""
 
-from pulp.app.pulp_hashlib import new  # noqa
+from pulpcore.app.pulp_hashlib import new  # noqa: F401

--- a/pulpcore/plugin/replica.py
+++ b/pulpcore/plugin/replica.py
@@ -1,1 +1,1 @@
-from pulpcore.app.replica import Replicator  # noqa
+from pulpcore.app.replica import Replicator  # noqa: F401

--- a/pulpcore/plugin/responses.py
+++ b/pulpcore/plugin/responses.py
@@ -1,1 +1,1 @@
-from pulpcore.responses import ArtifactResponse  # noqa
+from pulpcore.responses import ArtifactResponse  # noqa: F401

--- a/pulpcore/plugin/serializers/__init__.py
+++ b/pulpcore/plugin/serializers/__init__.py
@@ -1,5 +1,5 @@
 # Import Serializers in platform that are potentially useful to plugin writers
-from pulpcore.app.serializers import (  # noqa
+from pulpcore.app.serializers import (
     AlternateContentSourceSerializer,
     AlternateContentSourcePathSerializer,
     ArtifactSerializer,
@@ -37,7 +37,7 @@ from pulpcore.app.serializers import (  # noqa
     TaskSerializer,
 )
 
-from .content import (  # noqa
+from .content import (
     NoArtifactContentUploadSerializer,
     SingleArtifactContentUploadSerializer,
 )

--- a/pulpcore/plugin/stages/__init__.py
+++ b/pulpcore/plugin/stages/__init__.py
@@ -1,5 +1,5 @@
-from .api import create_pipeline, EndStage, Stage  # noqa
-from .artifact_stages import (  # noqa
+from .api import create_pipeline, EndStage, Stage
+from .artifact_stages import (
     ACSArtifactHandler,
     ArtifactDownloader,
     ArtifactSaver,
@@ -7,11 +7,11 @@ from .artifact_stages import (  # noqa
     QueryExistingArtifacts,
     RemoteArtifactSaver,
 )
-from .content_stages import (  # noqa
+from .content_stages import (
     ContentAssociation,
     ContentSaver,
     QueryExistingContents,
     ResolveContentFutures,
 )
-from .declarative_version import DeclarativeVersion  # noqa
-from .models import DeclarativeArtifact, DeclarativeContent  # noqa
+from .declarative_version import DeclarativeVersion
+from .models import DeclarativeArtifact, DeclarativeContent

--- a/pulpcore/plugin/storage.py
+++ b/pulpcore/plugin/storage.py
@@ -1,1 +1,1 @@
-from pulpcore.app.models.storage import get_tls_path  # noqa
+from pulpcore.app.models.storage import get_tls_path  # noqa: F401

--- a/pulpcore/plugin/tasking.py
+++ b/pulpcore/plugin/tasking.py
@@ -1,7 +1,7 @@
 # Support plugins dispatching tasks
-from pulpcore.tasking.tasks import dispatch  # noqa
+from pulpcore.tasking.tasks import dispatch  # noqa: F401
 
-from pulpcore.app.tasks import (  # noqa
+from pulpcore.app.tasks import (  # noqa: F401
     fs_publication_export,
     fs_repo_version_export,
     general_create,
@@ -12,4 +12,4 @@ from pulpcore.app.tasks import (  # noqa
     orphan_cleanup,
     reclaim_space,
 )
-from pulpcore.app.tasks.repository import add_and_remove  # noqa
+from pulpcore.app.tasks.repository import add_and_remove  # noqa: F401

--- a/pulpcore/plugin/util.py
+++ b/pulpcore/plugin/util.py
@@ -1,4 +1,4 @@
-from pulpcore.app.role_util import (  # noqa
+from pulpcore.app.role_util import (  # noqa: F401
     assign_role,
     get_groups_with_perms,
     get_groups_with_perms_attached_perms,
@@ -12,7 +12,7 @@ from pulpcore.app.role_util import (  # noqa
     remove_role,
 )
 
-from pulpcore.app.util import (  # noqa
+from pulpcore.app.util import (  # noqa: F401
     extract_pk,
     get_artifact_url,
     get_url,

--- a/pulpcore/plugin/viewsets/__init__.py
+++ b/pulpcore/plugin/viewsets/__init__.py
@@ -1,10 +1,10 @@
-from pulpcore.filters import BaseFilterSet  # noqa
+from pulpcore.filters import BaseFilterSet
 
 # Allow plugin viewsets to return 202s
-from pulpcore.app.response import OperationPostponedResponse, TaskGroupOperationResponse  # noqa
+from pulpcore.app.response import OperationPostponedResponse, TaskGroupOperationResponse
 
 # Import Viewsets in platform that are potentially useful to plugin writers
-from pulpcore.app.viewsets import (  # noqa
+from pulpcore.app.viewsets import (
     AlternateContentSourceViewSet,
     AsyncUpdateMixin,
     ContentFilter,
@@ -34,15 +34,15 @@ from pulpcore.app.viewsets import (  # noqa
     TaskViewSet,
 )
 
-from pulpcore.app.viewsets.custom_filters import (  # noqa
+from pulpcore.app.viewsets.custom_filters import (
     CharInFilter,
     LabelFilter,
     RepositoryVersionFilter,
 )
 
-from pulpcore.filters import HyperlinkRelatedFilter  # noqa
+from pulpcore.filters import HyperlinkRelatedFilter
 
-from .content import (  # noqa
+from .content import (
     NoArtifactContentUploadViewSet,
     SingleArtifactContentUploadViewSet,
 )

--- a/pulpcore/tests/functional/__init__.py
+++ b/pulpcore/tests/functional/__init__.py
@@ -66,7 +66,7 @@ from pulpcore.client.pulpcore import (
     WorkersApi,
 )
 
-from .gpg_ascii_armor_signing_service import (  # noqa: F401
+from .gpg_ascii_armor_signing_service import (
     _ascii_armored_detached_signing_service_name,
     ascii_armored_detached_signing_service,
     sign_with_ascii_armored_detached_signing_service,


### PR DESCRIPTION
In this commit, there were also removed redundant #noqa directives that
were used in the plugin API. The flake8 configuration had to be adjusted
accordingly to ignore the import errors.

closes #4006