### PR TITLE
Incremental Export fix for File/Pass Through publications

### DIFF
--- a/CHANGES/4051.bugfix
+++ b/CHANGES/4051.bugfix
@@ -1,0 +1,1 @@
+Updates file system exporter to correctly account the start_repository_version  for pass_through publications

--- a/pulpcore/app/tasks/export.py
+++ b/pulpcore/app/tasks/export.py
@@ -113,18 +113,12 @@ def _export_publication_to_file_system(
         path (str): Path to place the exported data
         publication_pk (str): Publication pk
     """
-    difference_content_artifacts = []
     content_artifacts = ContentArtifact.objects.filter(
         pk__in=publication.published_artifact.values_list("content_artifact__pk", flat=True)
     )
     if start_repo_version:
         start_version_content_artifacts = ContentArtifact.objects.filter(
             artifact__in=start_repo_version.artifacts
-        )
-        difference_content_artifacts = set(
-            content_artifacts.difference(start_version_content_artifacts).values_list(
-                "pk", flat=True
-            )
         )
 
     if publication.pass_through:
@@ -136,11 +130,20 @@ def _export_publication_to_file_system(
         # In some cases we may want to disable this validation
         _validate_fs_export(content_artifacts)
 
+    difference_content_artifacts = []
+    if start_repo_version:
+        difference_content_artifacts = set(
+            content_artifacts.difference(start_version_content_artifacts).values_list(
+                "pk", flat=True
+            )
+        )
+
     relative_path_to_artifacts = {}
     if publication.pass_through:
         relative_path_to_artifacts = {
             ca.relative_path: ca.artifact
             for ca in content_artifacts.select_related("artifact").iterator()
+            if (start_repo_version is None) or (ca.pk in difference_content_artifacts)
         }
 
     publication_metadata_paths = set(


### PR DESCRIPTION
The export logic [here](https://github.com/pulp/pulpcore/blob/main/pulpcore/app/tasks/export.py#L106-L161) does not correctly account for the start_repository_version for pass through publications like file publications. It seems to include everything in the export.

```python
    if publication.pass_through:
        relative_path_to_artifacts = {
            ca.relative_path: ca.artifact
            for ca in content_artifacts.select_related("artifact").iterator()
        }
```

This PR tries to address that issue by also checking in the difference_content_artifacts list if a file/other pass through publication was provided.


fixes #4051

Bugzilla https://bugzilla.redhat.com/show_bug.cgi?id=2172564