### PR TITLE
Fix a significant memory leak

### DIFF
--- a/CHANGES/2250.bugfix
+++ b/CHANGES/2250.bugfix
@@ -1,0 +1,1 @@
+Resolved a memory leak that could occur while making large repeated queries against the API service.

--- a/pulpcore/app/access_policy.py
+++ b/pulpcore/app/access_policy.py
@@ -1,4 +1,3 @@
-from functools import lru_cache
 from rest_access_policy import AccessPolicy
 from rest_framework.exceptions import APIException
 
@@ -12,7 +11,6 @@ class AccessPolicyFromDB(AccessPolicy):
     """
 
     @staticmethod
-    @lru_cache
     def get_access_policy(view):
         """
         Retrieves the AccessPolicy from the DB or None if it doesn't exist.


### PR DESCRIPTION
Which occurs when making repeated large queries against the API service. The cache unintentionally was holding references to entire instances of views, which are substantial.

closes #2250