### PR TITLE
Moves TaskGroup.finish() to outside the loop in the replication task

### DIFF
--- a/CHANGES/4175.bugfix
+++ b/CHANGES/4175.bugfix
@@ -1,0 +1,2 @@
+Fixed bug where the Task Group for replication would be marked as fully dispatched after just one
+replicator.

--- a/pulpcore/app/tasks/replica.py
+++ b/pulpcore/app/tasks/replica.py
@@ -98,4 +98,4 @@ def replicate_distributions(server_pk):
             distro_names.append(distro["name"])
 
         replicator.remove_missing(distro_names)
-        task_group.finish()
+    task_group.finish()


### PR DESCRIPTION
fixes: #4175