### PR TITLE
Avoid infinite waiting on tasks in tests

### DIFF
--- a/pulpcore/tests/functional/utils.py
+++ b/pulpcore/tests/functional/utils.py
@@ -11,7 +11,8 @@ async def get_response(url):
         return await session.get(url)
 
 
-SLEEP_TIME = 0.3
+SLEEP_TIME = 0.5
+TASK_TIMEOUT = 30 * 60  # 30 minutes
 
 
 try:


### PR DESCRIPTION
[noissue]

Open questions:
  * Do we need to make the timeout configurable?
  * How does this play with performance tests?