### PR TITLE
Fix 500 error on parallel same-object creates

### DIFF
--- a/CHANGES/4183.bugfix
+++ b/CHANGES/4183.bugfix
@@ -1,0 +1,1 @@
+Fixed a 500 server error when two concurrent requests try to create an object with the same unique fields.

--- a/pulpcore/app/serializers/base.py
+++ b/pulpcore/app/serializers/base.py
@@ -439,6 +439,16 @@ class ModelSerializer(
 
         return path
 
+    def save(self, **kwargs):
+        try:
+            return super().save(**kwargs)
+        except IntegrityError as e:
+            # Concurrent request got by the unique validator on the serializer
+            if "unique" in str(e):
+                # Run validation again to properly raise an unique-ValidationError
+                self.run_validation(self.initial_data)
+            raise e
+
     def __init_subclass__(cls, **kwargs):
         """Set default attributes in subclasses.
 


### PR DESCRIPTION
fixes: #4183

Not sure how to write a test for this. I manually tested this with 
```
http :5001/pulp/api/v3/repositories/file/file/ name=foo & http :5001/pulp/api/v3/repositories/file/file/ name=foo
```
Roughly 1 in 3 attempts will fail with a 500 error, this fixes the race condition and will give a nice 400 error. 

@jlsherrill Interestingly you found this bug when creating domains, but it actually affects all immediate-creation objects in Pulp. :open_mouth: 