### PR TITLE
Domain delete hook error fix

### DIFF
--- a/CHANGES/4157.bugfix
+++ b/CHANGES/4157.bugfix
@@ -1,0 +1,2 @@
+Fixed an exception that gets raised inside the domain delete hook
+when there are still repositories with content in the domain.

--- a/pulpcore/exceptions/__init__.py
+++ b/pulpcore/exceptions/__init__.py
@@ -4,6 +4,7 @@ from .base import (
     ResourceImmutableError,
     TimeoutException,
     exception_to_dict,
+    DomainProtectedError,
 )
 from .validation import (
     DigestValidationError,

--- a/pulpcore/exceptions/base.py
+++ b/pulpcore/exceptions/base.py
@@ -85,3 +85,16 @@ class TimeoutException(PulpException):
         return _(
             "Request timed out for {}. Increasing the total_timeout value on the remote might help."
         ).format(self.url)
+
+
+class DomainProtectedError(PulpException):
+    """
+    Exception to signal that a domain the user is trying to delete still contains
+    repositories with content.
+    """
+
+    def __init__(self):
+        super().__init__("PLP0007")
+
+    def __str__(self):
+        return _("You cannot delete a domain that still contains repositories with content.")


### PR DESCRIPTION
Fixed an exception that gets raised inside the domain delete hook when there is active content in the domain.

fixes: #4157