### PR TITLE
Enhance get_content() by omitting the version_membership lookup

### DIFF
--- a/CHANGES/3969.bugfix
+++ b/CHANGES/3969.bugfix
@@ -1,0 +1,1 @@
+Improved the performance when looking up content for repository versions.

--- a/pulpcore/app/models/repository.py
+++ b/pulpcore/app/models/repository.py
@@ -707,7 +707,7 @@ class RepositoryVersion(BaseModel):
         if content_qs is None:
             content_qs = Content.objects
 
-        return content_qs.filter(version_memberships__in=self._content_relationships())
+        return content_qs.filter(pk__in=self._content_relationships().values_list("content_id"))
 
     @property
     def content(self):


### PR DESCRIPTION
>>> timeit.timeit("len(v.get_content(Package.objects).only('pk'))", globals=globals(), number=10)
105.0813707895577
>>> timeit.timeit("len(v.get_content2(Package.objects).only('pk'))", globals=globals(), number=10)
58.41291802749038
>>> timeit.timeit("v.get_content(Package.objects).count()", globals=globals(), number=10)
62.557361379265785
>>> timeit.timeit("v.get_content2(Package.objects).count()", globals=globals(), number=10)
16.70007463544607

Credits to @newswangerd.

closes #3969