### PR TITLE
Made orphan clean up more tolerant when other tasks are running in pa…

### DIFF
--- a/CHANGES/4316.bugfix
+++ b/CHANGES/4316.bugfix
@@ -1,0 +1,1 @@
+Made orphan clean up more tolerant when other tasks are running in parallel.

--- a/pulpcore/app/tasks/purge.py
+++ b/pulpcore/app/tasks/purge.py
@@ -143,7 +143,7 @@ def purge(finished_before, states):
                     # Log the details of the object.
                     error_pb.done += 1
                     pks_failed.append(pk)
-                    log.info(e)
+                    log.debug(e)
 
     # Complete the progress-reports for the specific entities deleted
     for key, pb in details_reports.items():

--- a/pulpcore/app/tasks/reclaim_space.py
+++ b/pulpcore/app/tasks/reclaim_space.py
@@ -86,9 +86,9 @@ def reclaim_space(repo_pks, keeplist_rv_pks=None, force=False):
             # we need to manually call delete() because it cleans up the file on the filesystem
             artifact.delete()
         except ProtectedError as e:
-            # Rarely artifact could be shared between to different content units.
+            # Rarely artifact could be shared between two different content units.
             # Just log and skip the artifact deletion in this case
-            log.info(e)
+            log.debug(e)
         else:
             progress_bar.done += 1
             counter += 1


### PR DESCRIPTION
…rallel.

closes pulp/pulp_deb#865
Orphan clean up can fail when other tasks like sync or content upload might be rinning in paralell.