### PR TITLE
Taught import to be able to use less than all-available workers.

### DIFF
--- a/CHANGES/4068.bugfix
+++ b/CHANGES/4068.bugfix
@@ -1,0 +1,1 @@
+Taught pulp-import to be able to use a subset of available worker-threads.

--- a/pulpcore/app/settings.py
+++ b/pulpcore/app/settings.py
@@ -300,6 +300,10 @@ SHELL_PLUS_IMPORTS = [
     "from pulpcore.tasking.util import cancel_task",
 ]
 
+# What percentage of available-workers will pulpimport use at a time, max
+# By default, use all available workers.
+IMPORT_WORKERS_PERCENT = 100
+
 # HERE STARTS DYNACONF EXTENSION LOAD (Keep at the very bottom of settings.py)
 # Read more at https://dynaconf.readthedocs.io/en/latest/guides/django.html
 from dynaconf import DjangoDynaconf, Validator  # noqa


### PR DESCRIPTION
IMPORT_WORKERS_PERCENT is configurable in settings. We will document/expose this in a future PR, to keep this one maximally backportable. Default behavior remains "all workers".

fixes #4068.

(cherry picked from commit b5cb1d19a130b67aff5c818e1a8b1ce1e8655a67)