### PR TITLE
Add burst mode to worker

### DIFF
--- a/CHANGES/4341.feature
+++ b/CHANGES/4341.feature
@@ -1,0 +1,1 @@
+Added ``--burst`` flag to pulpcore-worker so it will terminate instead of sleeping.

--- a/docs/plugin_dev/plugin-writer/concepts/index.rst
+++ b/docs/plugin_dev/plugin-writer/concepts/index.rst
@@ -769,3 +769,9 @@ older codebases could run on newer, upgraded workers. To ensure this always work
 forever backwards compatible until the next major Pulp version. For example, you cannot have a
 breaking signature change in tasking code and if this is needed you need to make a new task name and
 preserve the old code until the next major Pulp version.
+
+.. note::
+
+   Users not performing zero downtime upgrades who are still wary of any task incompatibilities,
+   should consider running the pulpcore worker in burst mode (`pulpcore-worker --burst`) after
+   shutting down all the api and content workers to drain the task queue.

--- a/pulpcore/tasking/entrypoint.py
+++ b/pulpcore/tasking/entrypoint.py
@@ -14,9 +14,12 @@ from pulpcore.tasking.pulpcore_worker import NewPulpWorker  # noqa: E402: module
 _logger = logging.getLogger(__name__)
 
 
-@click.option("--pid", help="Write the process ID number to a file at the specified path")
+@click.option("--pid", help="Write the process ID number to a file at the specified path.")
+@click.option(
+    "--burst/--no-burst", help="Run in burst mode; terminate when no more tasks are available."
+)
 @click.command()
-def worker(pid):
+def worker(pid, burst):
     """A Pulp worker."""
 
     if pid:
@@ -25,4 +28,4 @@ def worker(pid):
 
     _logger.info("Starting distributed type worker")
 
-    NewPulpWorker().run_forever()
+    NewPulpWorker().run(burst=burst)


### PR DESCRIPTION
This allows to run a pulpcore-worker in the foreground that will handle tasks until no more are available.
This can help to drain the task queue during an upgrade, or overcome a congestion short term.

fixes #4341