### PR TITLE
Marked repository delete as unsafe for immetiate

### DIFF
--- a/CHANGES/4372.bugfix
+++ b/CHANGES/4372.bugfix
@@ -1,0 +1,2 @@
+Ensured that repository and remote delete is always executed in a task. This fixes a bug when the
+deletion blocks the gunicorn api worker for too long.

--- a/docs/plugin_dev/plugin-writer/concepts/index.rst
+++ b/docs/plugin_dev/plugin-writer/concepts/index.rst
@@ -240,7 +240,8 @@ be left in the task queue or marked as canceled, depending on the ``deferred`` a
    be executed in the current api worker. This will not only delay the response to the http call,
    but also the complete single threaded gunicorn process. To prevent degrading the whole Pulp
    service, this is only ever allowed for tasks that guarantee to perform fast **and** without
-   blocking on external resources. E.g. simple attribute updates, deletes...
+   blocking on external resources. E.g. simple attribute updates, deletes... A model with a lot of
+   dependants that cause cascaded deletes may not be suitable for immediate execution.
 
 **Diagnostics**
 

--- a/pulpcore/app/viewsets/base.py
+++ b/pulpcore/app/viewsets/base.py
@@ -467,6 +467,8 @@ class AsyncUpdateMixin(AsyncReservedObjectMixin):
     Provides an update method that dispatches a task with reservation
     """
 
+    ALLOW_NON_BLOCKING_UPDATE = True
+
     @extend_schema(
         description="Trigger an asynchronous update task",
         responses={202: AsyncOperationResponseSerializer},
@@ -482,7 +484,7 @@ class AsyncUpdateMixin(AsyncReservedObjectMixin):
             exclusive_resources=self.async_reserved_resources(instance),
             args=(pk, app_label, serializer.__class__.__name__),
             kwargs={"data": request.data, "partial": partial},
-            immediate=True,
+            immediate=self.ALLOW_NON_BLOCKING_UPDATE,
         )
         return OperationPostponedResponse(task, request)
 
@@ -500,6 +502,8 @@ class AsyncRemoveMixin(AsyncReservedObjectMixin):
     Provides a delete method that dispatches a task with reservation
     """
 
+    ALLOW_NON_BLOCKING_DELETE = True
+
     @extend_schema(
         description="Trigger an asynchronous delete task",
         responses={202: AsyncOperationResponseSerializer},
@@ -515,7 +519,7 @@ class AsyncRemoveMixin(AsyncReservedObjectMixin):
             tasks.base.general_delete,
             exclusive_resources=self.async_reserved_resources(instance),
             args=(pk, app_label, serializer.__class__.__name__),
-            immediate=True,
+            immediate=self.ALLOW_NON_BLOCKING_DELETE,
         )
         return OperationPostponedResponse(task, request)
 

--- a/pulpcore/app/viewsets/exporter.py
+++ b/pulpcore/app/viewsets/exporter.py
@@ -49,6 +49,9 @@ class ExporterViewSet(
     ViewSet for viewing exporters.
     """
 
+    # Too many cascaded deletes to block the gunicorn worker.
+    ALLOW_NON_BLOCKING_DELETE = False
+
     queryset = Exporter.objects.all()
     serializer_class = ExporterSerializer
     endpoint_name = "exporters"

--- a/pulpcore/app/viewsets/repository.py
+++ b/pulpcore/app/viewsets/repository.py
@@ -164,6 +164,9 @@ class ImmutableRepositoryViewSet(
     mixins.CreateModelMixin,
     AsyncRemoveMixin,
 ):
+    # Too many cascaded deletes to block the gunicorn worker.
+    ALLOW_NON_BLOCKING_DELETE = False
+
     """
     An immutable repository ViewSet that does not allow the usage of the methods PATCH and PUT.
     """
@@ -372,6 +375,9 @@ class RemoteViewSet(
     AsyncRemoveMixin,
     LabelsMixin,
 ):
+    # Too many cascaded deletes to block the gunicorn worker.
+    ALLOW_NON_BLOCKING_DELETE = False
+
     endpoint_name = "remotes"
     serializer_class = RemoteSerializer
     queryset = Remote.objects.all()


### PR DESCRIPTION
Deleting repositories casade deletes a lot of RepostoryVersions and RepositoryContent. This can easily extend beyond the gunicorn worker timeout.

fixes #4372