### PR TITLE
Delete downloaded tmp files after Artifact creation during sync

### DIFF
--- a/CHANGES/1936.bugfix
+++ b/CHANGES/1936.bugfix
@@ -1,0 +1,2 @@
+Fixed sync not deleting temporary files when WORKING_DIRECTORY is not a sub-directory of MEDIA_ROOT
+or when using a non-filesystem storage backend.


### PR DESCRIPTION
fixes: #1936

This should help clean up a worker's directory during a sync and keep their storage usage down, especially for concurrent syncing when duplicate artifacts have been downloaded.