### PR TITLE
Remove compression from exports by default

### DIFF
--- a/CHANGES/4411.bugfix
+++ b/CHANGES/4411.bugfix
@@ -1,1 +1,1 @@
-Ensure non-chunked exports also use gzip ``compressionlevel=1``
+Ensure non-chunked exports and chunked exports use the same compression level.

--- a/CHANGES/4434.bugfix
+++ b/CHANGES/4434.bugfix
@@ -1,0 +1,1 @@
+Removed compression from exports (using gzip level 0). For most users of export functionality it seems to be a poor tradeoff.

--- a/pulpcore/app/monkeypatch.py
+++ b/pulpcore/app/monkeypatch.py
@@ -1,7 +1,4 @@
-import sys
-
-# This is a monkeypatch for https://github.com/pulp/pulpcore/issues/3869
-if sys.version_info.major == 3 and sys.version_info.minor < 12:
+def patch_tarfile_default_compression_level(level):
     # Code copied from the Python 3.12 standard library
     # We modify the default gzip compression level for writing streams from
     # 9 to 1, attempting to vendor the minimum amount of code.
@@ -52,7 +49,7 @@ if sys.version_info.major == 3 and sys.version_info.minor < 12:
         def _init_write_gz(self):
             """Initialize for writing with gzip compression."""
             self.cmp = self.zlib.compressobj(
-                1, self.zlib.DEFLATED, -self.zlib.MAX_WBITS, self.zlib.DEF_MEM_LEVEL, 0
+                level, self.zlib.DEFLATED, -self.zlib.MAX_WBITS, self.zlib.DEF_MEM_LEVEL, 0
             )
             timestamp = struct.pack("<L", int(time.time()))
             self.__write(b"\037\213\010\010" + timestamp + b"\002\377")

--- a/pulpcore/app/tasks/export.py
+++ b/pulpcore/app/tasks/export.py
@@ -29,8 +29,6 @@ from pulpcore.app.models import (
 from pulpcore.app.models.content import ContentArtifact
 from pulpcore.app.serializers import PulpExportSerializer
 
-# ensure the compression patch is loaded
-from pulpcore.app import monkeypatch  # noqa
 from pulpcore.app.util import get_version_from_model
 from pulpcore.app.importexport import (
     export_versions,
@@ -381,6 +379,8 @@ def pulp_export(exporter_pk, params):
         ValidationError: When path is not in the ALLOWED_EXPORT_PATHS setting,
             OR path exists and is not a directory
     """
+    DEFAULT_COMPRESSION = 1
+
     pulp_exporter = PulpExporter.objects.get(pk=exporter_pk)
     serializer = PulpExportSerializer(data=params, context={"exporter": pulp_exporter})
     serializer.is_valid(raise_exception=True)
@@ -416,12 +416,20 @@ def pulp_export(exporter_pk, params):
             ) as split_process:
                 try:
                     # on Python < 3.12 we have a monkeypatch which enables compression levels
+                    # see https://github.com/pulp/pulpcore/issues/3869
                     if sys.version_info.major == 3 and sys.version_info.minor < 12:
+                        from pulpcore.app import monkeypatch
+
+                        monkeypatch.patch_tarfile_default_compression_level(DEFAULT_COMPRESSION)
+
                         with tarfile.open(tarfile_fp, "w|gz", fileobj=split_process.stdin) as tar:
                             _do_export(pulp_exporter, tar, the_export)
                     else:
                         with tarfile.open(
-                            tarfile_fp, "w|gz", fileobj=split_process.stdin, compresslevel=1
+                            tarfile_fp,
+                            "w|gz",
+                            fileobj=split_process.stdin,
+                            compresslevel=DEFAULT_COMPRESSION,
                         ) as tar:
                             _do_export(pulp_exporter, tar, the_export)
                 except Exception:
@@ -441,7 +449,7 @@ def pulp_export(exporter_pk, params):
         else:
             # write into the file
             try:
-                with tarfile.open(tarfile_fp, "w:gz", compresslevel=1) as tar:
+                with tarfile.open(tarfile_fp, "w:gz", compresslevel=DEFAULT_COMPRESSION) as tar:
                     _do_export(pulp_exporter, tar, the_export)
             except Exception:
                 # no matter what went wrong, we can't trust the file we created.

--- a/pulpcore/app/tasks/export.py
+++ b/pulpcore/app/tasks/export.py
@@ -379,7 +379,7 @@ def pulp_export(exporter_pk, params):
         ValidationError: When path is not in the ALLOWED_EXPORT_PATHS setting,
             OR path exists and is not a directory
     """
-    DEFAULT_COMPRESSION = 1
+    DEFAULT_COMPRESSION = 0
 
     pulp_exporter = PulpExporter.objects.get(pk=exporter_pk)
     serializer = PulpExportSerializer(data=params, context={"exporter": pulp_exporter})


### PR DESCRIPTION
Removes compression entirely, using the special gzip level 0 mode, which packs everything into a gzip archive without actually doing any compression.

The reason for this is that even the lowest level of compression, level 1, is still a massive cost without actually providing much benefits due to the fact that most of the exported artifact payloads (rpms, images, etc) are already compressed.

On a test system, the difference between exporting with gzip level 9 and completely uncompressed was 11.3gb vs 11.8gb, while the former took 2.5x as long.

For most major users of the import/export functionality, storage space is much less of an issue than runtime.

In the future we could do any of the following:

* make the compression level configurable for users who actually do care
* get rid of gzip and therefore monkeypatches entirely - you're not supposed to use exports from a different version of Pulp, so we don't have to care about that compatibility
* try out a more suitable algorithm such as zstd or lz4, which are much faster than e.g. gzip level 1 for similarly amounts of compression