### PR TITLE
Handle empty list for href and id in filters

### DIFF
--- a/CHANGES/4437.bugfix
+++ b/CHANGES/4437.bugfix
@@ -1,0 +1,2 @@
+Fixed bug where supplying an empty list for ``pulp_href__in`` or ``pulp_id__in`` would return all
+results instead of none.

--- a/pulpcore/tests/functional/api/test_filter.py
+++ b/pulpcore/tests/functional/api/test_filter.py
@@ -87,6 +87,10 @@ class TestFilter:
         redi_results = redirect_contentguard_api_client.list(**{filter: rbac_sample})
         assert redi_results.count == 0
 
+        # test out empty list
+        redi_results = redirect_contentguard_api_client.list(**{filter: []})
+        assert redi_results.count == 0
+
         # Test that filter fails when not a valid type
         with pytest.raises(ApiException) as exc:
             content_guards_api_client.list(**{filter: ["hello"]})


### PR DESCRIPTION
Fix bug where empty list for the `pulp_href__in` and `pulp_id__in` filters return all results instead of no results. The problem is that when using FilterMethod, django-filter just simply ignores empty set and returns the full list of results:

https://github.com/carltongibson/django-filter/blob/e4a70a667a0bf3882fd44b557bc76583d2c65cd1/django_filters/filters.py#L804-L805

There's no way to update the method to prevent this since this logic happens before the method is called. Instead, this change moves the method to the filter and adds a None check.

fixes #4437