### PR TITLE
Bump django-import-export dependency version for performance reasons

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ cryptography>=38.0.1,<41.0.2
 Django~=4.2.0  # LTS version, switch only if we have a compelling reason to
 django-filter>=23.1,<=23.2
 django-guid>=3.3,<=3.3.0
-django-import-export>=2.9,<3.3.0
+django-import-export>=2.9,<3.4.0
 django-lifecycle>=1.0,<=1.0.0
 djangorestframework>=3.14.0,<=3.14.0
 djangorestframework-queryfields>=1.0,<=1.0.0


### PR DESCRIPTION
3.1.0 contains some performance improvements.

[noissue]