### PR TITLE
Redirects user to a path that ends in /

### DIFF
--- a/CHANGES/3173.feature
+++ b/CHANGES/3173.feature
@@ -1,0 +1,1 @@
+The content app now returns a 301 redirect when a requested path does not end in a / but should end in a /.

--- a/CHANGES/plugin_api/3459.feature
+++ b/CHANGES/plugin_api/3459.feature
@@ -1,0 +1,1 @@
+Handler._match_distribution() method now accepts `add_trailing_slash` keyword argument. When set to False, the content app will not try to append a '/' to the path before trying to match it to a distribution. Plugin code that calls this method directly needs to be updated to account for the desired behavior. 

--- a/pulpcore/content/__init__.py
+++ b/pulpcore/content/__init__.py
@@ -94,6 +94,7 @@ async def server(*args, **kwargs):
     path_prefix = settings.CONTENT_PATH_PREFIX
     if settings.DOMAIN_ENABLED:
         path_prefix = path_prefix + "{pulp_domain}/"
+        app.add_routes([web.get(path_prefix[:-1], Handler().list_distributions)])
     app.add_routes([web.get(path_prefix, Handler().list_distributions)])
     app.add_routes([web.get(path_prefix + "{path:.+}", Handler().stream_content)])
     app.cleanup_ctx.append(_heartbeat_ctx)

--- a/pulpcore/tests/functional/api/pulp_file/test_download_policies.py
+++ b/pulpcore/tests/functional/api/pulp_file/test_download_policies.py
@@ -130,7 +130,10 @@ def test_download_policy(
     process = subprocess.run(["pulpcore-manager", "shell", "-c", commands], capture_output=True)
     assert process.returncode == 0
     content_artifact_created_date = process.stdout.decode().strip()
-    distribution_html_page = download_file(f"{distribution.base_url}foo/")
+    # Download the listing page for the 'foo' directory
+    distribution_html_page = download_file(f"{distribution.base_url}foo")
+    # Assert that requesting a path inside a distribution without a trailing / returns a 301
+    assert distribution_html_page.response_obj.history[0].status == 301
     soup = BeautifulSoup(distribution_html_page.body, "html.parser")
     all_strings = [s for s in soup.strings if s != "\n"]
     assert all_strings[3] == "0.iso"

--- a/pulpcore/tests/functional/api/using_plugin/test_content_path.py
+++ b/pulpcore/tests/functional/api/using_plugin/test_content_path.py
@@ -5,6 +5,9 @@ import uuid
 from urllib.parse import urljoin
 
 
+from pulpcore.tests.functional.utils import get_from_url
+
+
 @pytest.mark.parallel
 def test_content_directory_listing(
     file_distribution_factory,
@@ -51,3 +54,39 @@ def test_content_directory_listing(
 
     response = http_get(urljoin(url, "boo1/")).decode("utf-8")
     assert response.count('a href="foo1/"') == 1
+
+    # Assert that not using a trailing slash on the root returns a 301
+    base_url = urljoin(
+        pulp_status.content_settings.content_origin,
+        pulp_status.content_settings.content_path_prefix,
+    )
+    if pulp_settings.DOMAIN_ENABLED:
+        base_url = urljoin(base_url, "default/")
+    response = get_from_url(base_url[:-1])
+    assert response.history[0].status == 301
+    assert response.status == 200
+
+    # Assert that not using a trailing slash returns a 301 for a partial base path
+    url = urljoin(base_url, base_path)
+    response = get_from_url(url)
+    assert response.history[0].status == 301
+    assert response.status == 200
+
+    # Assert that not using a trailing slash within a distribution returns a 301
+    url = f"{url}/boo1"
+    response = get_from_url(url)
+    assert response.history[0].status == 301
+    assert response.status == 200
+
+    # Assert that not using a trailing slash for a full base path returns a 301
+    url = f"{url}/foo1"
+    response = get_from_url(url)
+    assert response.history[0].status == 301
+    assert response.status == 404
+    assert "Distribution is not pointing to" in response.reason
+
+    # Assert that a non-existing base path does not return a 301
+    url = url[:-1]
+    response = get_from_url(url)
+    assert len(response.history) == 0
+    assert response.status == 404


### PR DESCRIPTION
This patch returns a 301 redirect when a requested path does not end in a / but should end in a /.

closes: #3173
closes: #3459