### PR TITLE
Avoid automatic encoding for fixture server

### DIFF
--- a/pulpcore/tests/functional/utils.py
+++ b/pulpcore/tests/functional/utils.py
@@ -4,6 +4,7 @@ import asyncio
 
 from aiohttp import web
 from dataclasses import dataclass
+from multidict import CIMultiDict
 
 
 async def get_response(url):
@@ -56,7 +57,9 @@ def add_recording_route(app, fixtures_root):
         requests.append(request)
         path = fixtures_root / request.raw_path[1:]  # Strip off leading '/'
         if path.is_file():
-            return web.FileResponse(path)
+            return web.FileResponse(
+                path, headers=CIMultiDict({"content-type": "application/octet-stream"})
+            )
         else:
             raise web.HTTPNotFound()
 


### PR DESCRIPTION
This is a fix that was added to pulp-smash but is missing here.

See more here:

https://github.com/pulp/pulp-smash/issues/1309
https://github.com/pulp/pulp-smash/commit/a18afe97de6a5e2eba5be737ceea068333ad3122

---

It also speeds up local testing (at least in `pulp_deb`) because it will no longer try to verify the encoding of extracted archive files 4 times before failing. Which looks like this:

```
9d1d6ce495d7 Giving up download_wrapper(...) after 4 tries (pulpcore.exceptions.validation.DigestValidationError: A file located at the url http://127.0.0.1:59071/debian-update/dists/ragnarok/jotunheimr/binary-armeb/Packages.gz failed validation due to checksum. Expected 'c3d96859b1edfce90bfb47928dad84b0616d9322d6df5a8a8a704d361ab78930', Actual '6a5079388629eacffc797c85b9083d1153db91cf9bc124be4f4dac33fa0647a3')
9d1d6ce495d7 pulp [af77c374-19b8-4c87-9120-70d9e4e82331]: backoff:ERROR: Giving up download_wrapper(...) after 4 tries (pulpcore.exceptions.validation.DigestValidationError: A file located at the url http://127.0.0.1:59071/debian-update/dists/ragnarok/jotunheimr/binary-armeb/Packages.gz failed validation due to checksum. Expected 'c3d96859b1edfce90bfb47928dad84b0616d9322d6df5a8a8a704d361ab78930', Actual '6a5079388629eacffc797c85b9083d1153db91cf9bc124be4f4dac33fa0647a3')
9d1d6ce495d7 pulp [af77c374-19b8-4c87-9120-70d9e4e82331]: pulp_deb.app.tasks.synchronizing:INFO: Digest for artifact with relative_path='dists/ragnarok/jotunheimr/binary-armeb/Packages.gz' not matched. Ignored
```