### PR TITLE
Add `format` param in `BaseFilterSet` to fix Django API format

### DIFF
--- a/CHANGES/4450.bugfix
+++ b/CHANGES/4450.bugfix
@@ -1,0 +1,1 @@
+Added ``format`` param to ``DEFAULT_FILTERS`` in ``BaseFilterSet`` to fix django api format.

--- a/pulpcore/filters.py
+++ b/pulpcore/filters.py
@@ -382,6 +382,7 @@ class BaseFilterSet(filterset.FilterSet):
             "offset",
             "page_size",
             "ordering",
+            "format",
         ]
         for field in self.data.keys():
             if field in DEFAULT_FILTERS:


### PR DESCRIPTION
fixes: #4450