### PR TITLE
Allow older releases to opt-in to a faster mode of import/export

### DIFF
--- a/pulpcore/app/settings.py
+++ b/pulpcore/app/settings.py
@@ -249,6 +249,12 @@ ALLOWED_IMPORT_PATHS = []
 
 ALLOWED_EXPORT_PATHS = []
 
+# Enables a couple of performance-enhancing behaviors on export which result in an
+# export format which is incompatible with previous z-stream releases of this y-stream.
+# These modified export formats require compatibility on the import side, which should
+# be upgraded to the same level.
+BACKWARDS_INCOMPATIBLE_FAST_EXPORTS = False
+
 # https://docs.pulpproject.org/pulpcore/configuration/settings.html#pulp-cache
 CACHE_ENABLED = False
 CACHE_SETTINGS = {

--- a/pulpcore/app/tasks/export.py
+++ b/pulpcore/app/tasks/export.py
@@ -29,7 +29,7 @@ from pulpcore.app.models import (
 from pulpcore.app.models.content import ContentArtifact
 from pulpcore.app.serializers import PulpExportSerializer
 
-from pulpcore.app.util import get_version_from_model
+from pulpcore.app.util import compute_file_hash, get_version_from_model
 from pulpcore.app.importexport import (
     export_versions,
     export_artifacts,
@@ -442,7 +442,7 @@ def pulp_export(exporter_pk, params):
             global_hash = hashlib.sha256()
             paths = sorted([str(Path(p)) for p in glob(tarfile_fp + ".*")])
             for a_file in paths:
-                a_hash = _compute_hash(a_file, global_hash)
+                a_hash = compute_file_hash(a_file, cumulative_hash=global_hash)
                 rslts[a_file] = a_hash
             tarfile_hash = global_hash.hexdigest()
 
@@ -458,7 +458,7 @@ def pulp_export(exporter_pk, params):
                     os.remove(tarfile_fp)
                 raise
             # compute the hash
-            tarfile_hash = _compute_hash(tarfile_fp)
+            tarfile_hash = compute_file_hash(tarfile_fp)
             rslts[tarfile_fp] = tarfile_hash
 
         # store the outputfile/hash info
@@ -485,7 +485,7 @@ def pulp_export(exporter_pk, params):
             json.dump(chunk_toc, outfile)
 
         # store toc info
-        toc_hash = _compute_hash(output_file_info_path)
+        toc_hash = compute_file_hash(output_file_info_path)
         the_export.output_file_info[output_file_info_path] = toc_hash
         the_export.toc_info = {"file": output_file_info_path, "sha256": toc_hash}
     finally:
@@ -498,17 +498,6 @@ def pulp_export(exporter_pk, params):
     pulp_exporter.last_export = the_export
     # save the exporter
     pulp_exporter.save()
-
-
-def _compute_hash(filename, global_hash=None):
-    sha256_hash = hashlib.sha256()
-    with open(filename, "rb") as f:
-        # Read and update hash string value in blocks of 4K
-        for byte_block in iter(lambda: f.read(4096), b""):
-            sha256_hash.update(byte_block)
-            if global_hash:
-                global_hash.update(byte_block)
-        return sha256_hash.hexdigest()
 
 
 def _do_export(pulp_exporter, tar, the_export):

--- a/pulpcore/app/tasks/importer.py
+++ b/pulpcore/app/tasks/importer.py
@@ -1,4 +1,3 @@
-import hashlib
 import json
 import os
 import re
@@ -35,6 +34,7 @@ from pulpcore.app.modelresource import (
     ContentArtifactResource,
     RepositoryResource,
 )
+from pulpcore.app.util import compute_file_hash
 from pulpcore.constants import TASK_STATES
 from pulpcore.tasking.pulpcore_worker import Worker
 from pulpcore.tasking.tasks import dispatch
@@ -303,14 +303,6 @@ def pulp_import(importer_pk, path, toc, create_repositories):
             created or not.
     """
 
-    def _compute_hash(filename):
-        sha256_hash = hashlib.sha256()
-        with open(filename, "rb") as f:
-            # Read and update hash string value in blocks of 4K
-            for byte_block in iter(lambda: f.read(4096), b""):
-                sha256_hash.update(byte_block)
-            return sha256_hash.hexdigest()
-
     def validate_toc(toc_filename):
         """
         Check validity of table-of-contents file.
@@ -370,7 +362,7 @@ def pulp_import(importer_pk, path, toc, create_repositories):
             data = dict(message="Validating Chunks", code="validate.chunks", total=len(chunks))
             with ProgressReport(**data) as pb:
                 for chunk in pb.iter(chunks):
-                    a_hash = _compute_hash(os.path.join(base_dir, chunk))
+                    a_hash = compute_file_hash(os.path.join(base_dir, chunk))
                     if not a_hash == the_toc["files"][chunk]:
                         err_str = "File {} expected checksum : {}, computed checksum : {}".format(
                             chunk, the_toc["files"][chunk], a_hash
@@ -424,7 +416,7 @@ def pulp_import(importer_pk, path, toc, create_repositories):
                         exc_info=True,
                     )
 
-        combined_hash = _compute_hash(result_file)
+        combined_hash = compute_file_hash(result_file)
         if combined_hash != the_toc["meta"]["global_hash"]:
             raise ValidationError(
                 _("Mismatch between combined .tar.gz checksum [{}] and originating [{}]).").format(

--- a/pulpcore/app/tasks/importer.py
+++ b/pulpcore/app/tasks/importer.py
@@ -1,3 +1,4 @@
+import hashlib
 import json
 import os
 import re
@@ -34,7 +35,7 @@ from pulpcore.app.modelresource import (
     ContentArtifactResource,
     RepositoryResource,
 )
-from pulpcore.app.util import compute_file_hash
+from pulpcore.app.util import compute_file_hash, Crc32Hasher
 from pulpcore.constants import TASK_STATES
 from pulpcore.tasking.pulpcore_worker import Worker
 from pulpcore.tasking.tasks import dispatch
@@ -304,6 +305,12 @@ def pulp_import(importer_pk, path, toc, create_repositories):
             created or not.
     """
 
+    def get_hasher(toc):
+        if "checksum_type" in toc["meta"] and toc["meta"]["checksum_type"] == "crc32":
+            return Crc32Hasher
+        else:
+            return hashlib.sha256
+
     def validate_toc(toc_filename):
         """
         Check validity of table-of-contents file.
@@ -357,18 +364,25 @@ def pulp_import(importer_pk, path, toc, create_repositories):
                 )
 
             errs = []
-            # validate the sha256 of the toc-entries
+
+            hasher = get_hasher(the_toc)
+
+            def verify_chunk_hash(chunk_path, expected_digest):
+                actual_digest = compute_file_hash(chunk_path, hasher=hasher())
+                if actual_digest != expected_digest:
+                    err_str = "File {} expected checksum : {}, computed checksum : {}".format(
+                        chunk, expected_digest, actual_digest
+                    )
+                    errs.append(err_str)
+
+            # validate the checksum of the toc-entries
             # gather errors for reporting at the end
             chunks = sorted(the_toc["files"].keys())
             data = dict(message="Validating Chunks", code="validate.chunks", total=len(chunks))
             with ProgressReport(**data) as pb:
                 for chunk in pb.iter(chunks):
-                    a_hash = compute_file_hash(os.path.join(base_dir, chunk))
-                    if not a_hash == the_toc["files"][chunk]:
-                        err_str = "File {} expected checksum : {}, computed checksum : {}".format(
-                            chunk, the_toc["files"][chunk], a_hash
-                        )
-                        errs.append(err_str)
+                    chunk_path = os.path.join(base_dir, chunk)
+                    verify_chunk_hash(chunk_path, the_toc["files"][chunk])
 
             # if there are any errors, report and fail
             if errs:
@@ -417,7 +431,8 @@ def pulp_import(importer_pk, path, toc, create_repositories):
                         exc_info=True,
                     )
 
-        combined_hash = compute_file_hash(result_file)
+        hasher = get_hasher(the_toc)
+        combined_hash = compute_file_hash(result_file, hasher=hasher())
         if combined_hash != the_toc["meta"]["global_hash"]:
             raise ValidationError(
                 _("Mismatch between combined archive checksum [{}] and originating [{}]).").format(

--- a/pulpcore/app/util.py
+++ b/pulpcore/app/util.py
@@ -1,3 +1,4 @@
+import hashlib
 from functools import lru_cache
 from gettext import gettext as _
 import os
@@ -293,6 +294,19 @@ def gpg_verify(public_keys, signature, detached_data=None):
         if not verified.valid:
             raise InvalidSignatureError(_("The signature is not valid."), verified=verified)
     return verified
+
+
+def compute_file_hash(filename, hasher=None, cumulative_hash=None, blocksize=8192):
+    if hasher is None:
+        hasher = hashlib.sha256()
+
+    with open(filename, "rb") as f:
+        # Read and update hash string value in blocks of 8K
+        while chunk := f.read(blocksize):
+            hasher.update(chunk)
+            if cumulative_hash:
+                cumulative_hash.update(chunk)
+        return hasher.hexdigest()
 
 
 def configure_analytics():

--- a/pulpcore/app/util.py
+++ b/pulpcore/app/util.py
@@ -1,4 +1,5 @@
 import hashlib
+import zlib
 from functools import lru_cache
 from gettext import gettext as _
 import os
@@ -307,6 +308,22 @@ def compute_file_hash(filename, hasher=None, cumulative_hash=None, blocksize=163
             if cumulative_hash:
                 cumulative_hash.update(chunk)
         return hasher.hexdigest()
+
+
+class Crc32Hasher:
+    """Wrapper to make the CRC32 implementation act like a standard hashlib hasher"""
+
+    def __init__(self):
+        self.hashval = 0
+
+    def update(self, data):
+        self.hashval = zlib.crc32(data, self.hashval)
+
+    def digest(self):
+        return str(self.hashval)
+
+    def hexdigest(self):
+        return hex(self.hashval)[2:]
 
 
 def configure_analytics():

--- a/pulpcore/app/util.py
+++ b/pulpcore/app/util.py
@@ -296,12 +296,12 @@ def gpg_verify(public_keys, signature, detached_data=None):
     return verified
 
 
-def compute_file_hash(filename, hasher=None, cumulative_hash=None, blocksize=8192):
+def compute_file_hash(filename, hasher=None, cumulative_hash=None, blocksize=16384):
     if hasher is None:
         hasher = hashlib.sha256()
 
     with open(filename, "rb") as f:
-        # Read and update hash string value in blocks of 8K
+        # Read and update hash string value in blocks of 16K
         while chunk := f.read(blocksize):
             hasher.update(chunk)
             if cumulative_hash:


### PR DESCRIPTION
If a user enables the flag `_BACKWARDS_INCOMPATIBLE_FAST_EXPORTS` in the settings, the following will happen:

* Exports won't have any gzip wrapper at all.  This primarily improves imports as the gzip wrapper adds a bunch of internal crc32 checksum calculations that are totally unnecessary.
* The checksums used on export and import will be crc32 instead of sha256.  This makes a difference at scale when multiple terabytes are being processed.  
* Both kinds of exports are now supported on the import side transparently

When not bottlenecked on the database, these changes result in a 25-30% improvement in my testing of RHEL9 BaseOS + Appstream (48gb total).