### PR TITLE
Works around a sync-time performance regression on PG12

### DIFF
--- a/CHANGES/4591.bugfix
+++ b/CHANGES/4591.bugfix
@@ -1,0 +1,1 @@
+Resolved a sync-time performance regression.

--- a/pulpcore/app/models/repository.py
+++ b/pulpcore/app/models/repository.py
@@ -850,7 +850,9 @@ class RepositoryVersion(BaseModel):
             raise ResourceImmutableError(self)
 
         repo_content = []
-        to_add = set(content.exclude(pk__in=self.content).values_list("pk", flat=True))
+        to_add = set(content.values_list("pk", flat=True)) - set(
+            self.content.values_list("pk", flat=True)
+        )
 
         # Normalize representation if content has already been removed in this version and
         # is re-added: Undo removal by setting version_removed to None.


### PR DESCRIPTION
closes #4591

We still don't really "know":

* Why this only seems to happen on PG12
* Why the original query change (https://github.com/pulp/pulpcore/pull/4275/files) triggered this
* Why it only seems to happen on capsule syncs (this is most mysterious)