### PR TITLE
Revert some query adjustments

### DIFF
--- a/pulpcore/app/models/repository.py
+++ b/pulpcore/app/models/repository.py
@@ -707,7 +707,7 @@ class RepositoryVersion(BaseModel):
         if content_qs is None:
             content_qs = Content.objects
 
-        return content_qs.filter(pk__in=self._content_relationships().values_list("content_id"))
+        return content_qs.filter(version_memberships__in=self._content_relationships())
 
     @property
     def content(self):
@@ -850,9 +850,7 @@ class RepositoryVersion(BaseModel):
             raise ResourceImmutableError(self)
 
         repo_content = []
-        to_add = set(content.values_list("pk", flat=True)) - set(
-            self.content.values_list("pk", flat=True)
-        )
+        to_add = set(content.exclude(pk__in=self.content).values_list("pk", flat=True))
 
         # Normalize representation if content has already been removed in this version and
         # is re-added: Undo removal by setting version_removed to None.


### PR DESCRIPTION
Revert "Enhance get_content() by omitting the version_membership lookup"
Revert "Works around a sync-time performance regression on PG12"

This reverts commit f70316e196b045b613bbbb19b8c8de3a8b5e2bde.
This reverts commit 019266a80b96215b241c68ce65f17555adf6a592.