### PR TITLE
Fix content handler failing to find published/content artifacts for index pages

### DIFF
--- a/CHANGES/plugin_api/4654.bugfix
+++ b/CHANGES/plugin_api/4654.bugfix
@@ -1,0 +1,1 @@
+Fixed content app returning 404s on directory index pages for some published plugins.

--- a/pulpcore/content/handler.py
+++ b/pulpcore/content/handler.py
@@ -620,8 +620,8 @@ class Handler:
                 if not ends_in_slash:
                     # index.html found, but user didn't specify a trailing slash
                     raise HTTPMovedPermanently(f"{request.path}/")
-                rel_path = index_path
-                headers = self.response_headers(rel_path, distro)
+                original_rel_path = index_path
+                headers = self.response_headers(original_rel_path, distro)
             except ObjectDoesNotExist:
                 dir_list, dates, sizes = await self.list_directory(None, publication, rel_path)
                 dir_list.update(
@@ -695,7 +695,8 @@ class Handler:
                 content__in=repo_version.content, relative_path=index_path
             ).aexists()
             if contentartifact_exists:
-                rel_path = index_path
+                original_rel_path = index_path
+                headers = self.response_headers(original_rel_path, distro)
             else:
                 dir_list, dates, sizes = await self.list_directory(repo_version, None, rel_path)
                 dir_list.update(


### PR DESCRIPTION
Needed for pulp_python 3.40 compat release. Backport please :smiley: 

fixes: #4654