### PR TITLE
Fix pulp_file package name in status

### DIFF
--- a/CHANGES/4724.bugfix
+++ b/CHANGES/4724.bugfix
@@ -1,0 +1,1 @@
+Fixed that `pulp_file` presented its `python_package` as `pulp_file` instead of `pulp-file`.

--- a/pulp_file/app/__init__.py
+++ b/pulp_file/app/__init__.py
@@ -9,5 +9,5 @@ class PulpFilePluginAppConfig(PulpPluginAppConfig):
     name = "pulp_file.app"
     label = "file"
     version = "3.41.1.dev"
-    python_package_name = "pulp_file"  # TODO Add python_module_name
+    python_package_name = "pulp-file"  # TODO Add python_module_name
     domain_compatible = True


### PR DESCRIPTION
Status report of the pulp_file python_package must be pulp-file. Technically this is still wrong, because it should be pulpcore, but we will need another field to present the python module in order to be able to generate the bindings.

fixes #4724

(cherry picked from commit 822e2be3a246f71939250c0c94a7820c2667e70f)