### PR TITLE
Protect distributed repo versions from deletion

### DIFF
--- a/CHANGES/2705.bugfix
+++ b/CHANGES/2705.bugfix
@@ -1,0 +1,2 @@
+Repo versions are now protected from deletion if they are being used by Pulp to distribute content.
+Users must first update any necessary distributions before deleting a protected repo version.

--- a/docs/workflows/repo-versioning.rst
+++ b/docs/workflows/repo-versioning.rst
@@ -16,6 +16,9 @@ greater than or equal to 1.
 Setting retain_repo_versions to 1 effectively disables repository versioning since Pulp will only
 store the latest version.
 
+Cleanup will ignore any repo versions that are being served directly via a distribution or via a
+publication.
+
 To update this field for a file Repository called myrepo, simply call:
 
 ```

--- a/pulpcore/app/viewsets/repository.py
+++ b/pulpcore/app/viewsets/repository.py
@@ -10,6 +10,7 @@ from rest_framework.decorators import action
 from rest_framework.viewsets import GenericViewSet
 from urllib.parse import urlparse
 
+from pulpcore.constants import PROTECTED_REPO_VERSION_MESSAGE
 from pulpcore.filters import BaseFilterSet
 from pulpcore.app import tasks
 from pulpcore.app.models import (
@@ -295,6 +296,9 @@ class RepositoryVersionViewSet(
         Queues a task to handle deletion of a RepositoryVersion
         """
         version = self.get_object()
+
+        if version in version.repository.protected_versions():
+            raise serializers.ValidationError(PROTECTED_REPO_VERSION_MESSAGE)
 
         task = dispatch(
             tasks.repository.delete_version,

--- a/pulpcore/constants.py
+++ b/pulpcore/constants.py
@@ -1,3 +1,4 @@
+from gettext import gettext as _
 from pathlib import Path
 from types import SimpleNamespace
 
@@ -104,3 +105,9 @@ STORAGE_RESPONSE_MAP = {
     "storages.backends.azure_storage.AzureStorage": AZURE_RESPONSE_HEADER_MAP,
     "storages.backends.gcloud.GoogleCloudStorage": GCS_RESPONSE_HEADER_MAP,
 }
+
+# Message users receive when attempting to delete a protected repo version
+PROTECTED_REPO_VERSION_MESSAGE = _(
+    "The repository version cannot be deleted because it (or its publications) are currently being "
+    "used to distribute content. Please update the necessary distributions first."
+)


### PR DESCRIPTION
This change protects repo versions from being deleted up if their content is being served by distributions.

fixes #2705