### PR TITLE
Fix a race condition in distribution filtering

### DIFF
--- a/CHANGES/4766.bugfix
+++ b/CHANGES/4766.bugfix
@@ -1,0 +1,1 @@
+Removed a race condition leading to 500 error in distribution filtering.

--- a/CHANGES/plugin_api/4766.feature
+++ b/CHANGES/plugin_api/4766.feature
@@ -1,0 +1,1 @@
+Added the async safe `detail_model` property to master detail models.

--- a/pulpcore/app/models/base.py
+++ b/pulpcore/app/models/base.py
@@ -148,16 +148,20 @@ class MasterModel(BaseModel, metaclass=MasterModelMeta):
     def get_model_for_pulp_type(cls, pulp_type):
         return cls._pulp_model_map[pulp_type]
 
-    def save(self, *args, **kwargs):
+    @property
+    def detail_model(self):
+        return self._pulp_model_map[self.pulp_type]
+
+    def __init__(self, *args, **kwargs):
         # instances of "detail" models that subclass MasterModel are exposed
         # on instances of MasterModel by the string stored in that model's TYPE attr.
         # Storing this pulp_type in a column on the MasterModel next to makes it trivial
         # to filter for specific detail model types across master's relations.
         # Prepend the TYPE defined on a detail model with a django app label.
         # If a plugin sets the type field themselves, it's used as-is.
+        super().__init__(*args, **kwargs)
         if not self.pulp_type:
             self.pulp_type = self.get_pulp_type()
-        return super().save(*args, **kwargs)
 
     def cast(self):
         """Return the "Detail" model instance of this master-detail object.

--- a/pulpcore/app/viewsets/custom_filters.py
+++ b/pulpcore/app/viewsets/custom_filters.py
@@ -355,12 +355,12 @@ class DistributionWithContentFilter(Filter):
         for dist in qs.exclude(publication=None).values("publication__repository_version", "pk"):
             versions_distributions[dist["publication__repository_version"]].append(dist["pk"])
 
-        for dist in qs.exclude(repository_version=None).values("repository_version", "pk"):
-            if not dist.cast().SERVE_FROM_PUBLICATION:
+        for dist in qs.exclude(repository_version=None).values("repository_version", "pulp_type"):
+            if not dist.detail_model.SERVE_FROM_PUBLICATION:
                 versions_distributions[dist["repository_version"]].append(dist["pk"])
 
         for dist in qs.exclude(repository=None).prefetch_related("repository__versions"):
-            if dist.cast().SERVE_FROM_PUBLICATION:
+            if dist.detail_model.SERVE_FROM_PUBLICATION:
                 versions = dist.repository.versions.values_list("pk", flat=True)
                 publications = Publication.objects.filter(
                     repository_version__in=versions, complete=True


### PR DESCRIPTION
This change adds a `detail_model` property to the master-detail concept and removes a race condition by replacing calls to `cast` with it in `DistributionWithContentFilter`.

fixes #4766