### PR TITLE
Fixes repository version repair API for non-default domains.

### DIFF
--- a/CHANGES/4776.bugfix
+++ b/CHANGES/4776.bugfix
@@ -1,0 +1,1 @@
+Fixed a bug in the repository version repair API for non-default domains.

--- a/CHANGES/4806.bugfix
+++ b/CHANGES/4806.bugfix
@@ -1,0 +1,1 @@
+Fixed a bug in the repository version repair API for non-default domains.


### PR DESCRIPTION
The 'current_domain' ContextVar was not getting coppied into the thread that was running the artifact
verification. The context is now explicitly copied into that thread.
    
This patch also adds repair API tests for S3 and Azure storage backends.
    
This patch also adds test assertions that a repository version repair task can be run in a non-default
domain.


fixes: #4776
fixes: #4806