### PR TITLE
Fix async tests using unsafe fixtures

### DIFF
--- a/pulpcore/tests/unit/stages/test_stages.py
+++ b/pulpcore/tests/unit/stages/test_stages.py
@@ -1,5 +1,6 @@
 import asyncio
 import pytest
+import pytest_asyncio
 
 import mock
 
@@ -9,13 +10,13 @@ from pulpcore.plugin.stages import Stage, EndStage, DeclarativeContent
 pytestmark = pytest.mark.usefixtures("fake_domain")
 
 
-@pytest.fixture
-def in_q():
+@pytest_asyncio.fixture
+async def in_q():
     return asyncio.Queue()
 
 
-@pytest.fixture
-def stage(in_q):
+@pytest_asyncio.fixture
+async def stage(in_q):
     stage = Stage()
     stage._connect(in_q, None)
     return stage


### PR DESCRIPTION
With the latest version of pytest-asyncio, async tests run with individual event loops, and so fixtures providing e.g. queues need to use the same loop.

[noissue]

https://pytest-asyncio.readthedocs.io/en/latest/reference/changelog.html#id11