### PR TITLE
Fix orphan cleanup failing to fully delete content with subrepos

### DIFF
--- a/CHANGES/4837.bugfix
+++ b/CHANGES/4837.bugfix
@@ -1,0 +1,1 @@
+Ensured orphan cleanup properly deletes content with sub-repositories.


### PR DESCRIPTION
Tested this out with RPM kickstart fixture and I now see all 69 synced content units being deleted correctly (before it was only ~5). 

@ipanova I tried to still maintain your reliability changes, so hopefully it is still tolerant. :pray: 

fixes: #4837
