### PR TITLE
Casts a repository object before checking permission on it.

### DIFF
--- a/CHANGES/4932.bugfix
+++ b/CHANGES/4932.bugfix
@@ -1,0 +1,1 @@
+Fixed a bug where publications couldn't be created from repository versions when using RBAC.

--- a/pulpcore/app/global_access_conditions.py
+++ b/pulpcore/app/global_access_conditions.py
@@ -424,9 +424,9 @@ def has_repo_or_repo_ver_param_model_or_domain_or_obj_perms(request, view, actio
     )
     serializer.is_valid(raise_exception=True)
     if repository := serializer.validated_data.get("repository"):
-        return request.user.has_perm(permission, repository)
+        return request.user.has_perm(permission, repository.cast())
     elif repo_ver := serializer.validated_data.get("repository_version"):
-        return request.user.has_perm(permission, repo_ver.repository)
+        return request.user.has_perm(permission, repo_ver.repository.cast())
     return True
 
 

--- a/pulpcore/tests/functional/api/pulp_file/test_rbac.py
+++ b/pulpcore/tests/functional/api/pulp_file/test_rbac.py
@@ -267,6 +267,14 @@ def test_object_creation(
     try_action(
         bob, file_publication_api_client, "create", 403, {"repository": admin_repo.pulp_href}
     )
+    pub_from_repo_version = try_action(
+        bob,
+        file_publication_api_client,
+        "create",
+        202,
+        {"repository_version": repo.latest_version_href},
+    )
+    assert pub_from_repo_version.created_resources[0] is not None
     pub = try_action(
         bob, file_publication_api_client, "create", 202, {"repository": repo.pulp_href}
     )


### PR DESCRIPTION
fixes: #4932