### PR TITLE
fix: Bump dynaconf on 3.28.z

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -15,7 +15,7 @@ djangorestframework-queryfields>=1.0,<=1.0.0
 drf-access-policy>=1.1.2,<1.5.1
 drf-nested-routers>=0.93.4,<=0.93.4
 drf-spectacular==0.26.2  # We monkeypatch this so we need a very narrow requirement string
-dynaconf>=3.1.12,<3.1.13
+dynaconf>=3.1.12,<3.3
 gunicorn>=20.1,<=20.1.0
 jinja2>=3.1,<=3.1.2
 naya>=1.1.1,<=1.1.1


### PR DESCRIPTION
AAP 2.4 uses pulpcore 3.28.z and needs
dynaconf to be at least 3.2.4 to include
a fix for boolean parsing.

Previous versions of dynaconf would parse

```bash
export PULP_DEBUG=False
```

as a str `"False"` causing `if settings.DEBUG:` to evaluate to `True`

On 3.2.2, dynaconf [started parsing](https://github.com/dynaconf/dynaconf/pull/983) `False/True` string as booleans from envvars.

[noissue]