### PR TITLE
Backport the `--nightly` pytest arg

### DIFF
--- a/pulpcore/tests/functional/__init__.py
+++ b/pulpcore/tests/functional/__init__.py
@@ -72,6 +72,31 @@ def pytest_check_for_leftover_pulp_objects(config):
             raise Exception(f"This test left over a {api_to_check}.")
 
 
+try:
+    import pulp_smash
+except ImportError:
+
+    def pytest_addoption(parser):
+        group = parser.getgroup("pulpcore")
+        group.addoption(
+            "--nightly",
+            action="store_true",
+            default=False,
+            help="Enable to run nightly test.",
+        )
+
+    def pytest_collection_modifyitems(config, items):
+        # Skip nightly tests by default
+        # https://docs.pytest.org/en/7.1.x/example/simple.html#control-skipping-of-tests-according-to-command-line-option
+        if config.getoption("--nightly"):
+            # Run all tests unmodified
+            return
+        skip_nightly = pytest.mark.skip(reason="need --nightly option to run")
+        for item in items:
+            if "nightly" in item.keywords:
+                item.add_marker(skip_nightly)
+
+
 def pytest_configure(config):
     config.addinivalue_line(
         "markers",


### PR DESCRIPTION
This pytest flag used to be provided by pulp-smash, but we no longer want to depend on that. So we need to provide this functionality in the pulpcore pytest plugin. A safeguard is in place to not totally confuse pytest if pulp-smash happens to be installed anyway.

[noissue]

(cherry picked from commit c6135e81ae8aacd9c6dde092856d1a12bfdac8ab)