### PR TITLE
Backport the `--nightly` pytest arg

### DIFF
--- a/functest_requirements.txt
+++ b/functest_requirements.txt
@@ -2,7 +2,7 @@ aiohttp
 django
 dynaconf
 drf-spectacular
-pytest
+pytest<8
 pytest-custom_exit_code
 pytest-xdist
 python-gnupg

--- a/lint_requirements.txt
+++ b/lint_requirements.txt
@@ -6,7 +6,7 @@
 # For more info visit https://github.com/pulp/plugin_template
 
 # python packages handy for developers, but not required by pulp
-black
+black==23.12.1
 check-manifest
 flake8
 flake8-black

--- a/pulpcore/tests/functional/__init__.py
+++ b/pulpcore/tests/functional/__init__.py
@@ -86,6 +86,31 @@ from .gpg_ascii_armor_signing_service import (
 )
 
 
+try:
+    import pulp_smash
+except ImportError:
+
+    def pytest_addoption(parser):
+        group = parser.getgroup("pulpcore")
+        group.addoption(
+            "--nightly",
+            action="store_true",
+            default=False,
+            help="Enable to run nightly test.",
+        )
+
+    def pytest_collection_modifyitems(config, items):
+        # Skip nightly tests by default
+        # https://docs.pytest.org/en/7.1.x/example/simple.html#control-skipping-of-tests-according-to-command-line-option
+        if config.getoption("--nightly"):
+            # Run all tests unmodified
+            return
+        skip_nightly = pytest.mark.skip(reason="need --nightly option to run")
+        for item in items:
+            if "nightly" in item.keywords:
+                item.add_marker(skip_nightly)
+
+
 class PulpTaskTimeoutError(Exception):
     """Exception to describe task and taskgroup timeout errors."""
 


### PR DESCRIPTION
This pytest flag used to be provided by pulp-smash, but we no longer want to depend on that. So we need to provide this functionality in the pulpcore pytest plugin. A safeguard is in place to not totally confuse pytest if pulp-smash happens to be installed anyway.

[noissue]

(cherry picked from commit c6135e81ae8aacd9c6dde092856d1a12bfdac8ab)