### PR TITLE
Fix replicate for a distribution with publication

### DIFF
--- a/CHANGES/4637.bugfix
+++ b/CHANGES/4637.bugfix
@@ -1,0 +1,1 @@
+Fixed an issue in replicate, where an existing distribution had a conflicting publication set.

--- a/pulp_file/pytest_plugin.py
+++ b/pulp_file/pytest_plugin.py
@@ -308,7 +308,7 @@ def file_remote_client_cert_req_factory(
 
 
 @pytest.fixture(scope="class")
-def file_repository_factory(file_repository_api_client, gen_object_with_cleanup):
+def file_repository_factory(file_bindings, gen_object_with_cleanup):
     """A factory to generate a File Repository with auto-deletion after the test run."""
 
     def _file_repository_factory(pulp_domain=None, **body):
@@ -316,9 +316,24 @@ def file_repository_factory(file_repository_api_client, gen_object_with_cleanup)
         if pulp_domain:
             kwargs["pulp_domain"] = pulp_domain
         body.setdefault("name", str(uuid.uuid4()))
-        return gen_object_with_cleanup(file_repository_api_client, body, **kwargs)
+        return gen_object_with_cleanup(file_bindings.RepositoriesFileApi, body, **kwargs)
 
     return _file_repository_factory
+
+
+@pytest.fixture(scope="class")
+def file_publication_factory(file_bindings, gen_object_with_cleanup):
+    """A factory to generate a File Publication with auto-deletion after the test run."""
+
+    def _file_publication_factory(**kwargs):
+        extra_args = {}
+        if pulp_domain := kwargs.pop("pulp_domain", None):
+            extra_args["pulp_domain"] = pulp_domain
+        # XOR check on repository and repository_version
+        assert bool("repository" in kwargs) ^ bool("repository_version" in kwargs)
+        return gen_object_with_cleanup(file_bindings.PublicationsFileApi, kwargs, **extra_args)
+
+    return _file_publication_factory
 
 
 @pytest.fixture

--- a/pulpcore/app/tasks/replica.py
+++ b/pulpcore/app/tasks/replica.py
@@ -7,7 +7,6 @@ from tempfile import NamedTemporaryFile
 from pulpcore.app.apps import pulp_plugin_configs
 from pulpcore.app.models import UpstreamPulp, TaskGroup
 from pulpcore.app.replica import ReplicaContext
-from pulpcore.app.util import get_domain
 
 from pulp_glue.common import __version__ as pulp_glue_version
 
@@ -24,7 +23,6 @@ def user_agent():
 
 
 def replicate_distributions(server_pk):
-    domain = get_domain()
     server = UpstreamPulp.objects.get(pk=server_pk)
 
     # Write out temporary files related to SSL
@@ -80,18 +78,9 @@ def replicate_distributions(server_pk):
             # Create remote
             remote = replicator.create_or_update_remote(upstream_distribution=distro)
             if not remote:
-                # The upstream distribution is not serving any content, cleanup an existing local
-                # distribution
-                try:
-                    local_distro = replicator.distribution_model.objects.get(
-                        name=distro["name"], pulp_domain=domain
-                    )
-                    local_distro.repository = None
-                    local_distro.publication = None
-                    local_distro.save()
-                    continue
-                except replicator.distribution_model.DoesNotExist:
-                    continue
+                # The upstream distribution is not serving any content,
+                # let if fall throug the cracks and be cleanup below.
+                continue
             # Check if there is already a repository
             repository = replicator.create_or_update_repository(remote=remote)
 

--- a/pulpcore/tests/functional/__init__.py
+++ b/pulpcore/tests/functional/__init__.py
@@ -955,6 +955,44 @@ def random_artifact(random_artifact_factory):
     return random_artifact_factory()
 
 
+@pytest.fixture()
+def domain_factory(pulpcore_bindings, pulp_settings, gen_object_with_cleanup):
+    def _domain_factory():
+        if not pulp_settings.DOMAIN_ENABLED:
+            pytest.skip("Domains not enabled")
+        keys = dict()
+        keys["pulpcore.app.models.storage.FileSystem"] = ["MEDIA_ROOT"]
+        keys["storages.backends.s3boto3.S3Boto3Storage"] = [
+            "AWS_ACCESS_KEY_ID",
+            "AWS_SECRET_ACCESS_KEY",
+            "AWS_S3_ENDPOINT_URL",
+            "AWS_S3_ADDRESSING_STYLE",
+            "AWS_S3_SIGNATURE_VERSION",
+            "AWS_S3_REGION_NAME",
+            "AWS_STORAGE_BUCKET_NAME",
+        ]
+        keys["storages.backends.azure_storage.AzureStorage"] = [
+            "AZURE_ACCOUNT_NAME",
+            "AZURE_CONTAINER",
+            "AZURE_ACCOUNT_KEY",
+            "AZURE_URL_EXPIRATION_SECS",
+            "AZURE_OVERWRITE_FILES",
+            "AZURE_LOCATION",
+            "AZURE_CONNECTION_STRING",
+        ]
+        settings = dict()
+        for key in keys[pulp_settings.DEFAULT_FILE_STORAGE]:
+            settings[key] = getattr(pulp_settings, key, None)
+        body = {
+            "name": str(uuid.uuid4()),
+            "storage_class": pulp_settings.DEFAULT_FILE_STORAGE,
+            "storage_settings": settings,
+        }
+        return gen_object_with_cleanup(pulpcore_bindings.DomainsApi, body)
+
+    return _domain_factory
+
+
 # Random other fixtures
 
 
@@ -1263,41 +1301,3 @@ def wget_recursive_download_on_host():
         )
 
     return _wget_recursive_download_on_host
-
-
-@pytest.fixture()
-def domain_factory(domains_api_client, pulp_settings, gen_object_with_cleanup):
-    def _domain_factory():
-        if not pulp_settings.DOMAIN_ENABLED:
-            pytest.skip("Domains not enabled")
-        keys = dict()
-        keys["pulpcore.app.models.storage.FileSystem"] = ["MEDIA_ROOT"]
-        keys["storages.backends.s3boto3.S3Boto3Storage"] = [
-            "AWS_ACCESS_KEY_ID",
-            "AWS_SECRET_ACCESS_KEY",
-            "AWS_S3_ENDPOINT_URL",
-            "AWS_S3_ADDRESSING_STYLE",
-            "AWS_S3_SIGNATURE_VERSION",
-            "AWS_S3_REGION_NAME",
-            "AWS_STORAGE_BUCKET_NAME",
-        ]
-        keys["storages.backends.azure_storage.AzureStorage"] = [
-            "AZURE_ACCOUNT_NAME",
-            "AZURE_CONTAINER",
-            "AZURE_ACCOUNT_KEY",
-            "AZURE_URL_EXPIRATION_SECS",
-            "AZURE_OVERWRITE_FILES",
-            "AZURE_LOCATION",
-            "AZURE_CONNECTION_STRING",
-        ]
-        settings = dict()
-        for key in keys[pulp_settings.DEFAULT_FILE_STORAGE]:
-            settings[key] = getattr(pulp_settings, key, None)
-        body = {
-            "name": str(uuid.uuid4()),
-            "storage_class": pulp_settings.DEFAULT_FILE_STORAGE,
-            "storage_settings": settings,
-        }
-        return gen_object_with_cleanup(domains_api_client, body)
-
-    return _domain_factory


### PR DESCRIPTION
In case a distribution that is supposed to be subject to replication is referring to a publication (because it was created by someone else) we need to unset the publication field for the replicate task to succeed.

fixes #4637