### PR TITLE
Pin tablib<3.6 to not-break older versions of django-import-export.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -28,6 +28,7 @@ PyYAML>=5.1.1,<6.1.0
 python-gnupg~=0.4.8
 redis~=3.4.0
 setuptools>=39.2.0,<62.1.0
+tablib<3.6.0
 url-normalize~=1.4.3
 whitenoise>=5.0.0,<6.1.0
 yarl~=1.0


### PR DESCRIPTION
[noissue]

(cherry picked from commit 6baa23f41fb5d46ac0d45050e7d319c3ca60f79d)