### PR TITLE
Pin tablib<3.6 to not-break older versions of django-import-export.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -28,6 +28,7 @@ PyYAML>=5.1.1,<6.1.0
 python-gnupg~=0.5.0
 redis~=4.3
 setuptools>=39.2.0,<66.0.0
+tablib<3.6.0
 url-normalize~=1.4.3
 whitenoise>=5.0.0,<6.3.0
 yarl~=1.7


### PR DESCRIPTION
[noissue]

(cherry picked from commit 6baa23f41fb5d46ac0d45050e7d319c3ca60f79d)