### PR TITLE
Pin tablib<3.6 to not-break older versions of django-import-export.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -36,6 +36,7 @@ python-gnupg>=0.5,<=0.5.2
 PyYAML>=5.1.1,<=6.0.1
 redis>=4.3,<5.0.2
 setuptools>=39.2,<69.1.0
+tablib<3.6.0
 url-normalize>=1.4.3,<=1.4.3
 uuid6>=2023.5.2,<=2024.1.12
 whitenoise>=5.0,<6.7.0


### PR DESCRIPTION
[noissue]

(cherry picked from commit 6baa23f41fb5d46ac0d45050e7d319c3ca60f79d)