### PR TITLE
Ensure deprecation message on reserved-resources-record filter only shows when used

### DIFF
--- a/pulpcore/app/viewsets/custom_filters.py
+++ b/pulpcore/app/viewsets/custom_filters.py
@@ -84,13 +84,14 @@ class ReservedResourcesRecordFilter(Filter):
         Returns:
             django.db.models.query.QuerySet: Queryset filtered by the reserved resource
         """
-        deprecation_logger.warning(
-            "This filter is deprecated. Please use reserved_resources(__in) instead."
-        )
 
         if value is None:
             # a value was not supplied by a user
             return qs
+
+        deprecation_logger.warning(
+            "This filter is deprecated. Please use reserved_resources(__in) instead."
+        )
 
         try:
             resolve(urlparse(value).path)


### PR DESCRIPTION
I thought the issue was in the CLI, but after looking at the CLI code we don't use the old filter anymore. It seems the filter is always called even when the query isn't specified. Haven't check yet to see if this expected behavior of the filterset, but I think it might be.