### PR TITLE
Temporary fix for staging-docs build

### DIFF
--- a/.github/workflows/scripts/build_all_docs.sh
+++ b/.github/workflows/scripts/build_all_docs.sh
@@ -1,4 +1,11 @@
 # This script builds the documentation site for staging-docs.pulpproject.org
+
+# TODO: this chdir move is a tmp workaround. Remove when no longer needed.
+# see: https://github.com/mkdocstrings/python/issues/145
+mkdir ../build_dir && pushd ../build_dir
+
 pip install git+https://github.com/pulp/pulp-docs.git
 pulp-docs build
-tar cvf staging-docs.pulpproject.org.tar ./site
+tar cvf ../pulpcore/staging-docs.pulpproject.org.tar site
+
+popd


### PR DESCRIPTION
TLDR: because [Griffe looks for the package in the relative path by default](https://github.com/mkdocstrings/griffe/blob/01da648b10aca57d316e74e4b0eef2ca31e92f32/src/griffe/loader.py#L182-L185) (and mkdocstring uses that unchanged), the wrong package is discovered instead the one I've defined programmatically if I'm in A Folder Called Pulpcore.

[noissue]