### PR TITLE
Fix bug where Last-Modified header was being updated on duplicate package uploads

### DIFF
--- a/CHANGES/5149.bugfix
+++ b/CHANGES/5149.bugfix
@@ -1,0 +1,2 @@
+Fixed bug where Last-Modified header of packages in django-storages was being updated on duplicate
+uploads.

--- a/CHANGES/plugin_api/5149.bugfix
+++ b/CHANGES/plugin_api/5149.bugfix
@@ -1,0 +1,1 @@
+Check for existing artifact before saving uploaded content as an artifact.

--- a/pulpcore/plugin/viewsets/content.py
+++ b/pulpcore/plugin/viewsets/content.py
@@ -1,7 +1,6 @@
 from drf_spectacular.utils import extend_schema
 
 from django.db import DatabaseError
-from django.db.utils import IntegrityError
 
 from pulpcore.app import tasks
 from pulpcore.plugin.serializers import (
@@ -133,18 +132,14 @@ class SingleArtifactContentUploadViewSet(DefaultDeferredContextMixin, ContentVie
             # in the upload code path make sure, the artifact exists, and the 'file'
             # parameter is replaced by 'artifact'
             artifact = Artifact.init_and_validate(task_payload.pop("file"))
+            # if artifact already exists, let's use it
             try:
+                artifact = Artifact.objects.get(
+                    sha256=artifact.sha256, pulp_domain=request.pulp_domain
+                )
+                artifact.touch()
+            except (Artifact.DoesNotExist, DatabaseError):
                 artifact.save()
-            except IntegrityError:
-                # if artifact already exists, let's use it
-                try:
-                    artifact = Artifact.objects.get(
-                        sha256=artifact.sha256, pulp_domain=request.pulp_domain
-                    )
-                    artifact.touch()
-                except (Artifact.DoesNotExist, DatabaseError):
-                    # the artifact has since been removed from when we first attempted to save it
-                    artifact.save()
 
             task_payload["artifact"] = ArtifactSerializer(
                 artifact, context={"request": request}


### PR DESCRIPTION
Fixes a bug where the Last-Modified header of a package stored in django-storages was being updated on duplicate uploads.

Closes #5149