### PR TITLE
Make staging-docs publish workflow run nighly

### DIFF
--- a/.github/workflows/staging-docs.yml
+++ b/.github/workflows/staging-docs.yml
@@ -1,6 +1,10 @@
 ---
 name: Publish staging-docs.pulpproject.org
 on:
+  schedule:
+    # * is a special character in YAML so you have to quote this string
+    # runs at 3:00 UTC daily on weekdays 1 to 5 (no weekends)
+    - cron: '00 3 * * 1-5'
   workflow_dispatch:
 
 defaults:


### PR DESCRIPTION
Now that every repository has a staging-docs setup, we want to have the published staging-docs website automatically up-to-date with upcoming changes.

[noissue]