### PR TITLE
Adds HEAD support to Status API

### DIFF
--- a/CHANGES/5243.feature
+++ b/CHANGES/5243.feature
@@ -1,0 +1,1 @@
+Added support for HEAD requests in the Status API. HEAD requests should be used to assess the liveness of the REST API.

--- a/pulpcore/app/views/status.py
+++ b/pulpcore/app/views/status.py
@@ -43,6 +43,12 @@ class StatusView(APIView):
     authentication_classes = []
     permission_classes = []
 
+    def head(self, request):
+        """
+        Lightweight status check that ensures that the REST API can connect to the database.
+        """
+        return Response()
+
     @extend_schema(
         summary="Inspect status of Pulp",
         operation_id="status_read",

--- a/pulpcore/tests/functional/api/test_status.py
+++ b/pulpcore/tests/functional/api/test_status.py
@@ -175,3 +175,20 @@ def verify_get_response(status, expected_schema):
     else:
         assert status["storage"]["free"] is not None
         assert status["storage"]["total"] is not None
+
+
+@pytest.mark.parallel
+def test_head_unauthenticated(
+    test_path,
+    pulpcore_bindings,
+    pulp_api_v3_url,
+    anonymous_user,
+):
+    """
+    Assert that HEAD requests to Status API return 200 without a response body.
+    """
+    status_url = f"{pulp_api_v3_url}status/"
+    with anonymous_user:
+        r = pulpcore_bindings.client.request("HEAD", status_url, headers={"User-Agent": test_path})
+    assert r.status == 200
+    assert r.data == b""


### PR DESCRIPTION
drf-spectacular doesn't support HEAD requests. That's why this change doesn't have any OpenAPI schema related changes.

https://github.com/tfranzel/drf-spectacular/issues/684

closes: #5243