### PR TITLE
Fix creation hooks being called for Upload

### DIFF
--- a/CHANGES/5199.bugfix
+++ b/CHANGES/5199.bugfix
@@ -1,0 +1,3 @@
+Fix Upload failing to run post create hooks.
+On installations using the default access policy, this fixes the automatic owner assignment for
+users with the `core.upload_create` role on upload objects.

--- a/pulpcore/app/models/upload.py
+++ b/pulpcore/app/models/upload.py
@@ -9,11 +9,11 @@ from django.db.models.signals import post_delete
 from django.dispatch import receiver
 from rest_framework import serializers
 
-from pulpcore.app.models import BaseModel, fields, storage
+from pulpcore.app.models import BaseModel, fields, storage, AutoAddObjPermsMixin
 from pulpcore.app.util import get_domain_pk
 
 
-class Upload(BaseModel):
+class Upload(BaseModel, AutoAddObjPermsMixin):
     """
     A chunked upload. Stores chunks until used to create an artifact, etc.
 

--- a/pulpcore/tests/functional/__init__.py
+++ b/pulpcore/tests/functional/__init__.py
@@ -840,31 +840,31 @@ def role_factory(roles_api_client, gen_object_with_cleanup):
 
 
 @pytest.fixture
-def gen_user(bindings_cfg, users_api_client, users_roles_api_client, gen_object_with_cleanup):
+def gen_user(bindings_cfg, pulpcore_bindings, gen_object_with_cleanup):
     class user_context:
         def __init__(self, username=None, model_roles=None, object_roles=None, domain_roles=None):
             self.username = username or str(uuid.uuid4())
             self.password = str(uuid.uuid4())
             self.user = gen_object_with_cleanup(
-                users_api_client, {"username": self.username, "password": self.password}
+                pulpcore_bindings.UsersApi, {"username": self.username, "password": self.password}
             )
             self._saved_credentials = []
 
             if model_roles:
                 for role in model_roles:
-                    users_roles_api_client.create(
+                    pulpcore_bindings.UsersRolesApi.create(
                         auth_user_href=self.user.pulp_href,
                         user_role={"role": role, "domain": None, "content_object": None},
                     )
             if domain_roles:
                 for role, domain in domain_roles:
-                    users_roles_api_client.create(
+                    pulpcore_bindings.UsersRolesApi.create(
                         auth_user_href=self.user.pulp_href,
                         user_role={"role": role, "domain": domain, "content_object": None},
                     )
             if object_roles:
                 for role, content_object in object_roles:
-                    users_roles_api_client.create(
+                    pulpcore_bindings.UsersRolesApi.create(
                         auth_user_href=self.user.pulp_href,
                         user_role={"role": role, "domain": None, "content_object": content_object},
                     )

--- a/pulpcore/tests/functional/api/test_upload.py
+++ b/pulpcore/tests/functional/api/test_upload.py
@@ -1,4 +1,5 @@
 """Tests related to content upload."""
+
 import hashlib
 import uuid
 import pytest
@@ -183,3 +184,16 @@ def test_delete_upload(
         uploads_api_client.read(upload.pulp_href)
 
     assert e.value.status == 404
+
+
+def test_upload_owner(pulpcore_bindings, gen_user, gen_object_with_cleanup):
+    user = gen_user(model_roles=["core.upload_creator"])
+    with user:
+        upload = gen_object_with_cleanup(pulpcore_bindings.UploadsApi, {"size": 1024})
+        pulpcore_bindings.UploadsApi.read(upload.pulp_href)
+        assert set(pulpcore_bindings.UploadsApi.my_permissions(upload.pulp_href).permissions) == {
+            "core.view_upload",
+            "core.change_upload",
+            "core.delete_upload",
+            "core.manage_roles_upload",
+        }


### PR DESCRIPTION
The mixin for automatic calling of creation hooks was missing on the Upload model.

fixes #5199

- [x] Let me add a test.