### PR TITLE
Remove docs-build workaround

### DIFF
--- a/.github/workflows/scripts/build_all_docs.sh
+++ b/.github/workflows/scripts/build_all_docs.sh
@@ -1,11 +1,5 @@
 # This script builds the documentation site for staging-docs.pulpproject.org
 
-# TODO: this chdir move is a tmp workaround. Remove when no longer needed.
-# see: https://github.com/mkdocstrings/python/issues/145
-mkdir ../build_dir && pushd ../build_dir
-
 pip install git+https://github.com/pulp/pulp-docs.git
 pulp-docs build
-tar cvf ../pulpcore/staging-docs.pulpproject.org.tar site
-
-popd
+tar cvf staging-docs.pulpproject.org.tar site


### PR DESCRIPTION
The workaround was fixed by mkdocstrings-python 1.9.1 and pulp-docs pinned its dependencies to >=1.9.1

test run on my fork: https://github.com/pedro-psb/pulpcore/actions/runs/8665626487/job/23764717948#step:4:792
pulp-docs-pin: https://github.com/pulp/pulp-docs/pull/37 (just to assure future depsolving won't break us)

[noissue]