### PR TITLE
Add support for transfer_config in S3 domain serializer

### DIFF
--- a/CHANGES/4592.misc
+++ b/CHANGES/4592.misc
@@ -1,0 +1,1 @@
+Added domain support for newest fields in django-storages 1.14.2.


### PR DESCRIPTION
This change will also allow me to add GCP support for domains since the `credentials` setting requires a Google object.