### PR TITLE
Per core-team mtg, remove 3.18/45 from "supported" list.

### DIFF
--- a/template_config.yml
+++ b/template_config.yml
@@ -91,12 +91,10 @@ stalebot_days_until_close: 30
 stalebot_days_until_stale: 90
 stalebot_limit_to_pulls: true
 supported_release_branches:
-- '3.18'
 - '3.21'
 - '3.22'
 - '3.28'
 - '3.39'
-- '3.45'
 - '3.49'
 sync_ci: true
 test_azure: true


### PR DESCRIPTION
[noissue]