### PR TITLE
Adds a Liveness API

### DIFF
--- a/CHANGES/5243.feature
+++ b/CHANGES/5243.feature
@@ -1,0 +1,1 @@
+Added a Liveness API that can be used for the livenessProbe in k8s.

--- a/pulpcore/app/urls.py
+++ b/pulpcore/app/urls.py
@@ -13,7 +13,13 @@ from rest_framework_nested import routers
 from rest_framework.routers import APIRootView
 
 from pulpcore.app.apps import pulp_plugin_configs
-from pulpcore.app.views import OrphansView, PulpImporterImportCheckView, RepairView, StatusView
+from pulpcore.app.views import (
+    LivezView,
+    OrphansView,
+    PulpImporterImportCheckView,
+    RepairView,
+    StatusView,
+)
 from pulpcore.app.viewsets import (
     ListRepositoryVersionViewSet,
     OrphansCleanupViewset,
@@ -157,6 +163,7 @@ urlpatterns = [
 ]
 
 docs_and_status = [
+    path("livez/", LivezView.as_view()),
     path("status/", StatusView.as_view()),
     path(
         "docs/api.json",

--- a/pulpcore/app/views/__init__.py
+++ b/pulpcore/app/views/__init__.py
@@ -1,4 +1,4 @@
 from .orphans import OrphansView
-from .status import StatusView
+from .status import LivezView, StatusView
 from .repair import RepairView
 from .importer import PulpImporterImportCheckView

--- a/pulpcore/app/views/status.py
+++ b/pulpcore/app/views/status.py
@@ -136,3 +136,24 @@ class StatusView(APIView):
             return False
         else:
             return True
+
+
+class LivezView(APIView):
+    """
+    Liveness Probe for the REST API.
+    """
+
+    # allow anyone to access the liveness api
+    authentication_classes = []
+    permission_classes = []
+
+    @extend_schema(
+        summary="Inspect liveness of Pulp's REST API.",
+        operation_id="livez_read",
+        responses={200: None},
+    )
+    def get(self, request):
+        """
+        Returns 200 OK when API is alive.
+        """
+        return Response()

--- a/pulpcore/tests/functional/api/test_status.py
+++ b/pulpcore/tests/functional/api/test_status.py
@@ -175,3 +175,15 @@ def verify_get_response(status, expected_schema):
     else:
         assert status["storage"]["free"] is not None
         assert status["storage"]["total"] is not None
+
+
+@pytest.mark.parallel
+def test_livez_unauthenticated(
+    pulpcore_bindings,
+    anonymous_user,
+):
+    """
+    Assert that GET requests to Livez API return 200 without a response body.
+    """
+    with anonymous_user:
+        assert pulpcore_bindings.LivezApi.livez_read() is None


### PR DESCRIPTION
This API is intended to be used as the livenessProbe for the API workers runnign on Kubernetes.

closes #5243