### PR TITLE
Stop failing the post_create hooks with no viewset

### DIFF
--- a/CHANGES/plugin_api/5267.bugfix
+++ b/CHANGES/plugin_api/5267.bugfix
@@ -1,0 +1,1 @@
+Fixed a bug where models with auto assign permissions failed when no viewset was attached.

--- a/pulpcore/app/models/access_policy.py
+++ b/pulpcore/app/models/access_policy.py
@@ -67,10 +67,14 @@ class AutoAddObjPermsMixin:
 
     @hook("after_create")
     def add_perms(self):
-        viewset = get_viewset_for_model(self)
-        for permission_class in viewset.get_permissions(viewset):
-            if hasattr(permission_class, "handle_creation_hooks"):
-                permission_class.handle_creation_hooks(self)
+        try:
+            viewset = get_viewset_for_model(self)
+        except LookupError:
+            pass
+        else:
+            for permission_class in viewset.get_permissions(viewset):
+                if hasattr(permission_class, "handle_creation_hooks"):
+                    permission_class.handle_creation_hooks(self)
 
     def add_roles_for_users(self, roles, users):
         """

--- a/pulpcore/tests/unit/models/test_base.py
+++ b/pulpcore/tests/unit/models/test_base.py
@@ -1,12 +1,8 @@
 import pytest
 from uuid import uuid4
 
-from pulpcore.app.models import Repository
-
-try:
-    from pulp_file.app.models import FileRepository, FileRemote
-except ImportError:
-    pytestmark = pytest.mark.skip("These tests need pulp_file to be installed.")
+from pulpcore.app.models import AutoAddObjPermsMixin, Repository
+from pulp_file.app.models import FileRepository, FileRemote
 
 
 @pytest.mark.django_db
@@ -61,3 +57,15 @@ def test_cast(django_assert_num_queries):
 def test_get_model_for_pulp_type():
     assert Repository.get_model_for_pulp_type("core.repository") is Repository
     assert Repository.get_model_for_pulp_type("file.file") is FileRepository
+
+
+class PermissionRepository(Repository, AutoAddObjPermsMixin):
+    class Meta:
+        app_label = "test"
+        default_related_name = "permission_repository"
+        proxy = True
+
+
+@pytest.mark.django_db
+def test_resiliant_auto_perms():
+    PermissionRepository(name="auto permission test").save()


### PR DESCRIPTION
When e.g. pulp_container uses a subclass of Upload, we do not want the post create hook to fail. So we just ignore if a viewset cannot be found for the model.

fixes #5267