### PR TITLE
Fix jquery version for API html rendering

### DIFF
--- a/CHANGES/5306.bugfix
+++ b/CHANGES/5306.bugfix
@@ -1,0 +1,1 @@
+Update jquery version from 3.5.1 to 3.7.1 in API.html template

--- a/pulpcore/app/templates/rest_framework/api.html
+++ b/pulpcore/app/templates/rest_framework/api.html
@@ -291,7 +291,7 @@
           csrfToken: "{{ csrf_token }}"
         };
       </script>
-      <script src="{% static "rest_framework/js/jquery-3.5.1.min.js" %}"></script>
+      <script src="{% static "rest_framework/js/jquery-3.7.1.min.js" %}"></script>
       <script src="{% static "rest_framework/js/ajax-form.js" %}"></script>
       <script src="{% static "rest_framework/js/csrf.js" %}"></script>
       <script src="{% static "rest_framework/js/bootstrap.min.js" %}"></script>


### PR DESCRIPTION
As of 3.15.0 version of django-rest-framework the embeded jquery version is now 3.7.1

fixes #5306