### PR TITLE
Fix content directory list 500 when RemoteArtifact had null size

### DIFF
--- a/CHANGES/5318.bugfix
+++ b/CHANGES/5318.bugfix
@@ -1,0 +1,1 @@
+Fixed content directory listing returning 500 in certain scenarios due to missing artifact sizes.

--- a/pulpcore/content/handler.py
+++ b/pulpcore/content/handler.py
@@ -515,7 +515,7 @@ class Handler:
                 )
                 # Find the sizes for on_demand artifacts
                 r_artifacts = RemoteArtifact.objects.filter(
-                    content_artifact__in=artifacts_to_find.keys()
+                    content_artifact__in=artifacts_to_find.keys(), size__isnull=False
                 ).values_list("content_artifact_id", "size")
                 sizes.update({artifacts_to_find[ra_ca_id]: size for ra_ca_id, size in r_artifacts})
 


### PR DESCRIPTION
fixes: #5318

Like the issue said in the template we used to ignored the `None` sizes with the previous if condition, but now that we don't we should filter out the nulls. We can't really test this in pulp_file since on_demand syncs always know what the size of the artifact will be. Only in other plugins were they don't know can this bug be tested.