### PR TITLE
Stop task cleanup to delete Contents and Artifacts

### DIFF
--- a/CHANGES/5363.bugfix
+++ b/CHANGES/5363.bugfix
@@ -1,0 +1,2 @@
+Stopped deleting content and artifacts presumably created by later failed or canceled tasks.
+Deleting these lies solely in the responsibility of orphan cleanup.

--- a/pulpcore/tasking/_util.py
+++ b/pulpcore/tasking/_util.py
@@ -15,7 +15,7 @@ from django.db.models import Q
 from django.utils import timezone
 from django_guid import set_guid
 from django_guid.utils import generate_guid
-from pulpcore.app.models import Task, TaskSchedule
+from pulpcore.app.models import Artifact, Content, Task, TaskSchedule
 from pulpcore.app.role_util import get_users_with_perms
 from pulpcore.app.util import (
     set_current_user,
@@ -73,6 +73,8 @@ def delete_incomplete_resources(task):
     if task.state != TASK_STATES.CANCELING:
         raise RuntimeError(_("Task must be canceling."))
     for model in (r.content_object for r in task.created_resources.all()):
+        if isinstance(model, (Artifact, Content)):
+            continue
         try:
             if model.complete:
                 continue


### PR DESCRIPTION
These shared objects that may not even have been created by that task must only ever be deleted inside of orphan cleanup. That's the rule.

fixes #5363