### PR TITLE
Stop task cleanup to delete Contents and Artifacts

### DIFF
--- a/CHANGES/5363.bugfix
+++ b/CHANGES/5363.bugfix
@@ -1,0 +1,2 @@
+Stopped deleting content and artifacts presumably created by later failed or canceled tasks.
+Deleting these lies solely in the responsibility of orphan cleanup.

--- a/pulpcore/tasking/util.py
+++ b/pulpcore/tasking/util.py
@@ -4,7 +4,7 @@ from gettext import gettext as _
 from django.db import transaction
 from django.db import connection
 
-from pulpcore.app.models import Task
+from pulpcore.app.models import Artifact, Content, Task
 from pulpcore.constants import TASK_FINAL_STATES, TASK_INCOMPLETE_STATES, TASK_STATES
 
 _logger = logging.getLogger(__name__)
@@ -60,6 +60,8 @@ def _delete_incomplete_resources(task):
     if task.state not in [TASK_STATES.CANCELED, TASK_STATES.CANCELING]:
         raise RuntimeError(_("Task must be canceled."))
     for model in (r.content_object for r in task.created_resources.all()):
+        if isinstance(model, (Artifact, Content)):
+            continue
         try:
             if model.complete:
                 continue


### PR DESCRIPTION
These shared objects that may not even have been created by that task must only ever be deleted inside of orphan cleanup. That's the rule.

fixes #5363

(cherry picked from commit fb47f3c1f9773c29af13d814ebcbe703a6f72928) (cherry picked from commit ec26ffef3422610032777b488879cad4c1b6e887)