### PR TITLE
Replica - stop assuming every plugin supports publications

### DIFF
--- a/CHANGES/5464.bugfix
+++ b/CHANGES/5464.bugfix
@@ -1,0 +1,2 @@
+Pulpcore no longer assumes that every plugin implementing the Replication feature supports
+Publications.

--- a/pulpcore/app/replica.py
+++ b/pulpcore/app/replica.py
@@ -94,7 +94,9 @@ class Replicator:
         return {}
 
     def create_or_update_remote(self, upstream_distribution):
-        if not upstream_distribution["repository"] and not upstream_distribution["publication"]:
+        if not upstream_distribution.get("repository") and not upstream_distribution.get(
+            "publication"
+        ):
             return None
         url = self.url(upstream_distribution)
         remote_fields_dict = {"url": url}


### PR DESCRIPTION
Pulpcore no longer assumes that every plugin which implements support for the Replication feature supports publications (e.g. container doesn't).

closes #5464