### PR TITLE
Add a sentinal value to CONTENT_ORIGIN

### DIFF
--- a/CHANGES/5510.bugfix
+++ b/CHANGES/5510.bugfix
@@ -1,0 +1,1 @@
+Fixed openapi command where plugins relied on CONTENT_ORIGIN to be set.

--- a/pulpcore/app/checks.py
+++ b/pulpcore/app/checks.py
@@ -7,7 +7,7 @@ from django.core.checks import Error as CheckError, Warning as CheckWarning, reg
 @register(deploy=True)
 def content_origin_check(app_configs, **kwargs):
     messages = []
-    if not getattr(settings, "CONTENT_ORIGIN", None):
+    if getattr(settings, "CONTENT_ORIGIN", "UNREACHABLE") == "UNREACHABLE":
         messages.append(
             CheckError(
                 "CONTENT_ORIGIN is a required setting but it was not configured. This may be "

--- a/pulpcore/app/settings.py
+++ b/pulpcore/app/settings.py
@@ -248,6 +248,8 @@ LOGGING = {
 
 DRF_ACCESS_POLICY = {"reusable_conditions": ["pulpcore.app.global_access_conditions"]}
 
+# This is a sentinal value for deploy checks, since we don't want to set a default one.
+CONTENT_ORIGIN = "UNREACHABLE"
 CONTENT_PATH_PREFIX = "/pulp/content/"
 
 API_APP_TTL = 120  # The heartbeat is called from gunicorn notify (defaulting to 45 sec).


### PR DESCRIPTION
This helps circumventing issues where plugins rely on the setting, but a command is bypassing the checks.

fixes #5510