### PR TITLE
Provide more task info during test failures

### DIFF
--- a/pulpcore/tests/functional/utils.py
+++ b/pulpcore/tests/functional/utils.py
@@ -28,7 +28,7 @@ except ImportError:
 
         def __init__(self, task):
             """Provide task info to exception."""
-            description = task.to_dict()["error"].get("description")
+            description = task.to_dict()
             super().__init__(self, f"Pulp task failed ({description})")
             self.task = task
 


### PR DESCRIPTION
We're trying to debug a test failure in the CI that we can't reproduce locally:

https://github.com/pulp/pulp_deb/actions/runs/9898615528/job/27345874499?pr=1061#step:15:3505

Part of the challenge in debugging this is that there's not enough information to go on because the CI is only outputting the task error description. Not sure if there's a better way to handle this but in these cases it seems like printing the entire task details somehow would be more helpful.

[noissue]