### PR TITLE
Fix old content being persistent on the website server

### DIFF
--- a/.github/workflows/scripts/publish-staging-docs.sh
+++ b/.github/workflows/scripts/publish-staging-docs.sh
@@ -24,7 +24,7 @@ mkdir -p ../staging-docs.pulpproject.org
 tar -xvf staging-docs.pulpproject.org.tar --directory ../staging-docs.pulpproject.org
 pushd ../staging-docs.pulpproject.org
 
-# publish to staging-docs.pulpproject.org
-rsync -avzh site/ doc_builder_staging_pulp_core@docs.pulpproject.org:/var/www/docs.pulpproject.org/staging_pulp_core/
+# publish to pulpproject.org
+rsync -avzh --delete site/ doc_builder_staging_pulp_core@docs.pulpproject.org:/var/www/docs.pulpproject.org/staging_pulp_core/
 
 popd


### PR DESCRIPTION
The current `rsync` command only adds new content to the server, it doesn't remove old files that are no longer being built. Because of that, we have left-overs from older build, such as https://pulpproject.org/pulp-cli/changes/changelog/

The `--delete` option deletes files in <target> that are not present in <source> anymore ([reference](https://explainshell.com/explain?cmd=rsync+--delete)).

**DISCLAIMER:** I've barely used rsync in my life