### PR TITLE
Bump dynaconf upper bounds

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -16,7 +16,7 @@ djangorestframework-queryfields>=1.0,<=1.1.0
 drf-access-policy>=1.1.2,<1.5.1
 drf-nested-routers>=0.93.4,<=0.93.5
 drf-spectacular==0.26.5  # We monkeypatch this so we need a very narrow requirement string
-dynaconf>=3.1.12,<3.2.5
+dynaconf>=3.2.5,<3.3.0
 gunicorn>=20.1,<22.1.0
 importlib-metadata>=6.0.1,<=6.0.1  # Pinned to fix opentelemetry dependency solving issues with pip
 jinja2>=3.1,<=3.1.4


### PR DESCRIPTION
Dynaconf 3.2.6 comes with a performance fix on Access Hook Feature.

When access hooks are registered, DRF openapispec was taking long time to build.

https://github.com/dynaconf/dynaconf/releases/tag/3.2.6

[noissue]