### PR TITLE
Bump Dynaconf UB to <3.3.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -16,7 +16,7 @@ djangorestframework-queryfields>=1.0,<=1.1.0
 drf-access-policy>=1.1.2,<1.5.1
 drf-nested-routers>=0.93.4,<=0.94.1
 drf-spectacular==0.27.2  # We monkeypatch this so we need a very narrow requirement string
-dynaconf>=3.1.12,<3.2.6
+dynaconf>=3.1.12,<3.3.0
 gunicorn>=20.1,<22.1.0
 importlib-metadata>=6.0.1,<=6.0.1  # Pinned to fix opentelemetry dependency solving issues with pip
 jinja2>=3.1,<=3.1.4


### PR DESCRIPTION
Reason: [3.2.6](https://github.com/dynaconf/dynaconf/releases/tag/3.2.6) comes with important performance fix.

[noissue]


The problem was only observed if the application enabled Access Hooks (enabled on galaxy_ng to alter hostname settings upon access)


Before

```
$ time curl -s http://localhost:5001/api/galaxy/v3/openapi.json 2>&1 > /dev/null

real    0m41.374s
user    0m0.012s
sys     0m0.008s
```

After

```
$ time curl -s http://localhost:5001/api/galaxy/v3/openapi.json 2>&1 > /dev/null

real	0m2.969s
user	0m0.003s
sys	0m0.006s
```