### PR TITLE
[3.49]Bump Dynaconf UB to <3.3.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -16,7 +16,7 @@ djangorestframework-queryfields>=1.0,<=1.1.0
 drf-access-policy>=1.1.2,<1.5.1
 drf-nested-routers>=0.93.4,<=0.93.5
 drf-spectacular==0.26.5  # We monkeypatch this so we need a very narrow requirement string
-dynaconf>=3.1.12,<3.2.5
+dynaconf>=3.1.12,<3.3.0
 gunicorn>=20.1,<22.1.0
 importlib-metadata>=6.0.1,<=6.0.1  # Pinned to fix opentelemetry dependency solving issues with pip
 jinja2>=3.1,<=3.1.4


### PR DESCRIPTION
Reason: 3.2.6 comes with important performance fix.

[noissue]

(cherry picked from commit fd6c397783b84c584fd53cb35ce45e0ab3a3f64d)