### PR TITLE
Casts a repo object before checking permission

### DIFF
--- a/CHANGES/5619.bugfix
+++ b/CHANGES/5619.bugfix
@@ -1,0 +1,2 @@
+Fixed a bug in `has_repo_or_repo_ver_param_model_or_obj_perms` function to make
+it work with plugin Repositories.

--- a/pulpcore/app/global_access_conditions.py
+++ b/pulpcore/app/global_access_conditions.py
@@ -479,9 +479,9 @@ def has_repo_or_repo_ver_param_model_or_obj_perms(request, view, action, permiss
     )
     serializer.is_valid(raise_exception=True)
     if repository := serializer.validated_data.get("repository"):
-        return request.user.has_perm(permission, repository)
+        return request.user.has_perm(permission, repository.cast())
     elif repo_ver := serializer.validated_data.get("repository_version"):
-        return request.user.has_perm(permission, repo_ver.repository)
+        return request.user.has_perm(permission, repo_ver.repository.cast())
     return True
 
 


### PR DESCRIPTION
This change is similar to #4933, but for the condition function where domain is not enabled.
[noissue]

fixes: #5619