### PR TITLE
Fix incorrect RBAC permissions in object creation tasks

### DIFF
--- a/CHANGES/5683.bugfix
+++ b/CHANGES/5683.bugfix
@@ -1,0 +1,2 @@
+Fixed RBAC permissions being incorrectly assigned in tasks that create objects.
+https://access.redhat.com/security/cve/cve-2024-7143

--- a/pulpcore/app/models/task.py
+++ b/pulpcore/app/models/task.py
@@ -13,6 +13,7 @@ from django.contrib.postgres.fields import ArrayField, HStoreField
 from django.core.serializers.json import DjangoJSONEncoder
 from django.db import connection, models
 from django.utils import timezone
+from django_lifecycle import hook, AFTER_CREATE
 
 from pulpcore.app.models import (
     AutoAddObjPermsMixin,
@@ -137,6 +138,11 @@ class Task(BaseModel, AutoAddObjPermsMixin):
             pulpcore.app.models.Task: The current task.
         """
         return current_task.get()
+
+    @hook(AFTER_CREATE)
+    def add_role_dispatcher(self):
+        """Set the "core.task_user_dispatcher" role for the current user after creation."""
+        self.add_roles_for_object_creator("core.task_user_dispatcher")
 
     def set_running(self):
         """

--- a/pulpcore/app/viewsets/task.py
+++ b/pulpcore/app/viewsets/task.py
@@ -142,6 +142,10 @@ class TaskViewSet(
             ],
         },
         "core.task_viewer": ["core.view_task"],
+        # This is a special role to designate the user who dispatched the task, it is assigned to
+        # the user on the object-level at task creation. It is not meant to be edited or manually
+        # added/removed from users.
+        "core.task_user_dispatcher": ["core.add_task"],
     }
 
     def get_serializer(self, *args, **kwargs):
@@ -190,6 +194,11 @@ class TaskViewSet(
                 ),
                 Prefetch("child_tasks", queryset=Task.objects.only("pk")),
             )
+        if self.action in ("add_role", "remove_role"):
+            if "core.task_user_dispatcher" == self.request.data.get("role"):
+                raise ValidationError(
+                    _("core.task_user_dispatcher can not be added/removed from a task.")
+                )
         return qs
 
     @extend_schema(

--- a/pulpcore/tasking/_util.py
+++ b/pulpcore/tasking/_util.py
@@ -134,7 +134,26 @@ def perform_task(task_pk, task_working_dir_rel_path):
     # All processes need to create their own postgres connection
     connection.connection = None
     task = Task.objects.select_related("pulp_domain").get(pk=task_pk)
-    user = get_users_with_perms(task, with_group_users=False).first()
+    # These queries were specifically constructed and ordered this way to ensure we have the highest
+    # chance of getting the user who dispatched the task since we don't have a user relation on the
+    # task model. The second query acts as a fallback to provide ZDU support. Future changes will
+    # require to keep these around till a breaking change release is planned (3.70 the earliest).
+    user = (
+        get_users_with_perms(
+            task,
+            only_with_perms_in=["core.add_task"],
+            with_group_users=False,
+            include_model_permissions=False,
+            include_domain_permissions=False,
+        ).first()
+        or get_users_with_perms(
+            task,
+            only_with_perms_in=["core.manage_roles_task"],
+            with_group_users=False,
+            include_model_permissions=False,
+            include_domain_permissions=False,
+        ).first()
+    )
     # Isolate from the parent asyncio.
     asyncio.set_event_loop(asyncio.new_event_loop())
     # Set current contexts


### PR DESCRIPTION
fixes: #5683
https://access.redhat.com/security/cve/cve-2024-7143 (cherry picked from commit 20cffca49de5f3bfac44e0160c1f0fb262141ea5)