### PR TITLE
Fix incorrect RBAC permissions in object creation tasks

### DIFF
--- a/CHANGES/5683.bugfix
+++ b/CHANGES/5683.bugfix
@@ -1,0 +1,2 @@
+Fixed RBAC permissions being incorrectly assigned in tasks that create objects.
+https://access.redhat.com/security/cve/cve-2024-7143

--- a/pulpcore/app/models/task.py
+++ b/pulpcore/app/models/task.py
@@ -13,6 +13,7 @@ from django.contrib.postgres.fields import ArrayField, HStoreField
 from django.core.serializers.json import DjangoJSONEncoder
 from django.db import connection, models
 from django.utils import timezone
+from django_lifecycle import hook, AFTER_CREATE
 
 from pulpcore.app.models import (
     AutoAddObjPermsMixin,
@@ -142,6 +143,11 @@ class Task(BaseModel, AutoAddObjPermsMixin):
             pulpcore.app.models.Task: The current task.
         """
         return current_task.get()
+
+    @hook(AFTER_CREATE)
+    def add_role_dispatcher(self):
+        """Set the "core.task_user_dispatcher" role for the current user after creation."""
+        self.add_roles_for_object_creator("core.task_user_dispatcher")
 
     def set_running(self):
         """

--- a/pulpcore/app/viewsets/task.py
+++ b/pulpcore/app/viewsets/task.py
@@ -142,6 +142,10 @@ class TaskViewSet(
             ],
         },
         "core.task_viewer": ["core.view_task"],
+        # This is a special role to designate the user who dispatched the task, it is assigned to
+        # the user on the object-level at task creation. It is not meant to be edited or manually
+        # added/removed from users.
+        "core.task_user_dispatcher": ["core.add_task"],
     }
 
     def get_serializer(self, *args, **kwargs):
@@ -190,6 +194,11 @@ class TaskViewSet(
                 ),
                 Prefetch("child_tasks", queryset=Task.objects.only("pk")),
             )
+        if self.action in ("add_role", "remove_role"):
+            if "core.task_user_dispatcher" == self.request.data.get("role"):
+                raise ValidationError(
+                    _("core.task_user_dispatcher can not be added/removed from a task.")
+                )
         return qs
 
     @extend_schema(

--- a/pulpcore/tasking/_util.py
+++ b/pulpcore/tasking/_util.py
@@ -129,7 +129,26 @@ def perform_task(task_pk, task_working_dir_rel_path):
     # All processes need to create their own postgres connection
     connection.connection = None
     task = Task.objects.select_related("pulp_domain").get(pk=task_pk)
-    user = get_users_with_perms(task, with_group_users=False).first()
+    # These queries were specifically constructed and ordered this way to ensure we have the highest
+    # chance of getting the user who dispatched the task since we don't have a user relation on the
+    # task model. The second query acts as a fallback to provide ZDU support. Future changes will
+    # require to keep these around till a breaking change release is planned (3.70 the earliest).
+    user = (
+        get_users_with_perms(
+            task,
+            only_with_perms_in=["core.add_task"],
+            with_group_users=False,
+            include_model_permissions=False,
+            include_domain_permissions=False,
+        ).first()
+        or get_users_with_perms(
+            task,
+            only_with_perms_in=["core.manage_roles_task"],
+            with_group_users=False,
+            include_model_permissions=False,
+            include_domain_permissions=False,
+        ).first()
+    )
     # Isolate from the parent asyncio.
     asyncio.set_event_loop(asyncio.new_event_loop())
     # Set current contexts

--- a/pulpcore/tests/functional/api/test_tasking.py
+++ b/pulpcore/tests/functional/api/test_tasking.py
@@ -349,3 +349,40 @@ def test_task_version_prevent_pickup(dispatch_task, tasks_api_client):
         task = tasks_api_client.read(task_href)
         assert task.state == "waiting"
         tasks_api_client.tasks_cancel(task_href, {"state": "canceled"})
+
+
+@pytest.mark.parallel
+def test_correct_task_ownership(
+    dispatch_task, users_roles_api_client, gen_user, file_repository_factory
+):
+    """Test that tasks get the correct ownership when dispatched."""
+    alice = gen_user(model_roles=["core.task_viewer"])
+    bob = gen_user(model_roles=["file.filerepository_creator"])
+
+    with alice:
+        atask_href = dispatch_task("pulpcore.app.tasks.test.sleep", args=(0,))
+    aroles = users_roles_api_client.list(alice.user.pulp_href)
+    assert aroles.count == 3
+    roles = {r.role: r.content_object for r in aroles.results}
+    correct_roles = {
+        "core.task_owner": atask_href,
+        "core.task_user_dispatcher": atask_href,
+        "core.task_viewer": None,
+    }
+    assert roles == correct_roles
+
+    with bob:
+        btask_href = dispatch_task("pulpcore.app.tasks.test.sleep", args=(0,))
+        repo = file_repository_factory()
+    aroles = users_roles_api_client.list(alice.user.pulp_href)
+    assert aroles.count == 3
+    broles = users_roles_api_client.list(bob.user.pulp_href)
+    assert broles.count == 4
+    roles = {r.role: r.content_object for r in broles.results}
+    correct_roles = {
+        "core.task_owner": btask_href,
+        "core.task_user_dispatcher": btask_href,
+        "file.filerepository_owner": repo.pulp_href,
+        "file.filerepository_creator": None,
+    }
+    assert roles == correct_roles


### PR DESCRIPTION
fixes: #5683
https://access.redhat.com/security/cve/cve-2024-7143 (cherry picked from commit 20cffca49de5f3bfac44e0160c1f0fb262141ea5) (cherry picked from commit 4922cb22405d11c3a7d44f72c8db06ae76c94c3d)