### PR TITLE
Fix incorrect RBAC permissions in object creation tasks

### DIFF
--- a/CHANGES/5683.bugfix
+++ b/CHANGES/5683.bugfix
@@ -1,0 +1,2 @@
+Fixed RBAC permissions being incorrectly assigned in tasks that create objects.
+https://access.redhat.com/security/cve/cve-2024-7143

--- a/pulpcore/app/models/task.py
+++ b/pulpcore/app/models/task.py
@@ -13,6 +13,7 @@ from django.contrib.postgres.fields import ArrayField, HStoreField
 from django.core.serializers.json import DjangoJSONEncoder
 from django.db import connection, models
 from django.utils import timezone
+from django_lifecycle import hook, AFTER_CREATE
 
 from pulpcore.app.models import (
     AutoAddObjPermsMixin,
@@ -224,6 +225,11 @@ class Task(BaseModel, AutoAddObjPermsMixin):
             pulpcore.app.models.Task: The current task.
         """
         return current_task.get()
+
+    @hook(AFTER_CREATE)
+    def add_role_dispatcher(self):
+        """Set the "core.task_user_dispatcher" role for the current user after creation."""
+        self.add_roles_for_object_creator("core.task_user_dispatcher")
 
     def set_running(self):
         """

--- a/pulpcore/app/viewsets/task.py
+++ b/pulpcore/app/viewsets/task.py
@@ -143,6 +143,10 @@ class TaskViewSet(
             ],
         },
         "core.task_viewer": ["core.view_task"],
+        # This is a special role to designate the user who dispatched the task, it is assigned to
+        # the user on the object-level at task creation. It is not meant to be edited or manually
+        # added/removed from users.
+        "core.task_user_dispatcher": ["core.add_task"],
     }
 
     def get_serializer(self, *args, **kwargs):
@@ -191,6 +195,11 @@ class TaskViewSet(
                 ),
                 Prefetch("child_tasks", queryset=Task.objects.only("pk")),
             )
+        if self.action in ("add_role", "remove_role"):
+            if "core.task_user_dispatcher" == self.request.data.get("role"):
+                raise ValidationError(
+                    _("core.task_user_dispatcher can not be added/removed from a task.")
+                )
         return qs
 
     @extend_schema(


### PR DESCRIPTION
fixes: #5683
https://access.redhat.com/security/cve/cve-2024-7143 (cherry picked from commit 20cffca49de5f3bfac44e0160c1f0fb262141ea5) (cherry picked from commit 4922cb22405d11c3a7d44f72c8db06ae76c94c3d) (cherry picked from commit f1841136d6f758736e330cd06a446eed6a067607)