### PR TITLE
General admonition fixes on docs

### DIFF
--- a/docs/admin/guides/auth/external.md
+++ b/docs/admin/guides/auth/external.md
@@ -92,6 +92,7 @@ Pulp provides a setting named `REMOTE_USER_ENVIRON_NAME <remote-user-environ-nam
 you to specify another WSGI environment variable to read the authenticated username from.
 
 !!! warning
+
     Configuring this has serious security implications. See the [Django warning at the end of this
     section in their docs](https://docs.djangoproject.com/en/4.2/howto/auth-remote-user/#configuration) for more details.
 

--- a/docs/admin/guides/sign-metadata.md
+++ b/docs/admin/guides/sign-metadata.md
@@ -28,9 +28,9 @@ are relative paths inside the current working directory:
 The filename must remain the same for the detached signature, as shown.
 
 !!! note
-      Plugins may provide other signing service classes that may need their JSON output to
-      contain different information.
 
+    Plugins may provide other signing service classes that may need their JSON output to
+    contain different information.
 
 Below is an example of a signing script that produces signatures for content:
 
@@ -58,11 +58,11 @@ fi
 ```
 
 !!! note
-      As the creator of the signing script, you can expect PULP_SIGNING_KEY_FINGERPRINT
-      and potentially other environment variables, depending on the content plugin calling signing service.
-      Make sure the script contains a proper shebang and Pulp has got valid permissions
-      to execute it.
 
+    As the creator of the signing script, you can expect PULP_SIGNING_KEY_FINGERPRINT
+    and potentially other environment variables, depending on the content plugin calling signing service.
+    Make sure the script contains a proper shebang and Pulp has got valid permissions
+    to execute it.
 
 ## 3. Create a signing service
 
@@ -77,14 +77,14 @@ pulpcore-manager add-signing-service ${SERVICE_NAME} ${SCRIPT_ABS_FILENAME} ${KE
 ```
 
 !!! note
-      The public key must be available on the caller's keyring or on a keyring provided via the
-      `--gpghome` or `--keyring` parameters.
 
+    The public key must be available on the caller's keyring or on a keyring provided via the
+    `--gpghome` or `--keyring` parameters.
 
 !!! warning
-      It is possible to insert a new signing service into the database by using the
-      `pulpcore-manager shell_plus` interactive Python shell. However, this is not recommended.
 
+    It is possible to insert a new signing service into the database by using the
+    `pulpcore-manager shell_plus` interactive Python shell. However, this is not recommended.
 
 ## 4. Check the signing service
 

--- a/docs/admin/reference/settings.md
+++ b/docs/admin/reference/settings.md
@@ -233,9 +233,9 @@ Store cached responses from the content app into Redis. This setting improves th
 of the content app under heavy load for similar requests. Defaults to `False`.
 
 !!! note
-The entire response is not stored in the cache. Only the location of the file needed to
-recreate the response is stored. This reduces database queries and allows for many
-responses to be stored inside the cache.
+    The entire response is not stored in the cache. Only the location of the file needed to
+    recreate the response is stored. This reduces database queries and allows for many
+    responses to be stored inside the cache.
 
 
 ### CACHE_SETTINGS

--- a/docs/dev/guides/git.md
+++ b/docs/dev/guides/git.md
@@ -23,10 +23,11 @@ The `git commit --amend` command is very useful, but be sure that you [understan
 GitHub will update the PR and keep the comments when you force push an amended commit.
 
 !!! warning
-Keep in mind that rebasing creates new commits that are unique from your
-original commits. Thus, if you have three commits and rebase them, you must
-make sure that all copies of those original commits get deleted. Did you push
-your branch to origin? Delete it and re-push after the rebase.
+
+    Keep in mind that rebasing creates new commits that are unique from your
+    original commits. Thus, if you have three commits and rebase them, you must
+    make sure that all copies of those original commits get deleted. Did you push
+    your branch to origin? Delete it and re-push after the rebase.
 
 
 
@@ -56,8 +57,9 @@ closes #1392
 ```
 
 !!! tip
-A good candidate for a `noissue` tag is a one line fix or a typo, otherwise we encourage
-you to open an issue.
+
+    A good candidate for a `noissue` tag is a one line fix or a typo, otherwise we encourage
+    you to open an issue.
 
 
 

--- a/docs/dev/guides/plugin-walkthrough.md
+++ b/docs/dev/guides/plugin-walkthrough.md
@@ -72,7 +72,8 @@ in the `object-relationships` section:
   corresponding {class}`~pulpcore.plugin.models.Artifact` is downloaded
 
 !!! note
-Some of these steps may need to behave differently for other download policies.
+
+    Some of these steps may need to behave differently for other download policies.
 
 
 The remote implementation suggestion above allows plugin writer to have an understanding and

--- a/docs/dev/learn/domains/domains_compatibility.md
+++ b/docs/dev/learn/domains/domains_compatibility.md
@@ -29,10 +29,11 @@ class FileContent(Content):
 ```
 
 !!! note
-Child content models need a separate domain relation since Postgres does not allow
-`unique_together` on fields from the parent table. The base `Content` model has a
-`pulp_domain` relation already, so the child content model must use an underscore to prevent
-a name collision.
+
+    Child content models need a separate domain relation since Postgres does not allow
+    `unique_together` on fields from the parent table. The base `Content` model has a
+    `pulp_domain` relation already, so the child content model must use an underscore to prevent
+    a name collision.
 
 
 ## Ensure any Custom Action Serializer Prevents Cross-Domain Parameters

--- a/docs/dev/learn/other/content-protection.md
+++ b/docs/dev/learn/other/content-protection.md
@@ -23,9 +23,9 @@ Master/Detail objects a `TYPE` class attribute is needed which is then used in t
 ```
 
 !!! note
-The [pulp-certguard](site:pulp_certguard/) plugin ships various
-`ContentGuard` types for users and plugin writers to use together. Plugins can ship their own
-content guards too, but look at the existing ones first.
+    The [pulp-certguard](site:pulp_certguard/) plugin ships various
+    `ContentGuard` types for users and plugin writers to use together. Plugins can ship their own
+    content guards too, but look at the existing ones first.
 
 
 ## Simple Example

--- a/docs/dev/learn/other/how-to-doc-api.md
+++ b/docs/dev/learn/other/how-to-doc-api.md
@@ -35,11 +35,11 @@ class CustomView(APIView):
 ```
 
 !!! note
-`Meta.ref_name` is a string that is used as the model definition name for
-the serializer class. If this attribute is not specified, all serializers
-have an implicit name derived from their class name. In order to avoid
-possible name collisions between plugins, plugins must define `ref_name`
-on the Meta class using `<app_label>.` as a prefix.
+    `Meta.ref_name` is a string that is used as the model definition name for
+    the serializer class. If this attribute is not specified, all serializers
+    have an implicit name derived from their class name. In order to avoid
+    possible name collisions between plugins, plugins must define `ref_name`
+    on the Meta class using `<app_label>.` as a prefix.
 
 For the model based serializers offered by pulpcore (i.e.
 {class}`~pulpcore.plugin.serializers.ModelSerializer` and derived
@@ -61,7 +61,8 @@ class SnippetSerializerV1(serializers.Serializer):
 
 
 !!! note
-Plugin authors can provide manual overrides using the [@extend_schema decorator](https://drf-spectacular.readthedocs.io/en/stable/drf_spectacular.html#drf_spectacular.utils.extend_schema)
+    Plugin authors can provide manual overrides using the
+    [@extend_schema decorator](https://drf-spectacular.readthedocs.io/en/stable/drf_spectacular.html#drf_spectacular.utils.extend_schema)
 
 
 The OpenAPI schema for pulpcore and all installed plugins can be downloaded from the `pulp-api`

--- a/docs/dev/learn/other/metadata-signing.md
+++ b/docs/dev/learn/other/metadata-signing.md
@@ -16,11 +16,11 @@ the `validate()` method (which must be implemented by each subclass), and the `s
 calls the `validate()` method, but is otherwise fully implemented).
 
 !!! note
-The `sign()` function will be calling the provided script to give the administrator the
-freedom to define, how the signature is obtained. It is their responsibility to setup the
-software or hardware facilities for signing and make the script use them. The plugin writer
-however should provide a reasonably easy default script based on e.g. a simple call to `gpg`.
 
+    The `sign()` function will be calling the provided script to give the administrator the
+    freedom to define, how the signature is obtained. It is their responsibility to setup the
+    software or hardware facilities for signing and make the script use them. The plugin writer
+    however should provide a reasonably easy default script based on e.g. a simple call to `gpg`.
 
 In order to sign metadata, plugin writers are required to call the `sign()` method of the signing service
 being used. This method invokes the signing script (or other executable) which is provided by the
@@ -32,11 +32,12 @@ any signatures, signature files, and return values, as required by the individua
 This is why implementing a signing service model other than `AsciiArmoredDetachedSigningService` simply
 requires inheriting from `SiginingService` and then implementing `validate()`.
 
-!!! note
 The existing `AsciiArmoredDetachedSigningService` requires a signing script that creates a detached
 ascii-armored signature file, and prints valid JSON in the following format to stdout:
 
-> {"file": "filename", "signature": "filename.asc"}
+```json
+{"file": "filename", "signature": "filename.asc"}
+```
 
 Here "filename" is a path to the original file that was signed (passed to the signing script by the
 `sign()` method), and "filename.asc" is a path to the signature file created by the script.

--- a/docs/dev/learn/other/on-demand-support.md
+++ b/docs/dev/learn/other/on-demand-support.md
@@ -34,10 +34,10 @@ async def run(self):
 ```
 
 !!! tip
-The `deferred_download` flag is used at the artifact level, to support on-demand concepts for
-plugins that need some artifacts to download immediately in all cases.
-See also `multi-level-discovery`.
 
+    The `deferred_download` flag is used at the artifact level, to support on-demand concepts for
+    plugins that need some artifacts to download immediately in all cases.
+    See also `multi-level-discovery`.
 
 ## Adding Support when using a Custom Stages API Pipeline
 
@@ -58,14 +58,14 @@ stages.extend(the_rest_of_the_pipeline)  # This adds the Content and Association
 ```
 
 !!! warning
-Skipping of those Stages does not work with `multi-level-discovery`.
-If you need some artifacts downloaded anyway, follow the example on
-\:ref:on-demand-support-with-dv\` and include the artifact stages in the custom pipeline.
 
+    Skipping of those Stages does not work with `multi-level-discovery`.
+    If you need some artifacts downloaded anyway, follow the example on
+    \:ref:on-demand-support-with-dv\` and include the artifact stages in the custom pipeline.
 
 !!! tip
-Consider to also exclude the `ResolveContentFutures` stage.
 
+    Consider to also exclude the `ResolveContentFutures` stage.
 
 ## What if the Custom Pipeline Needs Artifact Downloading?
 
@@ -78,7 +78,8 @@ By specifying `deferred_download=False` in the `DeclarativeArtifact` regardless 
 policy, lazy downloading for that specific artifact can be prohibited.
 
 !!! tip
-See also `on-demand-support-with-da`
+
+    See also `on-demand-support-with-da`
 
 
 ## How Does This Work at the Model Layer?
@@ -104,9 +105,10 @@ If `remote.policy == Remote.ON_DEMAND` the Artifact is saved on the first downlo
 future requests to serve the already-downloaded and validated Artifact.
 
 !!! note
-In situations where multiple Remotes synced and provided the same `Content` unit, only one
-`Content` unit is created but many `RemoteArtifact` objects may be created. The Pulp Content app
-will try all `RemoteArtifact` objects that correspond with a `ContentArtifact`. It's possible an
-unexpected `Remote` could be used when fetching that equivalent `Content` unit. Similar warnings
-are in the user documentation on on-demand.
+
+    In situations where multiple Remotes synced and provided the same `Content` unit, only one
+    `Content` unit is created but many `RemoteArtifact` objects may be created. The Pulp Content app
+    will try all `RemoteArtifact` objects that correspond with a `ContentArtifact`. It's possible an
+    unexpected `Remote` could be used when fetching that equivalent `Content` unit. Similar warnings
+    are in the user documentation on on-demand.
 

--- a/docs/dev/learn/plugin-concepts.md
+++ b/docs/dev/learn/plugin-concepts.md
@@ -224,12 +224,13 @@ In case a task was marked for immediate execution, but the reservations were not
 be left in the task queue or marked as canceled, depending on the `deferred` attribute.
 
 !!! warning
-A task marked for immediate execution will not be isolated in the `pulpcore-worker`, but may
-be executed in the current api worker. This will not only delay the response to the http call,
-but also the complete single threaded gunicorn process. To prevent degrading the whole Pulp
-service, this is only ever allowed for tasks that guarantee to perform fast **and** without
-blocking on external resources. E.g. simple attribute updates, deletes... A model with a lot of
-dependants that cause cascaded deletes may not be suitable for immediate execution.
+
+    A task marked for immediate execution will not be isolated in the `pulpcore-worker`, but may
+    be executed in the current api worker. This will not only delay the response to the http call,
+    but also the complete single threaded gunicorn process. To prevent degrading the whole Pulp
+    service, this is only ever allowed for tasks that guarantee to perform fast **and** without
+    blocking on external resources. E.g. simple attribute updates, deletes... A model with a lot of
+    dependants that cause cascaded deletes may not be suitable for immediate execution.
 
 
 **Diagnostics**
@@ -530,9 +531,10 @@ Then in 3.9 the following happens:
    removed.
 
 !!! note
-Deprecation log statements are shown to users of your plugin when using a deprecated call
-interface. This is by design to raise general awareness that the code in-use will eventually be
-removed.
+
+    Deprecation log statements are shown to users of your plugin when using a deprecated call
+    interface. This is by design to raise general awareness that the code in-use will eventually be
+    removed.
 
 
 This also applies to models importable from `pulpcore.plugin.models`. For example, an attribute
@@ -591,13 +593,13 @@ import and use Django directly, but pulpcore also includes Django. Since your pl
 directly, your plugin should declare its dependency on Django.
 
 !!! note
-Why add a requirement when pulpcore is known to provide it? To continue with the Django
-example... Django can introduce breaking changes with each release, so if your plugin relies on
-pulpcore to declare the Django requirement, and then pulpcore upgrades, your plugin could
-receive breaking changes with a new version of pulpcore. These breaking changes could be subtle
-and not be noticeable until they affect your users. By your plugin declaring the dependency on
-Django directly, at install/upgrade time (in the CI), you'll know right away you have a
-conflicting dependency on Django.
+    Why add a requirement when pulpcore is known to provide it? To continue with the Django
+    example... Django can introduce breaking changes with each release, so if your plugin relies on
+    pulpcore to declare the Django requirement, and then pulpcore upgrades, your plugin could
+    receive breaking changes with a new version of pulpcore. These breaking changes could be subtle
+    and not be noticeable until they affect your users. By your plugin declaring the dependency on
+    Django directly, at install/upgrade time (in the CI), you'll know right away you have a
+    conflicting dependency on Django.
 
 
 One useful tool for managing the upperbound is [dependabot](https://github.com/dependabot) which
@@ -629,11 +631,12 @@ is allowed to handle. This includes two types of "checksum handling":
    data used in those publications to the set of allowed hashers in `ALLOWED_CONTENT_CHECKSUMS`.
 
 !!! note
-The plugin API provides the `pulpcore.plugin.pulp_hashlib` module which provides the `new`
-function. This is a wrapper around `hashlib.new` which raises an exception if a hasher is
-requested that is not listed in the `ALLOWED_CONTENT_CHECKSUMS` setting. This is a convenience
-facility allowing plugin writers to not check the `ALLOWED_CONTENT_CHECKSUMS` setting
-themselves.
+
+    The plugin API provides the `pulpcore.plugin.pulp_hashlib` module which provides the `new`
+    function. This is a wrapper around `hashlib.new` which raises an exception if a hasher is
+    requested that is not listed in the `ALLOWED_CONTENT_CHECKSUMS` setting. This is a convenience
+    facility allowing plugin writers to not check the `ALLOWED_CONTENT_CHECKSUMS` setting
+    themselves.
 
 
 (il8n-expectations)=
@@ -733,7 +736,8 @@ breaking signature change in tasking code and if this is needed you need to make
 preserve the old code until the next major Pulp version.
 
 !!! note
-Users not performing zero downtime upgrades who are still wary of any task incompatibilities,
-should consider running the pulpcore worker in burst mode (`pulpcore-worker --burst`) after
-shutting down all the api and content workers to drain the task queue.
+
+    Users not performing zero downtime upgrades who are still wary of any task incompatibilities,
+    should consider running the pulpcore worker in burst mode (`pulpcore-worker --burst`) after
+    shutting down all the api and content workers to drain the task queue.
 

--- a/docs/dev/learn/rbac/access_policy.md
+++ b/docs/dev/learn/rbac/access_policy.md
@@ -1,5 +1,3 @@
-
-
 # Defining an Access Policy
 
 The Access Policy controls the authorization of a given request and is enforced at the
@@ -10,7 +8,7 @@ described here](https://rsinger86.github.io/drf-access-policy/policy_logic/).
 
 Below is an example policy used by `FileRemote`, with an explanation of its effect below that:
 
-```
+```python
 [
     {
         "action": ["list"],
@@ -75,15 +73,17 @@ When multiple conditions are present, **all** of them must return True for the r
 authorized.
 
 !!! note
-If you are making your plugin compatible with Domains, then use the `has_model_or_domain_perms`
-and `has_model_or_domain_or_obj_perms` checks where appropriate.
+
+    If you are making your plugin compatible with Domains, then use the `has_model_or_domain_perms`
+    and `has_model_or_domain_or_obj_perms` checks where appropriate.
 
 
 !!! warning
-The `admin` user created on installations prior to RBAC being enabled has
-`is_superuser=True`. Django assumes a superuser has any model-level permission even without it
-being assigned. Django's permission checking machinery assumes superusers bypass authorization
-checks.
+
+    The `admin` user created on installations prior to RBAC being enabled has
+    `is_superuser=True`. Django assumes a superuser has any model-level permission even without it
+    being assigned. Django's permission checking machinery assumes superusers bypass authorization
+    checks.
 
 
 ## Custom ViewSet Actions
@@ -92,7 +92,7 @@ The `action` part of a policy statement can reference [any custom action your vi
 For example `FileRepositoryViewSet` has a `sync` custom action used by users to sync a given
 `FileRepository`. Below is an example of the default policy used to guard that action:
 
-```
+```python
 {
     "action": ["sync"],
     "principal": "authenticated",
@@ -108,13 +108,8 @@ For example `FileRepositoryViewSet` has a `sync` custom action used by users to 
 
 ## Storing an Access Policy in the DB
 
-All access policies are stored in the database in the `pulpcore.plugin.models.AccessPolicy` model,
-which stores the policy statements described above. Here is a look at the `AccessPolicy` model:
-
-```{eval-rst}
-.. autoclass:: pulpcore.plugin.models.AccessPolicy
-   :members: viewset_name, statements, creation_hooks
-```
+All access policies are stored in the database in the [pulpcore.plugin.models.AccessPolicy][] model,
+which stores the policy statements described above.
 
 By storing these in the database they are readable to users with a GET to
 `/pulp/api/v3/access_policies/`. Additionally users can PUT/PATCH modify them at
@@ -137,7 +132,7 @@ Here's an example of code to define a default policy:
 ```python
 class FileRemoteViewSet(RemoteViewSet):
 
-<...>
+    # <...>
     DEFAULT_ACCESS_POLICY = {
         "statements": [
             {
@@ -190,7 +185,7 @@ class FileRemoteViewSet(RemoteViewSet):
 ```
 
 For an explanation of the `creation_hooks` see the
-`shipping_a_default_new_object_policy` documentation.
+[Shipping a default new object policy](site:pulpcore/docs/dev/learn/rbac/adding_automatic_permissions/#shipping-a-default-new-object-policy) documentation.
 
 The attribute `LOCKED_ROLES` contains roles that are managed by the plugin author. Their name
 needs to be prefixed by the plugins `app_label` with a dot to prevent collisions. Roles defined
@@ -283,15 +278,8 @@ to be globally available. Pulp enables this as follows:
 DRF_ACCESS_POLICY = {"reusable_conditions": ["pulpcore.app.global_access_conditions"]}
 ```
 
-The `pulpcore.app.global_access_conditions` provides the following checks that are available for
-both users and plugin writers to use in their policies:
-
-```{eval-rst}
-.. automodule:: pulpcore.app.global_access_conditions
-   :members:
-
-```
-
+The [pulpcore.app.global_access_conditions][]
+provides several checks that are available for both users and plugin writers to use in their policies.
 
 
 ## Custom Permission Checks
@@ -307,3 +295,11 @@ DRF_ACCESS_POLICY = {
 ```
 
 to their `app.settings` module.
+
+---
+
+## Reference
+
+::: pulpcore.plugin.models.AccessPolicy
+
+::: pulpcore.app.global_access_conditions

--- a/docs/dev/learn/rbac/adding_automatic_permissions.md
+++ b/docs/dev/learn/rbac/adding_automatic_permissions.md
@@ -1,5 +1,3 @@
-
-
 # Adding Automatic Permissions for New Objects
 
 When creating new objects in either viewsets or tasks it's important to have the right permissions.
@@ -62,8 +60,9 @@ example assigning the `"core.task_viewer"` role to the group `"foo"`.
 ```
 
 !!! note
-All the hooks shipped with pulpcore accept either a single item or list of items for their
-arguments like `roles`, `users` or `groups`.
+
+    All the hooks shipped with pulpcore accept either a single item or list of items for their
+    arguments like `roles`, `users` or `groups`.
 
 
 
@@ -71,20 +70,12 @@ arguments like `roles`, `users` or `groups`.
 ## Enabling New Object Permission Creation
 
 To enable automatic permission creation for an object managed by an AccessPolicy, have your model
-use the `pulpcore.plugin.models.AutoAddObjPermsMixin`. See the example below as an example:
+use the [pulpcore.plugin.models.AutoAddObjPermsMixin][]. See the example below as an example:
 
 ```python
 class MyModel(BaseModel, AutoAddObjPermsMixin):
    ...
 ```
-
-See the docstring below for more information on this mixin.
-
-```{eval-rst}
-.. autoclass:: pulpcore.app.models.access_policy.AutoAddObjPermsMixin
-
-```
-
 
 
 ## Shipping a Default New Object Policy
@@ -151,5 +142,11 @@ This would be callable with a configuration like this one:
 ```
 
 !!! note
-The `parameters` dict must actually match the creation hooks signature.
 
+    The `parameters` dict must actually match the creation hooks signature.
+
+---
+
+## Reference
+
+::: pulpcore.plugin.models.AutoAddObjPermsMixin

--- a/docs/dev/learn/rbac/index.md
+++ b/docs/dev/learn/rbac/index.md
@@ -40,7 +40,8 @@ To add authorization for a given resource, e.g. `FileRemote`, you'll need to:
 2. Define the `roles` as sets of permissions for that resource.
 3. Define the default role associations created for new objects using the `creation_hooks`
    attribute of the new Access Policy for the resource. See the
-   `adding_automatic_permissions_for_new_objects` documentation for more information on that.
+   [Adding Automatic Permissions](site:pulpcore/docs/dev/learn/rbac/adding_automatic_permissions/)
+   documentation for more information on that.
 4. Ship that Access Policy as the class attribute `DEFAULT_ACCESS_POLICY` of a
    `NamedModelViewSet`. This will contain the `statements` and `creation_hooks` attributes.
    Ship the roles as the `LOCKED_ROLES` attribute accordingly. See the

--- a/docs/dev/learn/rbac/permissions.md
+++ b/docs/dev/learn/rbac/permissions.md
@@ -67,8 +67,9 @@ class FileRepository(Repository):
 ```
 
 !!! note
-It is not necessary to "namespace" this `modify_repo_content` permission because by including
-it in the meta class of your Detail view, it will already be namespaced on the correct object.
+
+    It is not necessary to "namespace" this `modify_repo_content` permission because by including
+    it in the meta class of your Detail view, it will already be namespaced on the correct object.
 
 
 
@@ -81,18 +82,17 @@ the permissions to view modify and delete the object, or `viewer` limited to see
 scope the reach of the permissions in a role, these role are assigned to `Users` or `Groups`
 either on the model-level, domain-level (if domains are enabled), or the object-level.
 
-```{eval-rst}
+### Role Levels
 
-FileRemotes".
-:Domain-Level: When the domains feature is enabled, a role is associated to a user or group for
-    access to a specific model within the specific domain and only that domain. This allows you
-    to express concepts like "Hilde can administer all FileRemotes within Domain 'foo'".
-:Object-Level: A role is associated to a user or group for access to a specific instance of a
-   specific model. This allows you to express concepts like "Hilde can administer
-   FileRemote(name='foo remote').
+Domain-Level
+: When the domains feature is enabled, a role is associated to a user or group for
+access to a specific model within the specific domain and only that domain. This allows you
+to express concepts like "Hilde can administer all FileRemotes within Domain 'foo'".
 
-Certain roles may contain permissions that are only ever checked on the model(or domain)-level.
-```
+Object-Level
+: A role is associated to a user or group for access to a specific instance of a
+specific model. This allows you to express concepts like "Hilde can administer
+FileRemote(name='foo remote').
 
 Certain roles may contain permissions that are only ever checked on the model(or domain)-level.
 For example the `creator` role for a model that contains the models `add` permission.
@@ -112,10 +112,16 @@ LOCKED_ROLES = {
 }
 ```
 
-Roles come in two flavors, locked and user-defined. First there are so called locked roles that are
+### Locked and User-Defined
+
+Roles come in two flavors, locked and user-defined.
+
+First there are so called locked roles that are
 provided by plugins. Their name needs to be prefixed by the plugin `app_label` followed by a dot
 (see the example above). They can be seen, but not modified via the api, and are kept up to date
 with their definition in the plugin code. That way, plugins can ship default access policies that
-rely on those roles. The other flavor is user defined roles. These are managed via the Pulp
+rely on those roles.
+
+The other flavor is user defined roles. These are managed via the Pulp
 API, and plugin code will not interfere with them. Users can opt to use the provided locked roles or
 roll their own.

--- a/docs/dev/learn/rbac/queryset_scoping.md
+++ b/docs/dev/learn/rbac/queryset_scoping.md
@@ -1,5 +1,3 @@
-
-
 # Restricting Viewable Objects
 
 With limited object-level permissions on certain objects, its desirable to restrict the objects
@@ -11,8 +9,9 @@ filter on the base Queryset of a ViewSet. This causes the permission filtering t
 filterings applied by a user.
 
 !!! note
-If Domains are enabled, querysets will be scoped by the current request's domain before being
-passed onto RBAC queryset scoping.
+
+    If Domains are enabled, querysets will be scoped by the current request's domain before being
+    passed onto RBAC queryset scoping.
 
 
 
@@ -27,7 +26,7 @@ Pulp's default permission class, `pulpcore.app.AccessPolicyFromDB`, implementati
 defined. This field can be changed by the user to any method on the ViewSet or set empty if they
 wish to turn off Queryset Scoping for that view:
 
-```
+```python
 DEFAULT_ACCESS_POLICY = {
     ...
     # Call method `scope_queryset` on ViewSet to perform Queryset Scoping
@@ -44,7 +43,7 @@ model-level or object-level.
 For example Tasks are restricted only to those users with the "core.view_task" permission like
 this:
 
-```
+```python
 TaskViewSet(NamedModelViewSet):
     ...
     queryset_filtering_required_permission = "core.view_task"
@@ -60,9 +59,10 @@ Content ViewSet's have their `scope_queryset` method overriden to scope based on
 the user can see.
 
 !!! note
-When queryset scoping is enabled for content you must also use the
-`has_required_repo_perms_on_upload` access condition on the upload endpoint to ensure users
-specify a repository for upload or they won't be able to see their uploaded content.
+
+    When queryset scoping is enabled for content you must also use the
+    `has_required_repo_perms_on_upload` access condition on the upload endpoint to ensure users
+    specify a repository for upload or they won't be able to see their uploaded content.
 
 
 Extra Queryset Scoping methods can be defined on the ViewSet to allow users to choose different
@@ -109,7 +109,8 @@ class MyViewSet(rest_framework.viewsets.GenericViewSet):
 ```
 
 !!! warning
-If you have custom ViewSets and plan to add Domains compatibility to your plugin, you must
-scope your objects by the domain in the ViewSet's `get_queryset` method to comply
-with Domain's isolation policies.
+
+    If you have custom ViewSets and plan to add Domains compatibility to your plugin, you must
+    scope your objects by the domain in the ViewSet's `get_queryset` method to comply
+    with Domain's isolation policies.
 

--- a/docs/dev/learn/rbac/users_groups.md
+++ b/docs/dev/learn/rbac/users_groups.md
@@ -1,15 +1,13 @@
-
-
 # Users and Groups
 
 Users and Groups are always stored in the Django database. This is a requirement so that `Roles` and
 `Permissions` can relate to them.
 
-```{eval-rst}
+User
+: Provided by Django with the `django.contrib.auth.models.User` model.
 
-:User: Provided by Django with the ``django.contrib.auth.models.User`` model.
-:Group: Provided by Django with the ``django.contrib.auth.models.Group`` model.
-```
+Group
+: Provided by Django with the `django.contrib.auth.models.Group` model.
 
 Any role can be assigned to either users, groups, or both. This includes both Model-level and
 Object-level role assignments. Direct permission assignments are not recommended and cannot be

--- a/docs/dev/learn/subclassing/models.md
+++ b/docs/dev/learn/subclassing/models.md
@@ -5,13 +5,13 @@
 For the most part, models provided by plugin writers are just regular [Django Models](https://docs.djangoproject.com/en/2.1/topics/db/models/).
 
 !!! note
-One slight variation is that the validation is primarily handled in the Django Rest Framework
-Serializer. `.clean()` is not called.
+    One slight variation is that the validation is primarily handled in the Django Rest Framework
+    Serializer. `.clean()` is not called.
 
 
 Most plugins will implement:
-: - model(s) for the specific content type(s) used in the plugin, should be subclassed from Content model
-  - model(s) for the plugin specific remote(s), should be subclassed from Remote model
+- model(s) for the specific content type(s) used in the plugin, should be subclassed from Content model
+- model(s) for the plugin specific remote(s), should be subclassed from Remote model
 
 ## Adding Model Fields
 
@@ -21,7 +21,7 @@ for your fields. See the [Django field documentation](https://docs.djangoproject
 using these fields.
 
 !!! note
-It is required to declare the `default_related_name`.
+    It is required to declare the `default_related_name`.
 
 
 The TYPE class attribute is used for filtering purposes.
@@ -50,8 +50,8 @@ pulpcore-manager migrate
 ```
 
 !!! warning
-Do not use settings directly in the model fields, it will lead to a data migration that is
-specific to the users installation in case those settings change.
+    Do not use settings directly in the model fields, it will lead to a data migration that is
+    specific to the users installation in case those settings change.
 
 
 If you recognize this syntax, it is because pulpcore-manager is `manage.py` configured with

--- a/docs/dev/learn/subclassing/viewsets.md
+++ b/docs/dev/learn/subclassing/viewsets.md
@@ -57,13 +57,13 @@ this is accomplished.
 See {class}`~pulpcore.plugin.tasking.dispatch` for more details.
 
 !!! note
-The arguments provided to a task must be JSON serializable, but may contain instances of
-`uuid.UUID`.
+    The arguments provided to a task must be JSON serializable, but may contain instances of
+    `uuid.UUID`.
 
 
 !!! note
-You should always prefer handing primary keys instead of serialized instances of ORM objects to
-a task.
+    You should always prefer handing primary keys instead of serialized instances of ORM objects to
+    a task.
 
 
 ```python
@@ -135,6 +135,6 @@ If any additional context needs to be passed from the ViewSet to the creation ta
 available as `self.context` in the Serializer.
 
 !!! note
-Context passed from the ViewSet to the Task must be easily serializable. i.e. one cannot
-return the request from `get_deferred_context`.
+    Context passed from the ViewSet to the Task must be easily serializable. i.e. one cannot
+    return the request from `get_deferred_context`.
 

--- a/docs/dev/learn/sync_pipeline/sync_pipeline.md
+++ b/docs/dev/learn/sync_pipeline/sync_pipeline.md
@@ -61,13 +61,14 @@ the content to the next stage. The function `resolve()` will unblock the corouti
 attached `Future`.
 
 !!! tip
-To improve performance when you expect to create a lot of those futures, consider to
-create a larger batch before starting to await them. This way the batching in the subsequent
-stages will still be exploited.
 
+    To improve performance when you expect to create a lot of those futures, consider to
+    create a larger batch before starting to await them. This way the batching in the subsequent
+    stages will still be exploited.
 
 !!! tip
-If you need downloaded artifacts of this content for further discovery, make sure to
-provide `deferred_download=False` to the
-{class}`pulpcore.plugin.stages.DeclarativeArtifact`.
+
+    If you need downloaded artifacts of this content for further discovery, make sure to
+    provide `deferred_download=False` to the
+    {class}`pulpcore.plugin.stages.DeclarativeArtifact`.
 

--- a/docs/dev/learn/tasks/add-remove.md
+++ b/docs/dev/learn/tasks/add-remove.md
@@ -23,18 +23,16 @@ with repository.new_version() as new_version:
 ```
 
 !!! warning
-Any action that adds/removes content to a repository *must* create a new RepositoryVersion.
-Every action that creates a new RepositoryVersion *must* be asynchronous (defined as a task).
-Task reservations are necessary to prevent race conditions.
 
-
-
+    Any action that adds/removes content to a repository *must* create a new RepositoryVersion.
+    Every action that creates a new RepositoryVersion *must* be asynchronous (defined as a task).
+    Task reservations are necessary to prevent race conditions.
 
 ## Synchronizing
 
 !!! tip
-Please consider using the high level `stages-concept-docs` for actual implementations.
 
+    Please consider using the high level `stages-concept-docs` for actual implementations.
 
 Most plugins will define a synchronize task, which fetches content from a remote repository, and
 adds it to a Pulp repository.

--- a/docs/reference/api-reference/download.md
+++ b/docs/reference/api-reference/download.md
@@ -93,16 +93,16 @@ See the {class}`~pulpcore.plugin.download.DownloaderFactory` for more informatio
 supported urls.
 
 !!! tip
-The {meth}`~pulpcore.plugin.models.Remote.get_downloader` accepts kwargs that can
-enable size or digest based validation, and specifying a file-like object for the data to be
-written into. See {meth}`~pulpcore.plugin.models.Remote.get_downloader` for more
-information.
+    The {meth}`~pulpcore.plugin.models.Remote.get_downloader` accepts kwargs that can
+    enable size or digest based validation, and specifying a file-like object for the data to be
+    written into. See {meth}`~pulpcore.plugin.models.Remote.get_downloader` for more
+    information.
 
 
 !!! note
-All {class}`~pulpcore.plugin.download.HttpDownloader` downloaders produced by the same
-remote instance share an `aiohttp` session, which provides a connection pool, connection
-reusage and keep-alives shared across all downloaders produced by a single remote.
+    All {class}`~pulpcore.plugin.download.HttpDownloader` downloaders produced by the same
+    remote instance share an `aiohttp` session, which provides a connection pool, connection
+    reusage and keep-alives shared across all downloaders produced by a single remote.
 
 
 
@@ -128,8 +128,8 @@ Plugin writers can choose to halt the entire task by allowing the exception be u
 would mark the entire task as failed.
 
 !!! note
-The {class}`~pulpcore.plugin.download.HttpDownloader` automatically retry in some cases, but if
-unsuccessful will raise an exception for any HTTP response code that is 400 or greater.
+    The {class}`~pulpcore.plugin.download.HttpDownloader` automatically retry in some cases, but if
+    unsuccessful will raise an exception for any HTTP response code that is 400 or greater.
 
 
 
@@ -169,16 +169,16 @@ The {meth}`~pulpcore.plugin.download.DownloaderFactory.build` method constructs 
 downloader for any given url.
 
 !!! note
-Any `HttpDownloader <http-downloader>` objects produced by an instantiated
-`DownloaderFactory` share an `aiohttp` session, which provides a connection pool, connection
-reusage and keep-alives shared across all downloaders produced by a single factory.
+    Any `HttpDownloader <http-downloader>` objects produced by an instantiated
+    `DownloaderFactory` share an `aiohttp` session, which provides a connection pool, connection
+    reusage and keep-alives shared across all downloaders produced by a single factory.
 
 
 !!! tip
-The {meth}`~pulpcore.plugin.download.DownloaderFactory.build` method accepts kwargs that
-enable size or digest based validation or the specification of a file-like object for the data
-to be written into. See {meth}`~pulpcore.plugin.download.DownloaderFactory.build` for
-more information.
+    The {meth}`~pulpcore.plugin.download.DownloaderFactory.build` method accepts kwargs that
+    enable size or digest based validation or the specification of a file-like object for the data
+    to be written into. See {meth}`~pulpcore.plugin.download.DownloaderFactory.build` for
+    more information.
 
 
 ```{eval-rst}

--- a/docs/user/guides/create-domains.md
+++ b/docs/user/guides/create-domains.md
@@ -36,7 +36,7 @@ Current Domain Compatible Plugins:
 - pulp_certguard>=1.6.0
 
 !!! warning
-Before turning on domains, you should let all currently running tasks finished.
+    Before turning on domains, you should let all currently running tasks finished.
 
 ## Creating Domains
 


### PR DESCRIPTION
This does:
- On dev rbac pages
  - re-linked links that were not converted and were in the format `` `some-link` ``
  - added some code reference links with `[path.to.module][]`. Will work more on this on other PR
- Fixed general admonitions with wrong indent level.

Fixes some of https://github.com/pulp/pulpcore/issues/5496