### PR TITLE
Backport task schedule test improvement

### DIFF
--- a/pulpcore/tests/functional/api/test_workers.py
+++ b/pulpcore/tests/functional/api/test_workers.py
@@ -104,6 +104,7 @@ def test_task_schedule(task_schedule, task_schedules_api_client):
     # Worker TTL is configured to 30s, therefore they will have a heartbeat each 10s (6 bpm). The
     # task is scheduled 5s in the future to give us time to invesitgate the state before and after.
     # 16s later we can be sure it was scheduled (as long as at least one worker is running).
+    # Waiting for 18s to give some more slack.
 
     result = task_schedules_api_client.list(name=task_schedule["name"])
     assert result.count == 1
@@ -112,7 +113,7 @@ def test_task_schedule(task_schedule, task_schedules_api_client):
     assert ts.task_name == task_schedule["task_name"]
     assert ts.last_task is None
     # At least a worker heartbeat is needed
-    for i in range(16):
+    for i in range(18):
         sleep(1)
         ts = task_schedules_api_client.read(task_schedule_href=ts.pulp_href)
         if ts.last_task is not None:


### PR DESCRIPTION
The timing in the task schedule tests seems to be a bit tight, leading to a flakey test. By adding two extra seconds waiting time, the test should be reliable again.

[noissue]