### PR TITLE
Use secrets.choice for SECRET_KEY documentation sample

### DIFF
--- a/docs/admin/reference/settings.md
+++ b/docs/admin/reference/settings.md
@@ -27,10 +27,10 @@ provided.
 The following code snippet can be used to generate a random SECRET_KEY.
 
 ```python linenums="1"
-import random
+import secrets
 
 chars = 'abcdefghijklmnopqrstuvwxyz0123456789!@#$%^&*(-_=+)'
-print(''.join(random.choice(chars) for i in range(50)))
+print(''.join(secrets.choice(chars) for i in range(50)))
 ```
 
 ### DB_ENCRYPTION_KEY


### PR DESCRIPTION
This function is essentially `get_random_secret_key` from Django, extracted to a standalone function. Django [switched](https://github.com/django/django/commit/1d0bab0bfd77edcf1228d45bf654457a8ff1890d) from `random.choice` to `secrets.choice` with Django 3.0. Probably because the secrets module is only available on Python 3.6+.