### PR TITLE
Fix memory spike on repository delete

### DIFF
--- a/CHANGES/5048.bugfix
+++ b/CHANGES/5048.bugfix
@@ -1,0 +1,1 @@
+Fix a memory spike on deletion of large repositories.

--- a/pulpcore/app/models/publication.py
+++ b/pulpcore/app/models/publication.py
@@ -151,33 +151,29 @@ class Publication(MasterModel):
         Notes:
             Deletes the Task.created_resource when complete is False.
         """
+        # invalidate cache
+        if settings.CACHE_ENABLED:
+            # Find any publications being served directly
+            base_paths = self.distribution_set.values_list("base_path", flat=True)
+            # Find any publications being served indirectly by auto-distribute feature
+            # It's possible for errors to occur before any publication has been completed,
+            # so we need to handle the case when no Publication exists.
+            try:
+                versions = self.repository.versions.all()
+                pubs = Publication.objects.filter(repository_version__in=versions, complete=True)
+                publication = pubs.latest("repository_version", "pulp_created")
+                if self.pk == publication.pk:
+                    base_paths |= self.repository.distributions.values_list("base_path", flat=True)
+            except Publication.DoesNotExist:
+                pass
+
+            # Invalidate cache for all distributions serving this publication
+            if base_paths:
+                Cache().delete(base_key=cache_key(base_paths))
+
         with transaction.atomic():
-            # invalidate cache
-            if settings.CACHE_ENABLED:
-                # Find any publications being served directly
-                base_paths = self.distribution_set.values_list("base_path", flat=True)
-                # Find any publications being served indirectly by auto-distribute feature
-                # It's possible for errors to occur before any publication has been completed,
-                # so we need to handle the case when no Publication exists.
-                try:
-                    versions = self.repository.versions.all()
-                    pubs = Publication.objects.filter(
-                        repository_version__in=versions, complete=True
-                    )
-                    publication = pubs.latest("repository_version", "pulp_created")
-                    if self.pk == publication.pk:
-                        base_paths |= self.repository.distributions.values_list(
-                            "base_path", flat=True
-                        )
-                except Publication.DoesNotExist:
-                    pass
-
-                # Invalidate cache for all distributions serving this publication
-                if base_paths:
-                    Cache().delete(base_key=cache_key(base_paths))
-
             CreatedResource.objects.filter(object_id=self.pk).delete()
-            super().delete(**kwargs)
+            return super().delete(**kwargs)
 
     def finalize_new_publication(self):
         """


### PR DESCRIPTION
Django handles cascade deletes itself (as opposed to letting the database handle it) and in doing so it pulls a lot of data out, resulting in a memory spike on repository deletion.

The only solution is to write a custom cascade delete that deletes the objects at the bottom of the cascade tree more incrementally.

closes https://github.com/pulp/pulpcore/pull/2280