### PR TITLE
Fixed logging issues with task state transitions

### DIFF
--- a/CHANGES/+task_cancelling.bugfix
+++ b/CHANGES/+task_cancelling.bugfix
@@ -1,0 +1,1 @@
+Fixed a logging issue, when a task marked for cancelling that finished produced an unecessary stack trace.


### PR DESCRIPTION
This will log the task pk as well as the original state. Also it is now considered an OK situation if a cancelling task was attempted to be completed by it's worker.