### PR TITLE
Revert "Fix URL encoding issue in HttpDownloader to handle special characters"

### DIFF
--- a/CHANGES/5686.bugfix
+++ b/CHANGES/5686.bugfix
@@ -1,1 +1,0 @@
-Implemented a more robust URL encoding mechanism ensuring that special characters are processed correctly.

--- a/pulp_file/pytest_plugin.py
+++ b/pulp_file/pytest_plugin.py
@@ -102,16 +102,6 @@ def basic_manifest_path(write_3_iso_file_fixture_data_factory):
 
 
 @pytest.fixture
-def encoded_manifest_path(file_fixtures_root):
-    file_fixtures_root.joinpath("encoded").mkdir()
-    file1 = generate_iso(file_fixtures_root.joinpath("encoded/long-name-%253a-encoded.iso"))
-    file2 = generate_iso(file_fixtures_root.joinpath("encoded/another-%25-encoded.iso"))
-    file3 = generate_iso(file_fixtures_root.joinpath("encoded/more-%3C-encoded.iso"))
-    generate_manifest(file_fixtures_root.joinpath("encoded/PULP_MANIFEST"), [file1, file2, file3])
-    return "/encoded/PULP_MANIFEST"
-
-
-@pytest.fixture
 def copy_manifest_only_factory(file_fixtures_root):
     def _copy_manifest_only(name):
         file_fixtures_root.joinpath(f"{name}-manifest").mkdir()

--- a/pulp_file/tests/functional/api/test_sync.py
+++ b/pulp_file/tests/functional/api/test_sync.py
@@ -124,21 +124,6 @@ def test_duplicate_file_sync(
 
 
 @pytest.mark.parallel
-def test_encoded_file_name(
-    file_repo, file_bindings, encoded_manifest_path, file_remote_factory, monitor_task
-):
-    remote = file_remote_factory(manifest_path=encoded_manifest_path, policy="immediate")
-    body = RepositorySyncURL(remote=remote.pulp_href)
-    monitor_task(file_bindings.RepositoriesFileApi.sync(file_repo.pulp_href, body).task)
-    file_repo = file_bindings.RepositoriesFileApi.read(file_repo.pulp_href)
-
-    version = file_bindings.RepositoriesFileVersionsApi.read(file_repo.latest_version_href)
-    assert version.content_summary.present["file.file"]["count"] == 3
-    assert version.content_summary.added["file.file"]["count"] == 3
-    assert file_repo.latest_version_href.endswith("/1/")
-
-
-@pytest.mark.parallel
 def test_filepath_includes_commas(
     file_bindings,
     file_repo,

--- a/pulpcore/download/http.py
+++ b/pulpcore/download/http.py
@@ -3,7 +3,6 @@ import logging
 import aiohttp
 import asyncio
 import backoff
-import urllib.parse
 
 from .base import BaseDownloader, DownloadResult
 from pulpcore.exceptions import (
@@ -48,14 +47,6 @@ def http_giveup_handler(exc):
 
     # any other type of error (pre-filtered by the backoff decorator) shouldn't be fatal
     return False
-
-
-def encode_url(url):
-    """Helper function to encode only the path part of the URL."""
-    parsed_url = urllib.parse.urlparse(url)
-    encoded_path = urllib.parse.quote(parsed_url.path)
-    encoded_url = parsed_url._replace(path=encoded_path).geturl()
-    return encoded_url
 
 
 class HttpDownloader(BaseDownloader):
@@ -293,9 +284,8 @@ class HttpDownloader(BaseDownloader):
         """
         if self.download_throttler:
             await self.download_throttler.acquire()
-        encoded_url = encode_url(self.url)
         async with self.session.get(
-            encoded_url, proxy=self.proxy, proxy_auth=self.proxy_auth, auth=self.auth
+            self.url, proxy=self.proxy, proxy_auth=self.proxy_auth, auth=self.auth
         ) as response:
             self.raise_for_status(response)
             to_return = await self._handle_response(response)

--- a/pulpcore/pytest_plugin.py
+++ b/pulpcore/pytest_plugin.py
@@ -10,7 +10,6 @@ import ssl
 import subprocess
 import threading
 import uuid
-import urllib.parse
 
 import pytest
 
@@ -322,19 +321,11 @@ def gen_threaded_aiohttp_server(fixtures_cfg, unused_port):
 @pytest.fixture
 def gen_fixture_server(gen_threaded_aiohttp_server):
     def _gen_fixture_server(fixtures_root, ssl_ctx):
-        app = web.Application(middlewares=[_aiohttp_request_middleware])
+        app = web.Application()
         call_record = add_recording_route(app, fixtures_root)
         return gen_threaded_aiohttp_server(app, ssl_ctx, call_record)
 
     yield _gen_fixture_server
-
-
-@web.middleware
-async def _aiohttp_request_middleware(request, handler):
-    unquoted_url = urllib.parse.unquote(request.url.human_repr())
-    url = urllib.parse.urlparse(unquoted_url)
-    response = await handler(request.clone(rel_url=url.path))
-    return response
 
 
 # Proxy Fixtures


### PR DESCRIPTION
Reverts pulp/pulpcore#5809

Per comment (https://github.com/pulp/pulpcore/pull/5809#issuecomment-2368283179) this was breaking already existing functionality, we need to think some more about this.