### PR TITLE
Rename Replicator distribution_data to distribution_extra_fields

### DIFF
--- a/CHANGES/plugin_api/3649.deprecation
+++ b/CHANGES/plugin_api/3649.deprecation
@@ -1,0 +1,2 @@
+Deprecated Replicator's `distribution_data`, plugins should switch to `distribution_extra_fields`.
+`distribution_data` will be removed in pulpcore==3.70.


### PR DESCRIPTION
fixes: #3649

Container currently uses the `distribution_data` so deprecating it now to be removed later. https://github.com/pulp/pulp_container/blob/1a8fe634dba25b6adacd17459da3be931e37ae74/pulp_container/app/replica.py#L41