### PR TITLE
Removes opentelemetry-instrumentation-django from requirements.txt

### DIFF
--- a/CHANGES/5843.bugfix
+++ b/CHANGES/5843.bugfix
@@ -1,0 +1,1 @@
+Removed opentelemetry-instrumentation-django from dependencies.

--- a/requirements.txt
+++ b/requirements.txt
@@ -27,7 +27,6 @@ jq>=1.6.0,<1.9.0
 PyOpenSSL<25.0
 opentelemetry-distro[otlp]>=0.45b0,<=0.48b0
 opentelemetry-exporter-otlp-proto-http>=1.24.0,<=1.27.0
-opentelemetry-instrumentation-django>=0.45b0,<=0.48b0
 opentelemetry-instrumentation-wsgi>=0.45b,<=0.48b0
 protobuf>=4.21.1,<5.0
 pulp-glue>=0.18.0,<0.30


### PR DESCRIPTION
closes: #5843