### PR TITLE
Collect artifact size metrics after caching the content

### DIFF
--- a/CHANGES/5817.bugfix
+++ b/CHANGES/5817.bugfix
@@ -1,0 +1,1 @@
+Started collecting artifact size metrics even after caching the served content.

--- a/pulpcore/app/util.py
+++ b/pulpcore/app/util.py
@@ -1,6 +1,7 @@
 import hashlib
 import zlib
 import os
+import socket
 import tempfile
 import gnupg
 
@@ -656,6 +657,11 @@ def init_domain_metrics_exporter():
 
     for domain in Domain.objects.all():
         DomainMetricsEmitter.build(domain)
+
+
+@lru_cache(maxsize=1)
+def get_worker_name():
+    return f"{os.getpid()}@{socket.gethostname()}"
 
 
 class PGAdvisoryLock:

--- a/pulpcore/cache/cache.py
+++ b/pulpcore/cache/cache.py
@@ -21,6 +21,8 @@ from pulpcore.app.redis_connection import (
 )
 from pulpcore.responses import ArtifactResponse
 
+from pulpcore.metrics import artifacts_size_counter
+
 DEFAULT_EXPIRES_TTL = settings.CACHE_SETTINGS["EXPIRES_TTL"]
 
 
@@ -352,6 +354,10 @@ class AsyncContentCache(AsyncCache):
                 response = await self.make_entry(
                     key, bk, func, args, kwargs, self.default_expires_ttl
                 )
+
+            if size := response.headers.get("X-PULP-ARTIFACT-SIZE"):
+                artifacts_size_counter.add(size)
+
             return response
 
         return cached_function

--- a/pulpcore/metrics.py
+++ b/pulpcore/metrics.py
@@ -1,0 +1,23 @@
+from opentelemetry import metrics
+
+from pulpcore.app.util import MetricsEmitter, get_domain, get_worker_name
+
+
+class ArtifactsSizeCounter(MetricsEmitter):
+    def __init__(self):
+        self.meter = metrics.get_meter("artifacts.size.meter")
+        self.counter = self.meter.create_counter(
+            "artifacts.size.counter",
+            unit="Bytes",
+            description="Counts the size of served artifacts",
+        )
+
+    def add(self, amount):
+        attributes = {
+            "domain_name": get_domain().name,
+            "worker_process": get_worker_name(),
+        }
+        self.counter.add(int(amount), attributes)
+
+
+artifacts_size_counter = ArtifactsSizeCounter.build()


### PR DESCRIPTION
The caching machinery stores all headers from the response coming from content-handler. With this commit, we are introducing an proprietary header that contains the size of the served artifact or artifact available after the redirect, X-PULP-ARTIFACT-SIZE.

closes #5817

(cherry picked from commit e709de5c91629e4a77daf0160f8c8f4fd4cef66b)