### PR TITLE
Emit the name of the Pulp service in all default metrics

### DIFF
--- a/CHANGES/5864.bugfix
+++ b/CHANGES/5864.bugfix
@@ -1,0 +1,2 @@
+Fixed the name of the metrics' attribute reporting the worker's process name. Started emitting the
+name of the Pulp service with a dedicated label (i.e., job=pulp-api).

--- a/pulpcore/app/wsgi.py
+++ b/pulpcore/app/wsgi.py
@@ -17,6 +17,7 @@ from opentelemetry.sdk.metrics.export import PeriodicExportingMetricReader
 
 from pulpcore.app.entrypoint import using_pulp_api_worker
 from pulpcore.app.util import get_worker_name
+from opentelemetry.sdk.resources import Resource
 
 if not using_pulp_api_worker.get(False):
     raise RuntimeError("This app must be executed using pulpcore-api entrypoint.")
@@ -27,16 +28,17 @@ class WorkerNameMetricsExporter(OTLPMetricExporter):
         for resource_metric in metrics_data.resource_metrics:
             for scope_metric in resource_metric.scope_metrics:
                 for metric in scope_metric.metrics:
-                    if metric.name == "http.server.duration":
-                        histogram_data = metric.data.data_points[0]
-                        histogram_data.attributes["worker.process"] = get_worker_name()
+                    if metric.data.data_points:
+                        point = metric.data.data_points[0]
+                        point.attributes["worker.name"] = get_worker_name()
 
         return super().export(metrics_data, timeout_millis, **kwargs)
 
 
 exporter = WorkerNameMetricsExporter()
 reader = PeriodicExportingMetricReader(exporter)
-provider = MeterProvider(metric_readers=[reader])
+resource = Resource(attributes={"service.name": "pulp-api"})
+provider = MeterProvider(metric_readers=[reader], resource=resource)
 
 application = get_wsgi_application()
 application = OpenTelemetryMiddleware(application, meter_provider=provider)


### PR DESCRIPTION
In addition to that, this commit fixes the attribute's name used for reporting the name of the worker process.

closes #5864