### PR TITLE
Propagate response headers when using Azure, S3 or GCP storage

### DIFF
--- a/CHANGES/5879.bugfix
+++ b/CHANGES/5879.bugfix
@@ -1,0 +1,1 @@
+Started propagating headers from the content-app when using a non-default filesystem storage.

--- a/pulpcore/content/handler.py
+++ b/pulpcore/content/handler.py
@@ -1002,12 +1002,12 @@ class Handler:
         elif not domain.redirect_to_object_storage:
             return ArtifactResponse(content_artifact.artifact, headers=headers)
         elif domain.storage_class == "storages.backends.s3boto3.S3Boto3Storage":
-            raise HTTPFound(_build_url(http_method=request.method))
+            raise HTTPFound(_build_url(http_method=request.method), headers=headers)
         elif domain.storage_class in (
             "storages.backends.azure_storage.AzureStorage",
             "storages.backends.gcloud.GoogleCloudStorage",
         ):
-            raise HTTPFound(_build_url())
+            raise HTTPFound(_build_url(), headers=headers)
         else:
             raise NotImplementedError()
 


### PR DESCRIPTION
closes #5879