### PR TITLE
Fix scheduled task purge failing without user

### DIFF
--- a/CHANGES/5881.bugfix
+++ b/CHANGES/5881.bugfix
@@ -1,0 +1,1 @@
+Fixed task purge to not expect a user, when a run has been scheduled by Pulp itself.


### PR DESCRIPTION
When a task was dispatched by a task schedule, there is no user attached to it. So purge tasks should just look at all tasks. However when a user gets deleted after dispatching that task, the task will run with current_user=None also. We need to make sure not to purge too many tasks in this case.

fixes #5881