### PR TITLE
fix: Signing scripts needs access to environment variables.

### DIFF
--- a/CHANGES/5911.bugfix
+++ b/CHANGES/5911.bugfix
@@ -1,0 +1,1 @@
+pass envvars to Signing Scripts to access GNUPGHOME

--- a/pulpcore/app/models/content.py
+++ b/pulpcore/app/models/content.py
@@ -7,6 +7,7 @@ from gettext import gettext as _
 import asyncio
 import datetime
 import json
+import os
 import tempfile
 import shutil
 import subprocess
@@ -783,7 +784,7 @@ class SigningService(BaseModel):
         }
         if env_vars:
             env.update(env_vars)
-        return env
+        return {**os.environ, **env}
 
     def sign(self, filename, env_vars=None):
         """


### PR DESCRIPTION
A signing script usually needs to access `GNUPGHOME`, `HOME` and possibly other variables.


fixes #5911 