### PR TITLE
[SAT-22998] [3.39] Ensure Pulp closes the connection on corrupted streamed content

### DIFF
--- a/pulpcore/app/models/repository.py
+++ b/pulpcore/app/models/repository.py
@@ -1095,17 +1095,15 @@ class RepositoryVersion(BaseModel):
         repository.initialize_new_version(self)
         return self
 
-    # TODO: revert this
-    # only here so I can get the test right with less friction
-    async def __exit__(self, exc_type, exc_value, traceback):
+    def __exit__(self, exc_type, exc_value, traceback):
         """
         Finalize and save the RepositoryVersion if no errors are raised, delete it if not
         """
         if exc_value:
-            await sync_to_async(self.delete)()
+            self.delete()
         else:
             try:
-                repository = self.repository.acast()
+                repository = self.repository.cast()
                 repository.finalize_new_version(self)
                 no_change = not self.added() and not self.removed()
                 if no_change:

--- a/pulpcore/content/handler.py
+++ b/pulpcore/content/handler.py
@@ -704,6 +704,7 @@ class Handler:
                             request, StreamResponse(headers=headers), ca
                         )
                 else:
+                    breakpoint()
                     # Try to stream the RemoteArtifact and potentially save it as a new Content unit
                     save_artifact = remote.get_remote_artifact_content_type(rel_path) is not None
                     ca = ContentArtifact(relative_path=rel_path)

--- a/pulpcore/content/handler.py
+++ b/pulpcore/content/handler.py
@@ -642,7 +642,9 @@ class Handler:
                             request, StreamResponse(headers=headers), ca
                         )
 
-        assert repo_version and not publication and not distro.SERVE_FROM_PUBLICATION
+        assert repo_version
+        assert not publication
+        assert not distro.SERVE_FROM_PUBLICATION
         if repo_version and not publication and not distro.SERVE_FROM_PUBLICATION:
             if rel_path == "" or rel_path[-1] == "/":
                 index_path = "{}index.html".format(rel_path)

--- a/pulpcore/content/handler.py
+++ b/pulpcore/content/handler.py
@@ -644,7 +644,6 @@ class Handler:
 
         assert repo_version and not publication and not distro.SERVE_FROM_PUBLICATION
         if repo_version and not publication and not distro.SERVE_FROM_PUBLICATION:
-            # breakpoint()
             if rel_path == "" or rel_path[-1] == "/":
                 index_path = "{}index.html".format(rel_path)
 
@@ -688,7 +687,7 @@ class Handler:
 
         # If we haven't found a match yet, try to use pull-through caching with remote
         if distro.remote:
-            assert False
+            assert False, "Shouldt hit here"
             remote = await distro.remote.acast()
             if url := remote.get_remote_artifact_url(rel_path, request=request):
                 if (

--- a/pulpcore/content/handler.py
+++ b/pulpcore/content/handler.py
@@ -642,7 +642,9 @@ class Handler:
                             request, StreamResponse(headers=headers), ca
                         )
 
+        assert repo_version and not publication and not distro.SERVE_FROM_PUBLICATION
         if repo_version and not publication and not distro.SERVE_FROM_PUBLICATION:
+            # breakpoint()
             if rel_path == "" or rel_path[-1] == "/":
                 index_path = "{}index.html".format(rel_path)
 
@@ -686,6 +688,7 @@ class Handler:
 
         # If we haven't found a match yet, try to use pull-through caching with remote
         if distro.remote:
+            assert False
             remote = await distro.remote.acast()
             if url := remote.get_remote_artifact_url(rel_path, request=request):
                 if (
@@ -704,7 +707,6 @@ class Handler:
                             request, StreamResponse(headers=headers), ca
                         )
                 else:
-                    breakpoint()
                     # Try to stream the RemoteArtifact and potentially save it as a new Content unit
                     save_artifact = remote.get_remote_artifact_content_type(rel_path) is not None
                     ca = ContentArtifact(relative_path=rel_path)


### PR DESCRIPTION
Because of a design choice of streaming chunk-by-chunk as we receive it from the Remote (to minimize response time and allow only-stream workflow), as soon as we receive the first chunk, all http headers are already sent and we can't roll that back anymore (for example, set a 404).

Then, the best we can do is close the TCP connection, so at least the client knows something went wrong (although we can't do much here to inform what the problem was).

Closes #5012 

edit: was previous to address https://github.com/pulp/pulpcore/issues/5725, but I'll split, as proper closing the connection is a pre-requisite.