### PR TITLE
[PR #5936/58425d79 backport][3.22] Fix Any serializer type regression breaking Ruby bindings

### DIFF
--- a/CHANGES/+fix-any-type.bugfix
+++ b/CHANGES/+fix-any-type.bugfix
@@ -1,0 +1,2 @@
+Fixed the JSONField specification so it doesn't break ruby bindings.
+See context [here](https://github.com/pulp/pulp_rpm/issues/3639).

--- a/pulpcore/app/serializers/exporter.py
+++ b/pulpcore/app/serializers/exporter.py
@@ -15,6 +15,7 @@ from pulpcore.app.serializers import (
     RelatedField,
     RelatedResourceField,
     RepositoryVersionRelatedField,
+    fields,
 )
 from pulpcore.constants import FS_EXPORT_CHOICES, FS_EXPORT_METHODS
 
@@ -93,7 +94,7 @@ class ExportSerializer(ModelSerializer):
         view_name="None",  # This is a polymorphic field. The serializer does not need a view name.
     )
 
-    params = serializers.JSONField(
+    params = fields.JSONDictField(
         help_text=_("Any additional parameters that were used to create the export."),
         read_only=True,
     )
@@ -108,12 +109,12 @@ class PulpExportSerializer(ExportSerializer):
     Serializer for PulpExports.
     """
 
-    output_file_info = serializers.JSONField(
+    output_file_info = fields.JSONDictField(
         help_text=_("Dictionary of filename: sha256hash entries for export-output-file(s)"),
         read_only=True,
     )
 
-    toc_info = serializers.JSONField(
+    toc_info = fields.JSONDictField(
         help_text=_("Filename and sha256-checksum of table-of-contents for this export"),
         read_only=True,
     )

--- a/pulpcore/app/serializers/fields.py
+++ b/pulpcore/app/serializers/fields.py
@@ -4,6 +4,8 @@ from gettext import gettext as _
 from urllib.parse import urljoin
 
 from django.conf import settings
+from drf_spectacular.utils import extend_schema_field
+from drf_spectacular.types import OpenApiTypes
 from rest_framework import serializers
 from rest_framework.fields import empty
 from rest_framework.reverse import reverse
@@ -18,6 +20,15 @@ def relative_path_validator(relative_path):
         raise serializers.ValidationError(
             _("Relative path can't start with '/'. {0}").format(relative_path)
         )
+
+
+@extend_schema_field(OpenApiTypes.OBJECT)
+class JSONDictField(serializers.JSONField):
+    """A drf JSONField override to force openapi schema to use 'object' type.
+
+    Not strictly correct, but we relied on that for a long time.
+    See: https://github.com/tfranzel/drf-spectacular/issues/1095
+    """
 
 
 class SingleContentArtifactField(RelatedField):

--- a/pulpcore/app/serializers/importer.py
+++ b/pulpcore/app/serializers/importer.py
@@ -11,6 +11,7 @@ from pulpcore.app.serializers import (
     ModelSerializer,
     RelatedField,
     ValidateFieldsMixin,
+    fields,
 )
 
 
@@ -39,7 +40,7 @@ class ImportSerializer(ModelSerializer):
         view_name="tasks-detail",
     )
 
-    params = serializers.JSONField(
+    params = fields.JSONDictField(
         help_text=_("Any parameters that were used to create the import."),
     )
 

--- a/pulpcore/app/serializers/task.py
+++ b/pulpcore/app/serializers/task.py
@@ -11,6 +11,7 @@ from pulpcore.app.serializers import (
     RelatedField,
     RelatedResourceField,
     TaskGroupStatusCountField,
+    fields,
 )
 from pulpcore.constants import TASK_STATES
 
@@ -41,7 +42,7 @@ class TaskSerializer(ModelSerializer):
         help_text=_("Timestamp of the when this task stopped execution."), read_only=True
     )
     error = serializers.DictField(
-        child=serializers.JSONField(),
+        child=fields.JSONDictField(),
         help_text=_(
             "A JSON Object of a fatal error encountered during the execution of this task."
         ),


### PR DESCRIPTION
See https://github.com/pulp/pulp_rpm/issues/3639

(cherry picked from commit 58425d791296752be427a43cda9df0d2403bc7bc)