### PR TITLE
Allow aiohttp <3.10.11

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 aiodns>=3.0,<=3.1.1
 aiofiles>=22.1,<23.3.0
-aiohttp>=3.8.1,<3.9.6
+aiohttp>=3.8.1,<3.10.11
 asyncio-throttle>=1.0,<=1.0.2
 async-timeout>=4.0.3,<4.0.4;python_version<"3.11"
 backoff>=2.1.2,<2.2.2
@@ -40,4 +40,4 @@ tablib<3.6.0
 url-normalize>=1.4.3,<=1.4.3
 uuid6>=2023.5.2,<=2024.1.12
 whitenoise>=5.0,<6.7.0
-yarl>=1.8,<1.9.5
+yarl>=1.8,<1.15.3


### PR DESCRIPTION
This is supposed to allow consuming a bug in creating the caching key.