### PR TITLE
Allow aiohttp <3.10.11

### DIFF
--- a/pulpcore/tests/unit/download/test_factory.py
+++ b/pulpcore/tests/unit/download/test_factory.py
@@ -1,20 +1,21 @@
 from django.test import TestCase
+from asgiref.sync import sync_to_async
 
 from pulpcore.download.factory import DownloaderFactory
 from pulpcore.plugin.models import Remote
 
 
 class DownloaderFactoryHeadersTestCase(TestCase):
-    def test_user_agent_header(self):
-        remote = Remote.objects.create(url="http://example.org/", name="foo")
+    async def test_user_agent_header(self):
+        remote = await sync_to_async(Remote.objects.create)(url="http://example.org/", name="foo")
         factory = DownloaderFactory(remote)
         downloader = factory.build(remote.url)
         default_user_agent = DownloaderFactory.user_agent()
         self.assertEqual(downloader.session.headers["User-Agent"], default_user_agent)
-        remote.delete()
+        await sync_to_async(remote.delete)()
 
-    def test_custom_user_agent_header(self):
-        remote = Remote.objects.create(
+    async def test_custom_user_agent_header(self):
+        remote = await sync_to_async(Remote.objects.create)(
             url="http://example.org/", headers=[{"User-Agent": "foo"}], name="foo"
         )
         factory = DownloaderFactory(remote)
@@ -22,12 +23,13 @@ class DownloaderFactoryHeadersTestCase(TestCase):
         default_user_agent = DownloaderFactory.user_agent()
         expected_user_agent = f"{default_user_agent}, foo"
         self.assertEqual(downloader.session.headers["User-Agent"], expected_user_agent)
-        remote.delete()
+        await sync_to_async(remote.delete)()
 
-    def test_custom_headers(self):
-        remote = Remote.objects.create(
+    async def test_custom_headers(self):
+        remote = await sync_to_async(Remote.objects.create)(
             url="http://example.org/", headers=[{"Connection": "keep-alive"}], name="foo"
         )
         factory = DownloaderFactory(remote)
         downloader = factory.build(remote.url)
         self.assertEqual(downloader.session.headers["Connection"], "keep-alive")
+        await sync_to_async(remote.delete)()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 asyncio-throttle~=1.0
-aiohttp>=3.8.1,<3.9.2
+aiohttp>=3.8.1,<3.10.11
 aiodns~=3.0.0
 aiofiles==22.1.0
 backoff~=2.1.2
@@ -30,4 +30,4 @@ setuptools>=39.2.0,<66.0.0
 tablib<3.6.0
 url-normalize~=1.4.3
 whitenoise>=5.0.0,<6.3.0
-yarl~=1.7
+yarl>=1.7,<1.15.3


### PR DESCRIPTION
This is supposed to allow consuming a bug in creating the caching key.

(cherry picked from commit 24f8217a1ca27a8d3a10a9a8697b72a9ab9746c5) (cherry picked from commit b749ac09381d0769c96b92ec2857caf5a89adaf6)