### PR TITLE
Add cache_key to the plugin api

### DIFF
--- a/CHANGES/plugin_api/cache-key.feature
+++ b/CHANGES/plugin_api/cache-key.feature
@@ -1,0 +1,2 @@
+Added `pulpcore.app.util.cache_key` to the plugin api.
+Use this method to get the base-key when using the Pulp cache.

--- a/pulpcore/plugin/util.py
+++ b/pulpcore/plugin/util.py
@@ -14,6 +14,7 @@ from pulpcore.app.role_util import (
 
 from pulpcore.app.util import (
     batch_qs,
+    cache_key,
     extract_pk,
     get_artifact_url,
     get_prn,
@@ -60,4 +61,5 @@ __all__ = [
     "reverse",
     "set_current_user",
     "resolve_prn",
+    "cache_key",
 ]


### PR DESCRIPTION
cache_key handles domains correctly so plugins using the cache should use this method.

Side question: can we backport additions to the plugin-api?