### PR TITLE
Fix cross-domain content assertion

### DIFF
--- a/CHANGES/content-assert.bugfix
+++ b/CHANGES/content-assert.bugfix
@@ -1,0 +1,1 @@
+Fixed an assertion on all content being added/removed in a repository version is of the same domain.

--- a/pulpcore/app/models/repository.py
+++ b/pulpcore/app/models/repository.py
@@ -984,7 +984,11 @@ class RepositoryVersion(BaseModel):
         if self.complete:
             raise ResourceImmutableError(self)
 
-        assert not content.exclude(pulp_domain_id=get_domain_pk()).exists()
+        assert (
+            not Content.objects.filter(pk__in=content)
+            .exclude(pulp_domain_id=get_domain_pk())
+            .exists()
+        )
         repo_content = []
         to_add = set(content.values_list("pk", flat=True)) - set(
             self.content.values_list("pk", flat=True)
@@ -1026,7 +1030,11 @@ class RepositoryVersion(BaseModel):
 
         if not content or not content.count():
             return
-        assert not content.exclude(pulp_domain_id=get_domain_pk()).exists()
+        assert (
+            not Content.objects.filter(pk__in=content)
+            .exclude(pulp_domain_id=get_domain_pk())
+            .exists()
+        )
 
         # Normalize representation if content has already been added in this version.
         # Undo addition by deleting the RepositoryContent.


### PR DESCRIPTION
We allow plugins to pass in either a `Content` query or a queryset of `content_ids`, e.g. `RepositoryContent.objects.values_list("content_id")`