### PR TITLE
Future proof the pulp_file repair tests for python 3.11

### DIFF
--- a/pulpcore/tests/functional/api/using_plugin/test_repair.py
+++ b/pulpcore/tests/functional/api/using_plugin/test_repair.py
@@ -25,7 +25,7 @@ def repository_with_corrupted_artifacts(
     repo = file_bindings.RepositoriesFileApi.read(file_repo.pulp_href)
 
     # STEP 2: sample artifacts that will be modified on the filesystem later on
-    content1, content2 = sample(get_files_in_manifest(remote.url), 2)
+    content1, content2 = sample(list(get_files_in_manifest(remote.url)), 2)
 
     # Modify an artifact
     artifact1_path = pulpcore_bindings.ArtifactsApi.list(sha256=content1[1]).results[0].file


### PR DESCRIPTION
This change unblocks the functional pulp_file repair tests when run on a python 3.11+ environment. Stronger typing for the random.sample function is introduced in 3.11 and requires now a Sequence type as an input or it will throw a TypeError.

see: https://docs.python.org/3.11/library/random.html#random.sample

[noissue]