### PR TITLE
Add ClientConnectionError as retriable exception on content-app streaming

### DIFF
--- a/CHANGES/5967.bugfix
+++ b/CHANGES/5967.bugfix
@@ -1,0 +1,2 @@
+On the content-app, added ClientConnectionError (aiohttp) as an exception that can trigger
+a retry when streaming content from a Remote.

--- a/pulpcore/content/handler.py
+++ b/pulpcore/content/handler.py
@@ -5,7 +5,7 @@ import os
 import re
 from gettext import gettext as _
 
-from aiohttp.client_exceptions import ClientResponseError
+from aiohttp.client_exceptions import ClientResponseError, ClientConnectionError
 from aiohttp.web import FileResponse, StreamResponse, HTTPOk
 from aiohttp.web_exceptions import (
     HTTPError,
@@ -815,6 +815,13 @@ class Handler:
                 [pulpcore.plugin.models.ContentArtifact][] returned the binary data needed for
                 the client.
         """
+        # We should only retry with exceptions that happen before we receive any data
+        # and start streaming, as we can't rollback data if something happens after that.
+        RETRYABLE_EXCEPTIONS = (
+            ClientResponseError,
+            UnsupportedDigestValidationError,
+            ClientConnectionError,
+        )
 
         remote_artifacts = content_artifact.remoteartifact_set.select_related(
             "remote"
@@ -823,8 +830,7 @@ class Handler:
             try:
                 response = await self._stream_remote_artifact(request, response, remote_artifact)
                 return response
-
-            except (ClientResponseError, UnsupportedDigestValidationError) as e:
+            except RETRYABLE_EXCEPTIONS as e:
                 log.warning(
                     "Could not download remote artifact at '{}': {}".format(
                         remote_artifact.url, str(e)


### PR DESCRIPTION
A user reported that after changing the host and resyncing they would have some some leftover RAs with the invalid url, and that would raise an aiohttp.client_exceptions.ClientConnectionError.

Because that is not a retriable error for content streaming, the right RA wouldnt be tried afterwards.

Closes: #5967

---

We should probably backport these to supported branches.