### PR TITLE
Finish backporting aiohttp 3.10 bump

### DIFF
--- a/pulpcore/download/factory.py
+++ b/pulpcore/download/factory.py
@@ -137,8 +137,11 @@ class DownloaderFactory:
             sock_read=self._remote.sock_read_timeout,
             connect=self._remote.connect_timeout,
         )
+        # TCPConnector is supposed to be instanciated in a running loop.
+        # I don't see why...
+        # https://github.com/aio-libs/aiohttp/pull/3372
         return aiohttp.ClientSession(
-            connector=aiohttp.TCPConnector(**tcp_conn_opts),
+            connector=aiohttp.TCPConnector(loop=asyncio.get_event_loop(), **tcp_conn_opts),
             timeout=timeout,
             headers=headers,
             requote_redirect_url=False,


### PR DESCRIPTION
Bumping this req broke Pulp, but only when using the downloader outside of a coroutine, which some plugins do (pulp_container).

 (from commit 3b0d218af8ddf97a1d5831dd8cab080194c0c768)