### PR TITLE
[PULP-210] Update deprecated django storage config

### DIFF
--- a/.ci/ansible/settings.py.j2
+++ b/.ci/ansible/settings.py.j2
@@ -27,19 +27,30 @@ API_ROOT = {{ api_root | repr }}
 {% endif %}
 
 {% if s3_test | default(false) %}
-DEFAULT_FILE_STORAGE = "storages.backends.s3boto3.S3Boto3Storage"
-MEDIA_ROOT = ""
-AWS_ACCESS_KEY_ID = "{{ minio_access_key }}"
-AWS_SECRET_ACCESS_KEY = "{{ minio_secret_key }}"
-AWS_S3_REGION_NAME = "eu-central-1"
-AWS_S3_ADDRESSING_STYLE = "path"
+MEDIA_ROOT: ""
 S3_USE_SIGV4 = True
-AWS_S3_SIGNATURE_VERSION = "s3v4"
-AWS_STORAGE_BUCKET_NAME = "pulp3"
-AWS_S3_ENDPOINT_URL = "http://minio:9000"
-AWS_DEFAULT_ACL = "@none None"
+STORAGES = {
+    "default": {
+        "BACKEND": "storages.backends.s3boto3.S3Boto3Storage",
+        "OPTIONS": {
+            "access_key": "{{ minio_access_key }}",
+            "secret_key": "{{ minio_secret_key }}",
+            "region_name": "eu-central-1",
+            "addressing_style": "path",
+            "signature_version": "s3v4",
+            "bucket_name": "pulp3",
+            "endpoint_url": "http://minio:9000",
+            "default_acl": "@none None",
+        },
+    },
+    "staticfiles": {
+      "BACKEND": "django.contrib.staticfiles.storage.StaticFilesStorage",
+    },
+}
 {% endif %}
 
+# This is using DEFAULT_FILE_STORAGE to test both usages.
+# Remove when DEFAULT_FILE_STORAGE is completely removed.
 {% if azure_test | default(false) %}
 DEFAULT_FILE_STORAGE = "storages.backends.azure_storage.AzureStorage"
 MEDIA_ROOT = ""

--- a/CHANGES/5404.removal
+++ b/CHANGES/5404.removal
@@ -1,0 +1,11 @@
+Marked django's `DEFAULT_FILE_STORAGE` and `STATIC_FILE_STORAGE` settings to be
+removed in pulpcore 3.85. Users should upgrade to use the
+[`STORAGES`](https://docs.djangoproject.com/en/4.2/ref/settings/#std-setting-STORAGES)
+setting instead.
+
+The [django-upgrade](https://github.com/adamchainz/django-upgrade?tab=readme-ov-file#django-42)
+tool can handle simple cases. If cloud storages are being used, refer to django-storages
+to adapt their specific storage options. E.g:
+
+* <https://django-storages.readthedocs.io/en/latest/backends/amazon-S3.html>
+* <https://django-storages.readthedocs.io/en/latest/backends/azure.html>

--- a/CHANGES/plugin_api/5404.removal
+++ b/CHANGES/plugin_api/5404.removal
@@ -1,0 +1,9 @@
+Started using `settings.STORAGES` internally instead of `settings.DEFAULT_FILE_STORAGE` and `settings.STATICFILES_STORAGE`,
+which was deprecated in Django 4.2.
+
+For compatibility, plugins must replace access to:
+
+* `settings.DEFAULT_FILE_STORAGE` with `settings.STORAGES["default"]["BACKEND"]`
+* `settings.STATICFILES_STORAGE` with `settings.STORAGES["staticfiles"]["BACKEND"]`
+
+See the new storage structure in [Django docs](https://docs.djangoproject.com/en/4.2/ref/settings/#std-setting-STORAGES).

--- a/pulpcore/app/apps.py
+++ b/pulpcore/app/apps.py
@@ -323,11 +323,11 @@ def _ensure_default_domain(sender, **kwargs):
         if (
             settings.HIDE_GUARDED_DISTRIBUTIONS != default.hide_guarded_distributions
             or settings.REDIRECT_TO_OBJECT_STORAGE != default.redirect_to_object_storage
-            or settings.DEFAULT_FILE_STORAGE != default.storage_class
+            or settings.STORAGES["default"]["BACKEND"] != default.storage_class
         ):
             default.hide_guarded_distributions = settings.HIDE_GUARDED_DISTRIBUTIONS
             default.redirect_to_object_storage = settings.REDIRECT_TO_OBJECT_STORAGE
-            default.storage_class = settings.DEFAULT_FILE_STORAGE
+            default.storage_class = settings.STORAGES["default"]["BACKEND"]
             default.save(skip_hooks=True)
 
 
@@ -394,7 +394,7 @@ def adjust_roles(apps, role_prefix, desired_roles, verbosity=1):
 
 def _populate_artifact_serving_distribution(sender, apps, verbosity, **kwargs):
     if (
-        settings.DEFAULT_FILE_STORAGE == "pulpcore.app.models.storage.FileSystem"
+        settings.STORAGES["default"]["BACKEND"] == "pulpcore.app.models.storage.FileSystem"
         or not settings.REDIRECT_TO_OBJECT_STORAGE
     ):
         try:

--- a/pulpcore/app/apps.py
+++ b/pulpcore/app/apps.py
@@ -5,7 +5,6 @@ from gettext import gettext as _
 from importlib import import_module
 
 from django import apps
-from django.conf import settings
 from django.core.exceptions import ImproperlyConfigured
 from django.db import connection, transaction
 from django.db.models.signals import post_migrate
@@ -68,6 +67,15 @@ class PulpPluginAppConfig(apps.AppConfig):
 
     def __init__(self, app_name, app_module):
         super().__init__(app_name, app_module)
+        # begin Compatilibity layer for DEFAULT_FILE_STORAGE deprecation
+        # Remove on pulpcore=3.85 or pulpcore=4.0
+        # * Workaround for getting the up-to-date settings instance, otherwise is doesnt
+        #   get the patch in settings.py
+        # * Update code in signal handlers to use module-level imports again
+        from django.conf import settings
+
+        self.settings = settings
+        # end
 
         try:
             self.version
@@ -314,6 +322,7 @@ def _populate_system_id(sender, apps, verbosity, **kwargs):
 
 
 def _ensure_default_domain(sender, **kwargs):
+    settings = sender.settings
     table_names = connection.introspection.table_names()
     if "core_domain" in table_names:
         from pulpcore.app.util import get_default_domain
@@ -393,6 +402,7 @@ def adjust_roles(apps, role_prefix, desired_roles, verbosity=1):
 
 
 def _populate_artifact_serving_distribution(sender, apps, verbosity, **kwargs):
+    settings = sender.settings
     if (
         settings.STORAGES["default"]["BACKEND"] == "pulpcore.app.models.storage.FileSystem"
         or not settings.REDIRECT_TO_OBJECT_STORAGE

--- a/pulpcore/app/checks.py
+++ b/pulpcore/app/checks.py
@@ -38,7 +38,7 @@ def secret_key_check(app_configs, **kwargs):
 def storage_paths(app_configs, **kwargs):
     warnings = []
 
-    if settings.DEFAULT_FILE_STORAGE == "pulpcore.app.models.storage.FileSystem":
+    if settings.STORAGES["default"]["BACKEND"] == "pulpcore.app.models.storage.FileSystem":
         try:
             media_root_dev = Path(settings.MEDIA_ROOT).stat().st_dev
         except OSError:

--- a/pulpcore/app/importexport.py
+++ b/pulpcore/app/importexport.py
@@ -114,7 +114,7 @@ def export_artifacts(export, artifact_pks):
     with ProgressReport(**data) as pb:
         pb.BATCH_INTERVAL = 5000
 
-        if settings.DEFAULT_FILE_STORAGE != "pulpcore.app.models.storage.FileSystem":
+        if settings.STORAGES["default"]["BACKEND"] != "pulpcore.app.models.storage.FileSystem":
             with tempfile.TemporaryDirectory(dir=".") as temp_dir:
                 for offset in range(0, len(artifact_pks), EXPORT_BATCH_SIZE):
                     batch = artifact_pks[offset : offset + EXPORT_BATCH_SIZE]

--- a/pulpcore/app/serializers/domain.py
+++ b/pulpcore/app/serializers/domain.py
@@ -42,7 +42,10 @@ class BaseSettingsClass(HiddenFieldsMixin, serializers.Serializer):
         # Should I convert back the saved settings to their Setting names for to_representation?
         if getattr(self.context.get("domain", None), "name", None) == "default":
             for setting_name, field in self.SETTING_MAPPING.items():
-                if value := getattr(settings, setting_name.upper(), None):
+                value = getattr(settings, setting_name, None) or settings.STORAGES["default"].get(
+                    "OPTIONS", {}
+                ).get(field)
+                if value:
                     instance[field] = value
         return super().to_representation(instance)
 

--- a/pulpcore/app/tasks/export.py
+++ b/pulpcore/app/tasks/export.py
@@ -70,7 +70,7 @@ def _export_to_file_system(path, relative_paths_to_artifacts, method=FS_EXPORT_M
         ValidationError: When path is not in the ALLOWED_EXPORT_PATHS setting
     """
     using_filesystem_storage = (
-        settings.DEFAULT_FILE_STORAGE == "pulpcore.app.models.storage.FileSystem"
+        settings.STORAGES["default"]["BACKEND"] == "pulpcore.app.models.storage.FileSystem"
     )
 
     if method != FS_EXPORT_METHODS.WRITE and not using_filesystem_storage:

--- a/pulpcore/app/util.py
+++ b/pulpcore/app/util.py
@@ -536,7 +536,7 @@ def get_artifact_url(artifact, headers=None, http_method=None):
         if settings.DOMAIN_ENABLED:
             loc = f"domain {artifact_domain.name}.storage_class"
         else:
-            loc = "settings.DEFAULT_FILE_STORAGE"
+            loc = "settings.STORAGES['default']['BACKEND']"
 
         raise NotImplementedError(
             f"The value {loc}={artifact_domain.storage_class} does not allow redirecting."
@@ -582,7 +582,9 @@ def get_default_domain():
         try:
             default_domain = Domain.objects.get(name="default")
         except Domain.DoesNotExist:
-            default_domain = Domain(name="default", storage_class=settings.DEFAULT_FILE_STORAGE)
+            default_domain = Domain(
+                name="default", storage_class=settings.STORAGES["default"]["BACKEND"]
+            )
             default_domain.save(skip_hooks=True)
 
     return default_domain

--- a/pulpcore/pytest_plugin.py
+++ b/pulpcore/pytest_plugin.py
@@ -621,7 +621,7 @@ def backend_settings_factory(pulp_settings):
             "AZURE_CONNECTION_STRING",
         ]
         settings = storage_settings or dict()
-        backend = storage_class or pulp_settings.DEFAULT_FILE_STORAGE
+        backend = storage_class or pulp_settings.STORAGES["default"]["BACKEND"]
         for key in keys[backend]:
             if key not in settings:
                 settings[key] = getattr(pulp_settings, key, None)

--- a/pulpcore/tests/functional/api/test_artifact_distribution.py
+++ b/pulpcore/tests/functional/api/test_artifact_distribution.py
@@ -2,8 +2,6 @@ import requests
 import subprocess
 from hashlib import sha256
 
-from django.conf import settings
-
 
 OBJECT_STORAGES = (
     "storages.backends.s3boto3.S3Boto3Storage",
@@ -12,7 +10,8 @@ OBJECT_STORAGES = (
 )
 
 
-def test_artifact_distribution(random_artifact):
+def test_artifact_distribution(random_artifact, pulp_settings):
+    settings = pulp_settings
     artifact_uuid = random_artifact.pulp_href.split("/")[-2]
 
     commands = (
@@ -29,7 +28,7 @@ def test_artifact_distribution(random_artifact):
     hasher = sha256()
     hasher.update(response.content)
     assert hasher.hexdigest() == random_artifact.sha256
-    if settings.DEFAULT_FILE_STORAGE in OBJECT_STORAGES:
+    if settings.STORAGES["default"]["BACKEND"] in OBJECT_STORAGES:
         content_disposition = response.headers.get("Content-Disposition")
         assert content_disposition is not None
         filename = artifact_uuid

--- a/pulpcore/tests/functional/api/test_crd_artifacts.py
+++ b/pulpcore/tests/functional/api/test_crd_artifacts.py
@@ -7,7 +7,6 @@ import uuid
 import pytest
 
 
-
 @pytest.fixture
 def pulpcore_random_file(tmp_path):
     name = tmp_path / str(uuid.uuid4())

--- a/pulpcore/tests/functional/api/test_crd_artifacts.py
+++ b/pulpcore/tests/functional/api/test_crd_artifacts.py
@@ -6,7 +6,6 @@ import os
 import uuid
 import pytest
 
-from django.conf import settings
 
 
 @pytest.fixture
@@ -142,10 +141,11 @@ def test_upload_mixed_attrs(pulpcore_bindings, pulpcore_random_file):
 
 
 @pytest.mark.parallel
-def test_delete_artifact(pulpcore_bindings, pulpcore_random_file, gen_user):
+def test_delete_artifact(pulpcore_bindings, pulpcore_random_file, gen_user, pulp_settings):
     """Verify that the deletion of artifacts is prohibited for both regular users and
     administrators."""
-    if settings.DEFAULT_FILE_STORAGE != "pulpcore.app.models.storage.FileSystem":
+    settings = pulp_settings
+    if settings.STORAGES["default"]["BACKEND"] != "pulpcore.app.models.storage.FileSystem":
         pytest.skip("this test only works for filesystem storage")
     media_root = settings.MEDIA_ROOT
 

--- a/pulpcore/tests/functional/api/test_crud_domains.py
+++ b/pulpcore/tests/functional/api/test_crud_domains.py
@@ -5,7 +5,6 @@ import random
 import string
 import json
 from pulpcore.client.pulpcore import ApiException
-from pulpcore.app import settings
 
 from pulpcore.tests.functional.utils import PulpTaskError
 
@@ -51,15 +50,16 @@ def test_crud_domains(pulpcore_bindings, monitor_task):
 
 
 @pytest.mark.parallel
-def test_default_domain(pulpcore_bindings):
+def test_default_domain(pulpcore_bindings, pulp_settings):
     """Test properties around the default domain."""
+    settings = pulp_settings
     domains = pulpcore_bindings.DomainsApi.list(name="default")
     assert domains.count == 1
 
     # Read the default domain, ensure storage is set to default
     default_domain = domains.results[0]
     assert default_domain.name == "default"
-    assert default_domain.storage_class == settings.DEFAULT_FILE_STORAGE
+    assert default_domain.storage_class == settings.STORAGES["default"]["BACKEND"]
     assert default_domain.redirect_to_object_storage == settings.REDIRECT_TO_OBJECT_STORAGE
     assert default_domain.hide_guarded_distributions == settings.HIDE_GUARDED_DISTRIBUTIONS
 
@@ -92,8 +92,9 @@ def test_default_domain(pulpcore_bindings):
 
 
 @pytest.mark.parallel
-def test_active_domain_deletion(pulpcore_bindings, monitor_task):
+def test_active_domain_deletion(pulpcore_bindings, monitor_task, pulp_settings):
     """Test trying to delete a domain that is in use, has objects in it."""
+    settings = pulp_settings
     if not settings.DOMAIN_ENABLED:
         pytest.skip("Domains not enabled")
     name = str(uuid.uuid4())
@@ -133,8 +134,10 @@ def test_orphan_domain_deletion(
     gen_object_with_cleanup,
     monitor_task,
     tmp_path,
+    pulp_settings,
 ):
     """Test trying to delete a domain that is in use, has objects in it."""
+    settings = pulp_settings
     if not settings.DOMAIN_ENABLED:
         pytest.skip("Domains not enabled")
     body = {
@@ -177,8 +180,9 @@ def test_orphan_domain_deletion(
 
 
 @pytest.mark.parallel
-def test_special_domain_creation(pulpcore_bindings, gen_object_with_cleanup):
+def test_special_domain_creation(pulpcore_bindings, gen_object_with_cleanup, pulp_settings):
     """Test many possible domain creation scenarios."""
+    settings = pulp_settings
     if not settings.DOMAIN_ENABLED:
         pytest.skip("Domains not enabled")
     # This test needs to account for which environment it is running in

--- a/pulpcore/tests/functional/api/test_status.py
+++ b/pulpcore/tests/functional/api/test_status.py
@@ -2,7 +2,6 @@
 
 import pytest
 
-from django.conf import settings
 from jsonschema import validate
 
 
@@ -58,24 +57,24 @@ STATUS = {
 
 
 @pytest.mark.parallel
-def test_get_authenticated(test_path, pulpcore_bindings):
+def test_get_authenticated(test_path, pulpcore_bindings, pulp_settings):
     """GET the status path with valid credentials.
 
     Verify the response with :meth:`verify_get_response`.
     """
     response = pulpcore_bindings.StatusApi.status_read()
-    verify_get_response(response.to_dict(), STATUS)
+    verify_get_response(response.to_dict(), STATUS, pulp_settings)
 
 
 @pytest.mark.parallel
-def test_get_unauthenticated(test_path, pulpcore_bindings, anonymous_user):
+def test_get_unauthenticated(test_path, pulpcore_bindings, anonymous_user, pulp_settings):
     """GET the status path with no credentials.
 
     Verify the response with :meth:`verify_get_response`.
     """
     with anonymous_user:
         response = pulpcore_bindings.StatusApi.status_read()
-    verify_get_response(response.to_dict(), STATUS)
+    verify_get_response(response.to_dict(), STATUS, pulp_settings)
 
 
 @pytest.mark.parallel
@@ -130,7 +129,7 @@ def test_storage_per_domain(
     assert default_status.storage != domain_status.storage
 
 
-def verify_get_response(status, expected_schema):
+def verify_get_response(status, expected_schema, settings):
     """Verify the response to an HTTP GET call.
 
     Verify that several attributes and have the correct type or value.
@@ -145,7 +144,7 @@ def verify_get_response(status, expected_schema):
     assert status["content_settings"]["content_path_prefix"] is not None
 
     assert status["storage"]["used"] is not None
-    if settings.DEFAULT_FILE_STORAGE != "pulpcore.app.models.storage.FileSystem":
+    if settings.STORAGES["default"]["BACKEND"] != "pulpcore.app.models.storage.FileSystem":
         assert status["storage"]["free"] is None
         assert status["storage"]["total"] is None
     else:

--- a/pulpcore/tests/functional/api/using_plugin/test_orphans.py
+++ b/pulpcore/tests/functional/api/using_plugin/test_orphans.py
@@ -68,11 +68,12 @@ def test_orphans_delete(
     monitor_task,
     pulp_settings,
 ):
+    settings = pulp_settings
     # Verify that the system contains the orphan content unit and the orphan artifact.
     content_unit = file_bindings.ContentFilesApi.read(file_random_content_unit.pulp_href)
     artifact = pulpcore_bindings.ArtifactsApi.read(random_artifact.pulp_href)
 
-    if pulp_settings.DEFAULT_FILE_STORAGE == "pulpcore.app.models.storage.FileSystem":
+    if settings.STORAGES["default"]["BACKEND"] == "pulpcore.app.models.storage.FileSystem":
         # Verify that the artifacts are on disk
         relative_path = pulpcore_bindings.ArtifactsApi.read(content_unit.artifact).file
         artifact_path1 = os.path.join(pulp_settings.MEDIA_ROOT, relative_path)
@@ -88,7 +89,7 @@ def test_orphans_delete(
         with pytest.raises(file_bindings.ApiException) as exc:
             file_bindings.ContentFilesApi.read(file_random_content_unit.pulp_href)
         assert exc.value.status == 404
-        if pulp_settings.DEFAULT_FILE_STORAGE == "pulpcore.app.models.storage.FileSystem":
+        if settings.STORAGES["default"]["BACKEND"] == "pulpcore.app.models.storage.FileSystem":
             assert os.path.exists(artifact_path1) is False
             assert os.path.exists(artifact_path2) is False
 
@@ -101,6 +102,7 @@ def test_orphans_cleanup(
     monitor_task,
     pulp_settings,
 ):
+    settings = pulp_settings
     # Cleanup orphans with a nonzero orphan_protection_time
     monitor_task(pulpcore_bindings.OrphansCleanupApi.cleanup({"orphan_protection_time": 10}).task)
 
@@ -108,7 +110,7 @@ def test_orphans_cleanup(
     content_unit = file_bindings.ContentFilesApi.read(file_random_content_unit.pulp_href)
     artifact = pulpcore_bindings.ArtifactsApi.read(random_artifact.pulp_href)
 
-    if pulp_settings.DEFAULT_FILE_STORAGE == "pulpcore.app.models.storage.FileSystem":
+    if settings.STORAGES["default"]["BACKEND"] == "pulpcore.app.models.storage.FileSystem":
         # Verify that the artifacts are on disk
         relative_path = pulpcore_bindings.ArtifactsApi.read(content_unit.artifact).file
         artifact_path1 = os.path.join(pulp_settings.MEDIA_ROOT, relative_path)
@@ -123,7 +125,7 @@ def test_orphans_cleanup(
     with pytest.raises(file_bindings.ApiException) as exc:
         file_bindings.ContentFilesApi.read(file_random_content_unit.pulp_href)
     assert exc.value.status == 404
-    if pulp_settings.DEFAULT_FILE_STORAGE == "pulpcore.app.models.storage.FileSystem":
+    if settings.STORAGES["default"]["BACKEND"] == "pulpcore.app.models.storage.FileSystem":
         assert os.path.exists(artifact_path1) is False
         assert os.path.exists(artifact_path2) is False
 

--- a/pulpcore/tests/unit/models/test_content.py
+++ b/pulpcore/tests/unit/models/test_content.py
@@ -43,7 +43,7 @@ def test_create_read_delete_content(tmp_path):
 
 @pytest.mark.django_db
 def test_storage_location(tmp_path, settings):
-    if settings.DEFAULT_FILE_STORAGE != "pulpcore.app.models.storage.FileSystem":
+    if settings.STORAGES["default"]["BACKEND"] != "pulpcore.app.models.storage.FileSystem":
         pytest.skip("Skipping test for nonlocal storage.")
 
     tf = tmp_path / "ab"


### PR DESCRIPTION
## Summary

The setting [DEFAULT_FILE_STORAGE](https://docs.djangoproject.com/en/4.2/ref/settings/#default-file-storage) / [STATCIFILES_STORAGE](https://docs.djangoproject.com/en/4.2/ref/settings/#staticfiles-storage) was deprecated in django 4.2. They've implemented a compatibility layer to enable this legacy setting to be mapped to the new [STORAGES](https://docs.djangoproject.com/en/4.2/ref/settings/#std-setting-STORAGES), so users could gradually move and Pulp codebase to update to using only STORAGES.

The problem is that Pulp overrides the default (using the legacy setting name), so users can't really use STORAGE, as it raises a django exceptions on mutual exclusion.

This PR does:

1. Updates the codebase to rely on settings.STORAGES instead of DEFAULT_FILE_STORAGE
2. Enable users to start using STORAGES on their settings
3. Use both legacy and new setting in CI (s3 / azure) for sanity testing

## Open questions:
- **Removal deadline**: I'm suggesting that we remove it on 3.85 or 4.0, but we could choose something else. Deciding this is important so we can give a proper heads up for our users and stakeholders.

## Plugins TODO

- Check whether the signal handling (on `app/apps.py`) uses a module-level settings. That could cause errors, so it needs to be moved inside the AppConfig class
- Use STORAGES internally instead of DEFAULT_FILE_STORAGE and STATICFILES_STORAGE


Closes #5404 