### PR TITLE
[PULP-205] Allow multiple bind addresses on entrypoints

### DIFF
--- a/CHANGES/6053.bugfix
+++ b/CHANGES/6053.bugfix
@@ -1,0 +1,2 @@
+Allowed to bind api and content workers to multiple addresses.
+You can specify `--bind` multiple times on the `pulpcore-{api,content}` entrypoints.

--- a/pulpcore/app/entrypoint.py
+++ b/pulpcore/app/entrypoint.py
@@ -102,7 +102,7 @@ class PulpcoreApiApplication(PulpcoreGunicornApplication):
 # https://github.com/benoitc/gunicorn/blob/master/gunicorn/config.py
 
 
-@click.option("--bind", "-b", default="[::]:24817")
+@click.option("--bind", "-b", default=["[::]:24817"], multiple=True)
 @click.option("--workers", "-w", type=int)
 # @click.option("--threads", "-w", type=int)  # We don't use a threaded worker...
 @click.option("--name", "-n", "proc_name")
@@ -136,5 +136,6 @@ class PulpcoreApiApplication(PulpcoreGunicornApplication):
 @click.option("--user", "-u")
 @click.option("--group", "-g")
 @click.command()
-def main(**options):
+def main(bind, **options):
+    options["bind"] = list(bind)
     PulpcoreApiApplication(options).run()

--- a/pulpcore/content/entrypoint.py
+++ b/pulpcore/content/entrypoint.py
@@ -13,7 +13,7 @@ class PulpcoreContentApplication(PulpcoreGunicornApplication):
         return pulpcore.content.server
 
 
-@click.option("--bind", "-b", default="[::]:24816")
+@click.option("--bind", "-b", default=["[::]:24816"], multiple=True)
 @click.option("--workers", "-w", type=int)
 # @click.option("--threads", "-w", type=int)  # We don't use a threaded worker...
 @click.option("--name", "-n", "proc_name")
@@ -40,5 +40,6 @@ class PulpcoreContentApplication(PulpcoreGunicornApplication):
 @click.option("--user", "-u")
 @click.option("--group", "-g")
 @click.command()
-def main(**options):
+def main(bind, **options):
+    options["bind"] = list(bind)
     PulpcoreContentApplication(options).run()


### PR DESCRIPTION
Both content and api worker allow to specify --bind multiple times now.

fixes #6053