### PR TITLE
Fix GetOrCreateSerializerMixin not working with pulp_domain

### DIFF
--- a/CHANGES/plugin_api/domain-get-create-serializer-mixin.bugfix
+++ b/CHANGES/plugin_api/domain-get-create-serializer-mixin.bugfix
@@ -1,0 +1,1 @@
+Fixed `GetOrCreateSerializerMixin` not accepting pulp_domain for the natural key creation.

--- a/pulpcore/app/serializers/base.py
+++ b/pulpcore/app/serializers/base.py
@@ -386,6 +386,8 @@ class GetOrCreateSerializerMixin:
             if default_values:
                 data.update(default_values)
             data.update(natural_key)
+            if "pulp_domain" in natural_key:
+                del data["pulp_domain"]
             serializer = cls(data=data)
             try:
                 serializer.is_valid(raise_exception=True)
@@ -402,6 +404,8 @@ class GetOrCreateSerializerMixin:
                 # validation failed with 400 'unique' error code only
                 result = cls.Meta.model.objects.get(**natural_key)
             try:
+                if "pulp_domain" in natural_key:
+                    serializer.validated_data["pulp_domain"] = natural_key["pulp_domain"]
                 result = result or serializer.create(serializer.validated_data)
             except IntegrityError:
                 # recover from a race condition, where another thread just created the object


### PR DESCRIPTION
pulp_domain is not processed in model's serializer since the value is auto-set as a context var on request time. This helper method would run into serializer errors if pulp_domain was specified as a natural key (which you need to do when supporting domains). 