### PR TITLE
[PULP-208] Disable download retry with on demand streaming

### DIFF
--- a/CHANGES/5937.bugfix
+++ b/CHANGES/5937.bugfix
@@ -1,0 +1,2 @@
+Disable retry logic on the context of content-app on-demand streaming, as we can't recover
+from any errors after starting the streaming process (chunked transfer).

--- a/pulpcore/content/handler.py
+++ b/pulpcore/content/handler.py
@@ -1138,7 +1138,9 @@ class Handler:
         original_finalize = downloader.finalize
         downloader.finalize = finalize
         try:
-            download_result = await downloader.run()
+            download_result = await downloader.run(
+                extra_data={"disable_retry_list": (DigestValidationError,)}
+            )
         except DigestValidationError:
             await downloader.session.close()
             close_tcp_connection(request.transport._sock)

--- a/pulpcore/download/http.py
+++ b/pulpcore/download/http.py
@@ -214,20 +214,22 @@ class HttpDownloader(BaseDownloader):
 
     async def run(self, extra_data=None):
         """
-        Run the downloader with concurrency restriction and retry logic.
+        Run the downloader with concurrency restriction and optional retry logic.
 
         This method acquires `self.semaphore` before calling the actual download implementation
         contained in `_run()`. This ensures that the semaphore stays acquired even as the `backoff`
         wrapper around `_run()`, handles backoff-and-retry logic.
 
         Args:
-            extra_data (dict): Extra data passed to the downloader.
+            extra_data (dict): Extra data passed to the downloader:
+                disable_retry_list: List of exceptions which should not be retried.
 
         Returns:
             [pulpcore.plugin.download.DownloadResult][] from `_run()`.
 
         """
-        retryable_errors = (
+        disable_retry_list = [] if not extra_data else extra_data.get("disable_retry_list", [])
+        default_retryable_errors = (
             aiohttp.ClientConnectorSSLError,
             aiohttp.ClientConnectorError,
             aiohttp.ClientOSError,
@@ -240,6 +242,9 @@ class HttpDownloader(BaseDownloader):
             SizeValidationError,
         )
 
+        retryable_errors = tuple(
+            [e for e in default_retryable_errors if e not in disable_retry_list]
+        )
         async with self.semaphore:
 
             @backoff.on_exception(


### PR DESCRIPTION
https://github.com/pulp/pulpcore/issues/5937

## Testing

I dont know how to write an automated test for that, but I've asserted it through logs by running the `test_remote_content_changed_with_on_demand`, which causes a digest validation error in the on-demand streaming context.

**Before**:

```
[pulp]  | (OMITED) "GET /pulp/api/v3/distributions/file/file/01936f14-21af-7102-b69b-65a30d34596e/ HTTP/1.0" 200 631 "-" "api/using_plugin/test_content_delivery.py::test_remote_content_changed_with_on_demand"',)

[pulp]  | Backing off download_wrapper(...) for 0.8s (pulpcore.exceptions.validation.DigestValidationError: A file located at the url https://127.0.0.1:44247/basic/2.iso failed validation due to checksum. Expected '89a0fbc35e07fe70fb46467326b6ab6a5bc53da48d518f3a6c6ef17dc3fab256', Actual '22f92924b8fef320f9933b196339a5dc5f1f662a27b09a3da9f2d73ce4678aa1')
[pulp]  | pulp [None]: backoff:INFO: Backing off download_wrapper(...) for 0.8s (pulpcore.exceptions.validation.DigestValidationError: A file located at the url https://127.0.0.1:44247/basic/2.iso failed validation due to checksum. Expected '89a0fbc35e07fe70fb46467326b6ab6a5bc53da48d518f3a6c6ef17dc3fab256', Actual '22f92924b8fef320f9933b196339a5dc5f1f662a27b09a3da9f2d73ce4678aa1')
[pulp]  | Backing off download_wrapper(...) for 0.2s (pulpcore.exceptions.validation.DigestValidationError: A file located at the url https://127.0.0.1:44247/basic/2.iso failed validation due to checksum. Expected '89a0fbc35e07fe70fb46467326b6ab6a5bc53da48d518f3a6c6ef17dc3fab256', Actual '22f92924b8fef320f9933b196339a5dc5f1f662a27b09a3da9f2d73ce4678aa1')
[pulp]  | pulp [None]: backoff:INFO: Backing off download_wrapper(...) for 0.2s (pulpcore.exceptions.validation.DigestValidationError: A file located at the url https://127.0.0.1:44247/basic/2.iso failed validation due to checksum. Expected '89a0fbc35e07fe70fb46467326b6ab6a5bc53da48d518f3a6c6ef17dc3fab256', Actual '22f92924b8fef320f9933b196339a5dc5f1f662a27b09a3da9f2d73ce4678aa1')
[pulp]  | Backing off download_wrapper(...) for 1.6s (pulpcore.exceptions.validation.DigestValidationError: A file located at the url https://127.0.0.1:44247/basic/2.iso failed validation due to checksum. Expected '89a0fbc35e07fe70fb46467326b6ab6a5bc53da48d518f3a6c6ef17dc3fab256', Actual '22f92924b8fef320f9933b196339a5dc5f1f662a27b09a3da9f2d73ce4678aa1')
[pulp]  | pulp [None]: backoff:INFO: Backing off download_wrapper(...) for 1.6s (pulpcore.exceptions.validation.DigestValidationError: A file located at the url https://127.0.0.1:44247/basic/2.iso failed validation due to checksum. Expected '89a0fbc35e07fe70fb46467326b6ab6a5bc53da48d518f3a6c6ef17dc3fab256', Actual '22f92924b8fef320f9933b196339a5dc5f1f662a27b09a3da9f2d73ce4678aa1')
[pulp]  | Giving up download_wrapper(...) after 4 tries (pulpcore.exceptions.validation.DigestValidationError: A file located at the url https://127.0.0.1:44247/basic/2.iso failed validation due to checksum. Expected '89a0fbc35e07fe70fb46467326b6ab6a5bc53da48d518f3a6c6ef17dc3fab256', Actual '22f92924b8fef320f9933b196339a5dc5f1f662a27b09a3da9f2d73ce4678aa1')
[pulp]  | pulp [None]: backoff:ERROR: Giving up download_wrapper(...) after 4 tries (pulpcore.exceptions.validation.DigestValidationError: A file located at the url https://127.0.0.1:44247/basic/2.iso failed validation due to checksum. Expected '89a0fbc35e07fe70fb46467326b6ab6a5bc53da48d518f3a6c6ef17dc3fab256', Actual '22f92924b8fef320f9933b196339a5dc5f1f662a27b09a3da9f2d73ce4678aa1')

[pulp]  | [2024-11-27 19:23:34 +0000] [44606] [ERROR] Error handling request
```

**After**:

```
[pulp]  | (OMITED) "GET /pulp/api/v3/distributions/file/file/01936f15-b88b-770a-b1fe-16e47a99c3bf/ HTTP/1.0" 200 631 "-" "api/using_plugin/test_content_delivery.py::test_remote_content_changed_with_on_demand"',)

[pulp]  | [2024-11-27 19:25:15 +0000] [44813] [ERROR] Error handling request
```