### PR TITLE
Backport #5658 to 3.49

### DIFF
--- a/pulpcore/app/settings.py
+++ b/pulpcore/app/settings.py
@@ -14,13 +14,19 @@ from contextlib import suppress
 from importlib import import_module
 from logging import getLogger
 from pathlib import Path
-from pkg_resources import iter_entry_points
 
 from cryptography.fernet import Fernet
 from django.core.exceptions import ImproperlyConfigured
 from django.db import connection
 
 from pulpcore import constants
+
+if sys.version_info < (3, 10):
+    # Python 3.9 has a rather different interface for `entry_points`.
+    # Let's use a compatibility version.
+    from importlib_metadata import entry_points
+else:
+    from importlib.metadata import entry_points
 
 # Build paths inside the project like this: BASE_DIR / ...
 BASE_DIR = Path(__file__).absolute().parent
@@ -84,9 +90,9 @@ INSTALLED_APPS = [
 # Enumerate the installed Pulp plugins during the loading process for use in the status API
 INSTALLED_PULP_PLUGINS = []
 
-for entry_point in iter_entry_points("pulpcore.plugin"):
+for entry_point in entry_points(group="pulpcore.plugin"):
     plugin_app_config = entry_point.load()
-    INSTALLED_PULP_PLUGINS.append(entry_point.module_name)
+    INSTALLED_PULP_PLUGINS.append(entry_point.name)
     INSTALLED_APPS.append(plugin_app_config)
 
 # Optional apps that help with development, or augment Pulp in some non-critical way

--- a/pulpcore/app/tasks/replica.py
+++ b/pulpcore/app/tasks/replica.py
@@ -1,10 +1,9 @@
 import os
 import platform
-from pkg_resources import get_distribution
 import sys
 from tempfile import NamedTemporaryFile
 
-from pulpcore.app.apps import pulp_plugin_configs
+from pulpcore.app.apps import pulp_plugin_configs, PulpAppConfig
 from pulpcore.app.models import UpstreamPulp, TaskGroup
 from pulpcore.app.replica import ReplicaContext
 
@@ -15,7 +14,7 @@ def user_agent():
     """
     Produce a User-Agent string to identify Pulp and relevant system info.
     """
-    pulp_version = get_distribution("pulpcore").version
+    pulp_version = PulpAppConfig.version
     python = "{} {}.{}.{}-{}{}".format(sys.implementation.name, *sys.version_info)
     uname = platform.uname()
     system = f"{uname.system} {uname.machine}"

--- a/pulpcore/download/factory.py
+++ b/pulpcore/download/factory.py
@@ -5,7 +5,6 @@ import copy
 from gettext import gettext as _
 from multidict import MultiDict
 import platform
-from pkg_resources import get_distribution
 import ssl
 import sys
 from tempfile import NamedTemporaryFile
@@ -13,6 +12,7 @@ from urllib.parse import urlparse
 
 import aiohttp
 
+from pulpcore.app.apps import PulpAppConfig
 from .http import HttpDownloader
 from .file import FileDownloader
 
@@ -80,7 +80,7 @@ class DownloaderFactory:
         """
         Produce a User-Agent string to identify Pulp and relevant system info.
         """
-        pulp_version = get_distribution("pulpcore").version
+        pulp_version = PulpAppConfig.version
         python = "{} {}.{}.{}-{}{}".format(sys.implementation.name, *sys.version_info)
         uname = platform.uname()
         system = f"{uname.system} {uname.machine}"

--- a/requirements.txt
+++ b/requirements.txt
@@ -35,7 +35,6 @@ pyparsing>=3.1.0,<=3.1.1
 python-gnupg>=0.5,<=0.5.2
 PyYAML>=5.1.1,<=6.0.1
 redis>=4.3,<5.0.3
-setuptools>=39.2,<69.2.0
 tablib<3.6.0
 url-normalize>=1.4.3,<=1.4.3
 uuid6>=2023.5.2,<=2024.1.12


### PR DESCRIPTION
backport #5658 to 3.49

Fix pkg_resources (deprecated) error when loading extra requirements.

Required to be able to merge https://github.com/ansible/django-ansible-base/pull/656 on galaxy_ng

Will require a new patch release.