### PR TITLE
Update update dependencies to prevent downgrades from 3.49

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 aiodns>=3.0,<=3.2.0
 aiofiles>=22.1,<24.2.0
-aiohttp>=3.8.1,<3.10.9
+aiohttp>=3.8.1,<3.10.11
 asyncio-throttle>=1.0,<=1.0.2
 async-timeout>=4.0.3,<4.0.4;python_version<"3.11"
 backoff>=2.1.2,<2.2.2
@@ -38,4 +38,4 @@ tablib<3.6.0
 url-normalize>=1.4.3,<=1.4.3
 uuid6>=2023.5.2,<=2024.7.10
 whitenoise>=5.0,<6.8.0
-yarl>=1.8,<1.13.2
+yarl>=1.8,<1.15.3


### PR DESCRIPTION
This adjusts upper bounds of dependencies that were already bumped on the 3.49 branch.