### PR TITLE
Quiet a lint warning about improper flag usage

### DIFF
--- a/pulp_certguard/tests/functional/artifacts/x509/gensrv.sh
+++ b/pulp_certguard/tests/functional/artifacts/x509/gensrv.sh
@@ -32,7 +32,7 @@ then
     -CA certificates/ca.pem \
     -CAkey keys/ca.pem \
     -CAcreateserial \
-    -set_serial $RANDOM
+    -set_serial $RANDOM \
     -subj "/CN=$HOSTNAME" &> /dev/null
 else
   openssl x509 \
@@ -45,7 +45,7 @@ else
     -CA certificates/ca.pem \
     -CAkey keys/ca.pem \
     -CAcreateserial \
-    -set_serial $RANDOM
+    -set_serial $RANDOM \
     -subj "/CN=$HOSTNAME" &> /dev/null
 fi
 


### PR DESCRIPTION
None of these scripts are even used AFAICT.  They're just for posterity sake alongside the certs and such that they were used to create.