### PR TITLE
[PULP-296] Fixup running tasks that are not unblocked

### DIFF
--- a/CHANGES/6225.bugfix
+++ b/CHANGES/6225.bugfix
@@ -1,0 +1,2 @@
+Added an extra check to the task unblocking logic to catch a rare case of stuck tasks in running, but never unblocked.
+Tasks in normal operation should never end in this state, but at least with a specific upgrade it can happen.

--- a/pulpcore/tasking/worker.py
+++ b/pulpcore/tasking/worker.py
@@ -298,6 +298,17 @@ class PulpcoreWorker:
                 )
                 task.unblock()
                 changed = True
+            elif task.state == TASK_STATES.RUNNING and task.unblocked_at is None:
+                # This should not happen in normal operation.
+                # And it is only an issue if the worker running that task died, because it will
+                # never be considered for cleanup.
+                # But during at least one specific upgrade this situation can emerge.
+                # In this case, we can assume that the old algorithm was employed to identify the
+                # task as unblocked, and we just rectify the situation here.
+                _logger.warn(
+                    _("Running task %s was not previously marked unblocked. Fixing.", task.pk)
+                )
+                task.unblock()
 
             # Record the resources of the pending task
             taken_exclusive_resources.update(exclusive_resources)


### PR DESCRIPTION
This is supposed to be a very rare corner case up to now only known to happen during a certian upgrade (where unblocked_at was introduced). Since someone decided to run such tasks already, it must be ok to mark them unblocked now.