### PR TITLE
Add pulp_created field as a task filter

### DIFF
--- a/CHANGES/6241.feature
+++ b/CHANGES/6241.feature
@@ -1,0 +1,1 @@
+Added `pulp_created` filter for Tasks API.

--- a/pulpcore/app/viewsets/task.py
+++ b/pulpcore/app/viewsets/task.py
@@ -63,6 +63,7 @@ class TaskFilter(BaseFilterSet):
             "worker": ["exact", "in", "isnull"],
             "name": ["exact", "contains", "in", "ne"],
             "logging_cid": ["exact", "contains"],
+            "pulp_created": DATETIME_FILTER_OPTIONS,
             "started_at": DATETIME_FILTER_OPTIONS,
             "finished_at": DATETIME_FILTER_OPTIONS,
             "unblocked_at": DATETIME_FILTER_OPTIONS,


### PR DESCRIPTION
Adds the `pulp_created` datetime field as a filter to allow
filtering tasks by its creation date. Also, adds a test to
check if the filter is working as expected.

Closes #6241 
