### PR TITLE
Fix immediate tasks to run in temp dir

### DIFF
--- a/CHANGES/plugin_api/5928.bugfix
+++ b/CHANGES/plugin_api/5928.bugfix
@@ -1,0 +1,1 @@
+Fixed immediate tasks to run in a temporary directory. 

--- a/pulpcore/tasking/tasks.py
+++ b/pulpcore/tasking/tasks.py
@@ -3,11 +3,14 @@ import contextlib
 import contextvars
 import importlib
 import logging
+import os
 import sys
 import traceback
+import tempfile
 from datetime import timedelta
 from gettext import gettext as _
 
+from django.conf import settings
 from django.db import connection, transaction
 from django.db.models import Model, Max
 from django_guid import get_guid
@@ -226,7 +229,9 @@ def dispatch(
                 ).exists()
             ):
                 task.unblock()
-                execute_task(task)
+                with tempfile.TemporaryDirectory(dir=settings.WORKING_DIRECTORY) as working_dir:
+                    os.chdir(working_dir)
+                    execute_task(task)
                 if resources:
                     notify_workers = True
             elif deferred:


### PR DESCRIPTION
fixes: #5928

This one was pretty simple for the Cursor agent to solve. Should I add tests for this?