### PR TITLE
Fix a FileNotFound err with tmpDir in immediate tasks

### DIFF
--- a/pulpcore/tasking/tasks.py
+++ b/pulpcore/tasking/tasks.py
@@ -229,9 +229,11 @@ def dispatch(
                 ).exists()
             ):
                 task.unblock()
+                cur_dir = os.getcwd()
                 with tempfile.TemporaryDirectory(dir=settings.WORKING_DIRECTORY) as working_dir:
                     os.chdir(working_dir)
                     execute_task(task)
+                os.chdir(cur_dir)
                 if resources:
                     notify_workers = True
             elif deferred:


### PR DESCRIPTION
When an immediate task is ran the api worker switches directory to a tmp directory inside the working directory. After the task is finished the tmp directory is deleted, but the api worker still thinks it is in the tmp directory thus causing future cwd to fail. This commit changes the pulpcore code to chdir back after finishing the task.