### PR TITLE
[PR #6294/703333d backport][3.71] Change workdir even if the immediate task fails

### DIFF
--- a/CHANGES/6293.bugfix
+++ b/CHANGES/6293.bugfix
@@ -1,0 +1,1 @@
+Fixed an issue in immediate tasks switching to tmp directories and API worker failing to run `cwd`.

--- a/pulpcore/tasking/tasks.py
+++ b/pulpcore/tasking/tasks.py
@@ -229,9 +229,16 @@ def dispatch(
                 ).exists()
             ):
                 task.unblock()
+
+                cur_dir = os.getcwd()
                 with tempfile.TemporaryDirectory(dir=settings.WORKING_DIRECTORY) as working_dir:
                     os.chdir(working_dir)
-                    execute_task(task)
+                    try:
+                        execute_task(task)
+                    finally:
+                        # whether the task fails or not, we should always restore the workdir
+                        os.chdir(cur_dir)
+
                 if resources:
                     notify_workers = True
             elif deferred:


### PR DESCRIPTION
**This is a backport of PR https://github.com/pulp/pulpcore/pull/6294.**
(cherry picked from commit 703333dc12d0d4eb1ea4f02e7713e7a9fec728d9)