### PR TITLE
Revert "Use openapi 3.1.0 for schema generation"

### DIFF
--- a/pulpcore/app/settings.py
+++ b/pulpcore/app/settings.py
@@ -332,7 +332,6 @@ SPECTACULAR_SETTINGS = {
         "drf_spectacular.hooks.postprocess_schema_enums",
         "pulpcore.openapi.hooks.add_info_hook",
     ],
-    "OAS_VERSION": "3.1.1",
     "TITLE": "Pulp 3 API",
     "DESCRIPTION": "Fetch, Upload, Organize, and Distribute Software Packages",
     "VERSION": "v3",

--- a/pulpcore/tests/functional/api/test_openapi_schema.py
+++ b/pulpcore/tests/functional/api/test_openapi_schema.py
@@ -11,7 +11,7 @@ from drf_spectacular import validation
 from collections import defaultdict
 
 JSON_SCHEMA_SPEC_PATH = os.path.join(
-    os.path.dirname(validation.__file__), "openapi_3_1_schema.json"
+    os.path.dirname(validation.__file__), "openapi_3_0_schema.json"
 )
 
 
@@ -27,9 +27,9 @@ def openapi3_schema_spec():
 def openapi3_schema_with_modified_safe_chars(openapi3_schema_spec):
     openapi3_schema_spec_copy = copy.deepcopy(openapi3_schema_spec)  # Don't modify the original
     # Making OpenAPI validation to accept paths starting with / and {
-    properties = openapi3_schema_spec_copy["$defs"]["paths"]["patternProperties"]
-    properties["^/|{"] = properties["^/"]
-    del properties["^/"]
+    properties = openapi3_schema_spec_copy["definitions"]["Paths"]["patternProperties"]
+    properties["^\\/|{"] = properties["^\\/"]
+    del properties["^\\/"]
 
     return openapi3_schema_spec_copy
 


### PR DESCRIPTION
This change is just a setting and should not even change the api.
But the api specs change a bit more than our tooling can handle at the moment.

Reverts pulp/pulpcore#6296