### PR TITLE
[PULP-296] Fix an issue with a previous patch for tasks not marked unblocked

### DIFF
--- a/CHANGES/6225.misc
+++ b/CHANGES/6225.misc
@@ -1,0 +1,1 @@
+Fix an issue with a previous patch for a rare blocked tasks issue.

--- a/pulpcore/tasking/worker.py
+++ b/pulpcore/tasking/worker.py
@@ -310,7 +310,7 @@ class PulpcoreWorker:
                 # In this case, we can assume that the old algorithm was employed to identify the
                 # task as unblocked, and we just rectify the situation here.
                 _logger.warn(
-                    _("Running task %s was not previously marked unblocked. Fixing.", task.pk)
+                    "Running task %s was not previously marked unblocked. Fixing.", task.pk
                 )
                 task.unblock()
 


### PR DESCRIPTION
Tasks can get stuck in running without a runner in rare instances. The previous patch had a malformed log statement which caused crashes.

fixes #6225