### PR TITLE
Fix cache invalidation on publication create & repo-version delete

### DIFF
--- a/CHANGES/6333.bugfix
+++ b/CHANGES/6333.bugfix
@@ -1,0 +1,1 @@
+Fixed cache not being invalidated when a publication was created or a repository version was deleted.

--- a/pulpcore/app/models/publication.py
+++ b/pulpcore/app/models/publication.py
@@ -230,8 +230,7 @@ class Publication(MasterModel):
                     repository=self.repository_version.repository
                 ).values_list("base_path", flat=True)
                 if base_paths:
-                    base_keys = [f"{self.pulp_domain.name}:{base_path}" for base_path in base_paths]
-                    Cache().delete(base_key=base_keys)
+                    Cache().delete(base_key=cache_key(base_paths))
 
 
 class PublishedArtifact(BaseModel):

--- a/pulpcore/app/models/repository.py
+++ b/pulpcore/app/models/repository.py
@@ -1170,7 +1170,7 @@ class RepositoryVersion(BaseModel):
             if settings.CACHE_ENABLED:
                 base_paths = self.distribution_set.values_list("base_path", flat=True)
                 if base_paths:
-                    Cache().delete(base_key=base_paths)
+                    Cache().delete(base_key=cache_key(base_paths))
 
             # Handle the manipulation of the repository version content and its final deletion in
             # the same transaction.

--- a/pulpcore/tests/functional/api/using_plugin/test_content_cache.py
+++ b/pulpcore/tests/functional/api/using_plugin/test_content_cache.py
@@ -74,6 +74,14 @@ def test_full_workflow(
         url = urljoin(distro_base_url, file)
         assert (200, "HIT" if i % 2 == 1 else "MISS") == _check_cache(url), file
 
+    # Check that creating a new publication manually invalidates the cache
+    body = FileFilePublication(repository=repo.pulp_href)
+    monitor_task(file_bindings.PublicationsFileApi.create(body).task)
+    files = ["", "", "PULP_MANIFEST", "PULP_MANIFEST", "1.iso", "1.iso"]
+    for i, file in enumerate(files):
+        url = urljoin(distro_base_url, file)
+        assert (200, "HIT" if i % 2 == 1 else "MISS") == _check_cache(url), file
+
     # Add a new distribution and check that its responses are cached separately
     distro2 = file_distribution_factory(repository=repo.pulp_href)
     distro2_base_url = distribution_base_url(distro2.base_url)


### PR DESCRIPTION
From my understanding there was a timing window during the sync that probably caused the cache issue. In replicate we sync with auto-publish which means that right after the new repo-version is created we start publishing in the same task. We invalidate the cache after a new repo-version is created, but we were failing to do so when a new publication was created (when domains were turned off). So after the sync you could end up with old items still in the cache if you had clients still fetching content during the sync. 

fixes: #6333