### PR TITLE
[Docs] Improve admin configuration pages

### DIFF
--- a/docs/admin/guides/configure-pulp/configure-storages.md
+++ b/docs/admin/guides/configure-pulp/configure-storages.md
@@ -6,13 +6,10 @@ See the reference for the [`STORAGES` settings](site:pulpcore/docs/admin/referen
 ## Modifying the settings
 
 The settings can be updated via the `settings.py` file or through environment variables
-and have support to dynaconf merge features (learn more on the [Settings Introduction](site:pulpcore/docs/admin/guides/configure-pulp/introduction/)).
+and have support to dynaconf merge features.
+The means to modify them will depend on your deployment option.
 
-To learn where and how to modify the files and environment variables, refer to the appropriate installation method documentation:
-
-* [Container (single-process) quickstart](site:pulp-oci-images/docs/admin/tutorials/quickstart/#single-container)
-* [Container (multi-process) quickstart](site:pulp-oci-images/docs/admin/tutorials/quickstart/#podman-or-docker-compose)
-* [Pulp Operator quickstart](site:pulp-operator/docs/admin/tutorials/quickstart-kubernetes/)
+Learn more on the [Settings Introduction](site:pulpcore/docs/admin/guides/configure-pulp/).
 
 ## Local Filesystem (default)
 
@@ -94,12 +91,14 @@ Check out how to configure [django-storages to use CloudFront with URL signing](
 Also, you can follow this [doc](https://github.com/aws-samples/amazon-cloudfront-signed-urls-using-lambda-secretsmanager/tree/main/2-Create_CloudFront_Distribution) to understand what you need to configure on AWS side.
 
 You'll need:
+
 - The standard options for a normal S3 Bucket (access_key, secret_key, bucket_name and region_name)
 - A CloudFront Key ID (`cloudfront_key_id`)
 - A CloudFront Key (`cloudfront_key`)
 - And a Custom Domain (`custom_domain`)
 
 When creating a `Domain` you can use the following payload:
+
 ```json
 {
   "name": "cloudfront_storage",
@@ -119,20 +118,22 @@ When creating a `Domain` you can use the following payload:
 }
 ```
 
-=== Create a new Domain
-```bash
-# We need to format our key to a JSON friendly format
-export CLOUDFRONT_KEY=$(cat keyfile.pem | jq -sR .)
+=== "Create a new Domain"
 
-curl -X POST $BASE_HREF/pulp/default/api/v3/domains/ -d '{"name": "cloudfront_storage", "storage_class": "storages.backends.s3boto3.S3Boto3Storage", "storage_settings": {"access_key": "{aws_access_key}", "secret_key": "{aws_secret_key}", "bucket_name": "{aws_bucket_name}", "region_name": "{aws_region_name}", "default_acl": "private", "cloudfront_key_id": "{aws_cloudfront_key_id}", "cloudfront_key": '"$CLOUDFRONT_KEY"', "custom_domain": "{aws_cloudfront_custom_domain}"}, "redirect_to_object_storage": true, "hide_guarded_distributions": false}' -H 'Content-Type: application/json'
-```
+    ```bash
+    # We need to format our key to a JSON friendly format
+    export CLOUDFRONT_KEY=$(cat keyfile.pem | jq -sR .)
 
-=== Create a new Domain using pulp-cli
-```bash
-export CLOUDFRONT_KEY=$(cat keyfile.pem | jq -sR .)
+    curl -X POST $BASE_HREF/pulp/default/api/v3/domains/ -d '{"name": "cloudfront_storage", "storage_class": "storages.backends.s3boto3.S3Boto3Storage", "storage_settings": {"access_key": "{aws_access_key}", "secret_key": "{aws_secret_key}", "bucket_name": "{aws_bucket_name}", "region_name": "{aws_region_name}", "default_acl": "private", "cloudfront_key_id": "{aws_cloudfront_key_id}", "cloudfront_key": '"$CLOUDFRONT_KEY"', "custom_domain": "{aws_cloudfront_custom_domain}"}, "redirect_to_object_storage": true, "hide_guarded_distributions": false}' -H 'Content-Type: application/json'
+    ```
 
-pulp domain create --name cloudfront_test --storage-class storages.backends.s3boto3.S3Boto3Storage --storage-settings '{"access_key": "{aws_access_key}", "secret_key": "{aws_secret_key}", "bucket_name": "{aws_bucket_name}", "region_name": "{aws_region_name}", "default_acl": "private", "cloudfront_key_id": "{aws_cloudfront_key_id}", "cloudfront_key": '"$CLOUDFRONT_KEY"', "custom_domain": "{aws_cloudfront_custom_domain}"}'
-```
+=== "Create a new Domain using pulp-cli"
+
+    ```bash
+    export CLOUDFRONT_KEY=$(cat keyfile.pem | jq -sR .)
+
+    pulp domain create --name cloudfront_test --storage-class storages.backends.s3boto3.S3Boto3Storage --storage-settings '{"access_key": "{aws_access_key}", "secret_key": "{aws_secret_key}", "bucket_name": "{aws_bucket_name}", "region_name": "{aws_region_name}", "default_acl": "private", "cloudfront_key_id": "{aws_cloudfront_key_id}", "cloudfront_key": '"$CLOUDFRONT_KEY"', "custom_domain": "{aws_cloudfront_custom_domain}"}'
+    ```
 
 Create your remotes, repositories, and distributions under this domain and the requests will be redirected to the
 CloudFront custom domain specified.

--- a/docs/admin/guides/configure-pulp/index.md
+++ b/docs/admin/guides/configure-pulp/index.md
@@ -6,9 +6,24 @@ to configure Pulp settings using various ways:
 - `Environment Variables <env-var-settings>` - Enabled by default.
 - `Configuration File <config-file-settings>` - Disabled by default, but easy to enable.
 
+!!! note "Available Settings"
 
+    For a comprehensive list of core settings, refer to the
+    [Settings Reference](site:pulpcore/docs/admin/reference/settings/).
 
-## Through Environment Variables
+    Plugin-specific settings are typically located in the corresponding Admin/Reference section
+
+!!! note "Deployment-specific instructions"
+
+    For specialized instruction on how to edit/set files and environment, check the guide appropriate to your deployment option:
+
+    * [Container (single-process) quickstart](site:pulp-oci-images/docs/admin/tutorials/quickstart/#single-container)
+    * [Container (multi-process) quickstart](site:pulp-oci-images/docs/admin/tutorials/quickstart/#podman-or-docker-compose)
+    * [Pulp Operator quickstart](site:pulp-operator/docs/admin/tutorials/quickstart-kubernetes/)
+
+## Configure
+
+### Through Environment Variables
 
 Configuration by specifying environment variables is enabled by default. Any
 `Setting ` can be configured using Dynaconf by prepending `PULP_` to the setting
@@ -19,7 +34,7 @@ environment variable. For example, in a shell you can use `export` to set this:
 export PULP_SECRET_KEY="This should be a 50 chars or longer unique secret!"
 ```
 
-## Through Configuration File
+### Through Configuration File
 
 By default, Pulp does not read settings from a configuration file. Enable this by specifying the
 `PULP_SETTINGS` environment variable with the path to your configuration file. For example:
@@ -46,15 +61,20 @@ In this example the settings file ends in ".py" so it needs to be valid Python, 
 
 ## View Settings
 
-To list the effective settings on a Pulp installation, while on the system where Pulp is installed
-run the command `dynaconf list`. This will show the effective settings Pulp will use.
+To view the effective settings on a Pulp installation you can use `dynaconf` commands.
+Refer to the cli help for detailed usage instructions:
+
+- `dynaconf list`: List all effective settings
+- `dynaconf get -k <settings>`: Show value for a given key
+- `dynaconf inspect -k <setting>`: Show debug info for a given key (e.g, load history)
+
+For dynaconf to work, it'a required to set `DJANGO_SETTINGS_MODULE` to the django settings module location.
+E.g, `export DJANGO_SETTINGS_MODULE=pulpcore.app.settings`.
+
+The installations provided by Pulp will usually have that already set by default.
 
 !!! note
     Settings can come from both settings file and environment variables. When running the
     `dynaconf list` command, be sure you have the same environment variables set as your Pulp
     installation.
 
-
-!!! note
-    For the `dynaconf list` command to succeed it needs to environment variable set identifying
-    where the django settings file is. `export DJANGO_SETTINGS_MODULE=pulpcore.app.settings`.

--- a/docs/admin/reference/settings.md
+++ b/docs/admin/reference/settings.md
@@ -5,14 +5,15 @@ settings.
 
 - `SECRET_KEY <secret-key-setting>`
 
-!!! note
-    For more information on how to specify settings see the [`Applying Settings`](#).
-
 Pulp uses three types of settings:
 
 - `Django settings` Pulp is configuring
 - `Redis settings` Pulp is using
 - `Pulp defined settings`
+
+!!! note
+    For more information on how to specify settings see the
+    [`Applying Settings`](site:pulpcore/docs/admin/guides/configure-pulp/).
 
 ## Django Settings
 


### PR DESCRIPTION
This PR does:
- Move general info from storages config to general configuration guide
- Fix and add more inter-links between different settings pages
- Fix markdown formatting errors for tabbed content and listings (should have a space before the bullets).