### PR TITLE
Validate orphan_protection_time in orphans/cleanup

### DIFF
--- a/CHANGES/3234.feature
+++ b/CHANGES/3234.feature
@@ -1,0 +1,1 @@
+Added validation to the `orphans/cleanup/` endpoint to restrict the `orphan_protection_time` value.

--- a/pulpcore/app/serializers/orphans.py
+++ b/pulpcore/app/serializers/orphans.py
@@ -4,6 +4,10 @@ from rest_framework import fields, serializers
 
 from pulpcore.app.models import Content
 from pulpcore.app.serializers import ValidateFieldsMixin
+from pulpcore.constants import (
+    ORPHAN_PROTECTION_TIME_LOWER_BOUND,
+    ORPHAN_PROTECTION_TIME_UPPER_BOUND,
+)
 
 
 class OrphansCleanupSerializer(serializers.Serializer, ValidateFieldsMixin):
@@ -21,6 +25,8 @@ class OrphansCleanupSerializer(serializers.Serializer, ValidateFieldsMixin):
         ),
         allow_null=True,
         required=False,
+        min_value=ORPHAN_PROTECTION_TIME_LOWER_BOUND,
+        max_value=ORPHAN_PROTECTION_TIME_UPPER_BOUND,
     )
 
     def validate_content_hrefs(self, value):

--- a/pulpcore/constants.py
+++ b/pulpcore/constants.py
@@ -120,3 +120,8 @@ PROTECTED_REPO_VERSION_MESSAGE = _(
 
 # Valid timestamp format for checkpoint distribution paths.
 CHECKPOINT_TS_FORMAT = "%Y%m%dT%H%M%SZ"
+
+# Allowed range for the ORPHAN_PROTECTION_TIME value in minutes
+# The upper boundary represents an unsigned 32-bit integer and prevents overflow
+ORPHAN_PROTECTION_TIME_LOWER_BOUND = 0
+ORPHAN_PROTECTION_TIME_UPPER_BOUND = 4294967295  # (2^32)-1

--- a/pulpcore/tests/unit/serializers/test_orphans_cleanup.py
+++ b/pulpcore/tests/unit/serializers/test_orphans_cleanup.py
@@ -1,0 +1,18 @@
+import pytest
+
+from rest_framework import serializers
+
+from pulpcore.app.serializers import OrphansCleanupSerializer
+
+
+@pytest.mark.parametrize("value", [-1, 4294967296])
+def test_orphan_protection_time(value):
+    """
+    Test that OrphansCleanupSerializer is not valid if the "orphan_protection_time"
+    value is not in the range defined by ORPHAN_PROTECTION_TIME_LOWER_BOUND
+    and ORPHAN_PROTECTION_TIME_UPPER_BOUND.
+    """
+    serializer = OrphansCleanupSerializer(data={"orphan_protection_time": value})
+
+    with pytest.raises(serializers.ValidationError):
+        serializer.is_valid(raise_exception=True)


### PR DESCRIPTION
This PR adds validation to the `orphans/cleanup/` endpoint to restrict the `orphan_protection_time` value. The allowed range is from 0 to 365 days.

Fixes #3234