### PR TITLE
Fixed 0131 and 0132 migrations to allow upgrading from 3.73.

### DIFF
--- a/CHANGES/6375.bugfix
+++ b/CHANGES/6375.bugfix
@@ -1,0 +1,1 @@
+Fixed miigrations 0131 and 0132 to make it possible to upgrade from 3.73.

--- a/pulpcore/app/migrations/0131_distribution_checkpoint_publication_checkpoint.py
+++ b/pulpcore/app/migrations/0131_distribution_checkpoint_publication_checkpoint.py
@@ -6,7 +6,7 @@ from django.db import migrations, models
 class Migration(migrations.Migration):
 
     dependencies = [
-        ("core", "0130_upstreampulp_policy"),
+        ("core", "0132_alter_content_options"),
     ]
 
     operations = [

--- a/pulpcore/app/migrations/0132_alter_content_options.py
+++ b/pulpcore/app/migrations/0132_alter_content_options.py
@@ -6,7 +6,7 @@ from django.db import migrations
 class Migration(migrations.Migration):
 
     dependencies = [
-        ("core", "0131_distribution_checkpoint_publication_checkpoint"),
+        ("core", "0130_upstreampulp_policy"),
     ]
 
     operations = [


### PR DESCRIPTION
See notes in the issue for details.

fixes #6375.