### PR TITLE
Fixed task purge when no user can be infered

### DIFF
--- a/CHANGES/6380.bugfix
+++ b/CHANGES/6380.bugfix
@@ -1,0 +1,1 @@
+Fixed task purge in case no access policy based permission framework is configured for Pulp.

--- a/pulpcore/app/util.py
+++ b/pulpcore/app/util.py
@@ -561,10 +561,10 @@ def set_current_user(user):
     _current_user_func.set(lambda: user)
 
 
-def set_current_user_lazy(user):
+def set_current_user_lazy(user_func):
     # This allows to be lazy, because the authentication happens on the view and not in the
     # middleware.
-    _current_user_func.set(user)
+    _current_user_func.set(user_func)
 
 
 default_domain = None

--- a/pulpcore/app/viewsets/task.py
+++ b/pulpcore/app/viewsets/task.py
@@ -33,7 +33,7 @@ from pulpcore.app.serializers import (
     WorkerSerializer,
 )
 from pulpcore.app.tasks import purge
-from pulpcore.app.util import get_domain, get_artifact_url
+from pulpcore.app.util import get_domain, get_artifact_url, get_current_user
 from pulpcore.app.viewsets import NamedModelViewSet, RolesMixin
 from pulpcore.app.viewsets.base import DATETIME_FILTER_OPTIONS, NAME_FILTER_OPTIONS
 from pulpcore.app.viewsets.custom_filters import (
@@ -258,8 +258,11 @@ class TaskViewSet(
         """
         serializer = PurgeSerializer(data=request.data)
         serializer.is_valid(raise_exception=True)
+        current_user = get_current_user()
         task = dispatch(
-            purge, args=[serializer.data["finished_before"], list(serializer.data["states"])]
+            purge,
+            args=[serializer.data["finished_before"], list(serializer.data["states"])],
+            kwargs={"user_pk": None if current_user is None else current_user.pk},
         )
         return OperationPostponedResponse(task, request)
 


### PR DESCRIPTION
Guessing the user to scope tasks to purge via the permission framework, requires one to us an access policy based permission class. We should not rely on that.