### PR TITLE
Fix pull-through cache for on-demand content

### DIFF
--- a/CHANGES/6385.bugfix
+++ b/CHANGES/6385.bugfix
@@ -1,0 +1,1 @@
+Fixed pull-through caching failure when content already existed on-demand.

--- a/pulpcore/content/handler.py
+++ b/pulpcore/content/handler.py
@@ -1060,18 +1060,20 @@ class Handler:
                 except IntegrityError:
                     # There is already content saved
                     content = c_type.objects.get(content.q())
-                    created_artifact_digests = {rp: a.sha256 for rp, a in artifacts.items() if a}
+                    # Update the ContentArtifacts to point to the new Artifacts
                     cas = list(content.contentartifact_set.select_related("artifact"))
-                    found_artifact_digests = {
-                        ca.relative_path: ca.artifact.sha256 for ca in cas if ca.artifact
-                    }
-                    # The created artifacts should be (at least) a subset of the found artifacts
-                    if not created_artifact_digests.items() <= found_artifact_digests.items():
-                        raise RuntimeError(
-                            "The Artifacts created during pull-through does not "
-                            "match the Artifacts already stored for the same "
-                            "content."
+                    if len(cas) == 0 or any(ca.artifact is None for ca in cas):
+                        new_cas = [
+                            ContentArtifact(artifact=a, content=content, relative_path=rp)
+                            for rp, a in artifacts.items()
+                        ]
+                        cas = ContentArtifact.objects.bulk_create(
+                            new_cas,
+                            update_conflicts=True,
+                            update_fields=["artifact"],
+                            unique_fields=["content", "relative_path"],
                         )
+
                 # Now try to save RemoteArtifacts for each ContentArtifact
                 for ca in cas:
                     if url := remote.get_remote_artifact_url(ca.relative_path, request=request):

--- a/pulpcore/tests/unit/content/test_handler.py
+++ b/pulpcore/tests/unit/content/test_handler.py
@@ -5,6 +5,7 @@ import uuid
 from unittest.mock import Mock, AsyncMock
 
 from aiohttp.web_exceptions import HTTPMovedPermanently
+from django.db import IntegrityError
 from pulpcore.content.handler import Handler, CheckpointListings, PathNotResolved
 from pulpcore.plugin.models import (
     Artifact,
@@ -342,6 +343,39 @@ def test_pull_through_save_multi_artifact_content(
     artifacts = set(ca1.content._artifacts.all())
     assert len(artifacts) == 2
     assert {ca2.artifact, artifact123} == artifacts
+
+
+def test_pull_through_save_single_artifact_on_demand_content(
+    remote123, request123, download_result_mock, monkeypatch
+):
+    """Ensure single-artifact content is properly saved on pull-through."""
+    handler = Handler()
+    remote123.get_remote_artifact_content_type = Mock(return_value=Content)
+    content = Content.objects.create()
+    content.save = Mock(side_effect=IntegrityError)
+    content_init_mock = Mock(return_value=content)
+    monkeypatch.setattr(Content, "init_from_artifact_and_relative_path", content_init_mock)
+    monkeypatch.setattr(Content.objects, "get", Mock(return_value=content))
+    ca = ContentArtifact(relative_path="c123")
+    ra = RemoteArtifact(url=f"{remote123.url}/c123", remote=remote123, content_artifact=ca)
+
+    # Content is saved during handler._save_artifact
+    content_artifacts = handler._save_artifact(download_result_mock, ra, request=request123)
+    artifact = content_artifacts[ra.content_artifact.relative_path].artifact
+
+    remote123.get_remote_artifact_content_type.assert_called_once_with("c123")
+    content_init_mock.assert_called_once_with(artifact, "c123")
+    content.save.assert_called_once()
+    Content.objects.get.assert_called_once()
+
+    # Assert the CA and RA are properly saved
+    ca = artifact.content_memberships.first()
+    assert ca.content is not None
+    assert ca.relative_path == "c123"
+    ra = RemoteArtifact.objects.filter(
+        url=f"{remote123.url}/c123", remote=remote123, content_artifact=ca
+    ).first()
+    assert ra is not None
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
fixes: #6385

Now follows the same logic used in upload: https://github.com/pulp/pulpcore/blob/faeecb95f74cee763c5e51cb0d840e06335ce70b/pulpcore/app/serializers/content.py#L89-L102