### PR TITLE
[PULP-238] Fix remote timeout configuration

### DIFF
--- a/CHANGES/5439.bugfix
+++ b/CHANGES/5439.bugfix
@@ -1,0 +1,1 @@
+Fixes the Remote configuration of timeouts to properly fallback to aiohttp defaults if they are unset by the user.

--- a/pulpcore/download/factory.py
+++ b/pulpcore/download/factory.py
@@ -131,11 +131,14 @@ class DownloaderFactory:
                     headers["User-Agent"] = f"{headers['User-Agent']}, {user_agent_header}"
                 headers.extend(header_dict)
 
+        # Explicit fallback is required, as passing None to ClientTimeout means disabling it
+        # https://docs.aiohttp.org/en/stable/client_quickstart.html#timeouts
+        default_timeout = aiohttp.client.DEFAULT_TIMEOUT
         timeout = aiohttp.ClientTimeout(
-            total=self._remote.total_timeout,
-            sock_connect=self._remote.sock_connect_timeout,
-            sock_read=self._remote.sock_read_timeout,
-            connect=self._remote.connect_timeout,
+            total=self._remote.total_timeout or default_timeout.total,
+            sock_connect=self._remote.sock_connect_timeout or default_timeout.sock_connect,
+            sock_read=self._remote.sock_read_timeout or default_timeout.sock_read,
+            connect=self._remote.connect_timeout or default_timeout.connect,
         )
         # TCPConnector is supposed to be instanciated in a running loop.
         # I don't see why...


### PR DESCRIPTION
We were passing None to the timeout items relying that they would fallback to the defaults, but this actually just disables them.

The aiohttp documentation was a bit confusing about this, but the defaults are only applied if no ClientTimeout instance is passed, not at specific timeout attributes.

https://github.com/aio-libs/aiohttp/blob/f3b0610d1207cd6649b28287e2ad19192ffe2f4a/aiohttp/client.py#L311-L312

Closes #5439