### PR TITLE
Set the X-PULP-ARTIFACT-SIZE header at the handle_response_header function.

### DIFF
--- a/CHANGES/6390.bugfix
+++ b/CHANGES/6390.bugfix
@@ -1,0 +1,1 @@
+Set the X-PULP-ARTIFACT-SIZE header at the handle_response_header function.


### PR DESCRIPTION
Set the X-PULP-ARTIFACT-SIZE header at the handle_response_header function
using the original `Content-Length` header when a `Content-Encoding` header
is not present. Also, remove old code that weren't used to set the header.

Close #6390
