### PR TITLE
Fix second scenario for on-demand pull-through caching

### DIFF
--- a/CHANGES/+second_ondemand_pullthrough.bugfix
+++ b/CHANGES/+second_ondemand_pullthrough.bugfix
@@ -1,0 +1,1 @@
+Fixed an oversight in the #6385 fix.

--- a/pulpcore/content/handler.py
+++ b/pulpcore/content/handler.py
@@ -1067,13 +1067,13 @@ class Handler:
                             ContentArtifact(artifact=a, content=content, relative_path=rp)
                             for rp, a in artifacts.items()
                         ]
-                        cas = ContentArtifact.objects.bulk_create(
+                        ContentArtifact.objects.bulk_create(
                             new_cas,
                             update_conflicts=True,
                             update_fields=["artifact"],
                             unique_fields=["content", "relative_path"],
                         )
-
+                        cas = list(content.contentartifact_set.select_related("artifact"))
                 # Now try to save RemoteArtifacts for each ContentArtifact
                 for ca in cas:
                     if url := remote.get_remote_artifact_url(ca.relative_path, request=request):

--- a/pulpcore/tests/unit/content/test_handler.py
+++ b/pulpcore/tests/unit/content/test_handler.py
@@ -370,7 +370,26 @@ def test_pull_through_save_single_artifact_on_demand_content(
 
     # Assert the CA and RA are properly saved
     ca = artifact.content_memberships.first()
-    assert ca.content is not None
+    assert ca.content == content
+    assert ca.relative_path == "c123"
+    ra = RemoteArtifact.objects.filter(
+        url=f"{remote123.url}/c123", remote=remote123, content_artifact=ca
+    ).first()
+    assert ra is not None
+
+    # Test on-demand were CA is updated with downloaded artifact
+    ra.delete()
+    ca.artifact = None
+    ca.save()
+
+    ca = ContentArtifact(relative_path="c123")
+    ra = RemoteArtifact(url=f"{remote123.url}/c123", remote=remote123, content_artifact=ca)
+    content_artifacts = handler._save_artifact(download_result_mock, ra, request=request123)
+    assert artifact == content_artifacts[ra.content_artifact.relative_path].artifact
+
+    # Assert the CA and RA are properly saved
+    ca = artifact.content_memberships.first()
+    assert ca.content == content
     assert ca.relative_path == "c123"
     ra = RemoteArtifact.objects.filter(
         url=f"{remote123.url}/c123", remote=remote123, content_artifact=ca


### PR DESCRIPTION
My initial fix forgot to account/test for the second condition in the if statement on line 1065:
https://github.com/pulp/pulpcore/blob/8b72c898a018d5f7954c4998f53ab654d79682d2/pulpcore/content/handler.py#L1064-L1075

When the ContentArtifact already exists then the `bulk_create` will update the exisiting object, but the returned value of this will be the objects from `new_cas`, not the actual saved values from the DB. This results in the later RemoteArtifact saving failing since the ContentArtifact in `cas` would have the wrong `pk`