### PR TITLE
Validate repo and remote in PublicationSerializer and DistributionSerializer

### DIFF
--- a/CHANGES/6174.bugfix
+++ b/CHANGES/6174.bugfix
@@ -1,0 +1,1 @@
+Added validation to `PublicationSerializer` and `DistributionSerializer` to raise an error if repo and remote differ.

--- a/pulpcore/tests/unit/serializers/test_repository.py
+++ b/pulpcore/tests/unit/serializers/test_repository.py
@@ -77,6 +77,8 @@ def test_hidden_fields():
 
 def test_validate_repository_only(monkeypatch):
     mock_repo = Mock()
+    mock_repo.cast = lambda: mock_repo
+    mock_repo.remote = None
     monkeypatch.setattr(models, "Repository", mock_repo)
     data = {"repository": mock_repo}
     serializer = PublicationSerializer()
@@ -86,7 +88,11 @@ def test_validate_repository_only(monkeypatch):
 
 
 def test_validate_repository_version_only():
+    mock_repo = Mock()
+    mock_repo.cast = lambda: mock_repo
+    mock_repo.remote = None
     mock_version = Mock()
+    mock_version.repository = mock_repo
     data = {"repository_version": mock_version}
     serializer = PublicationSerializer()
     new_data = serializer.validate(data)
@@ -127,6 +133,8 @@ def test_validate_repository_version_only_unknown_field():
 
 def test_validate_checkpoint_and_repository():
     mock_repository = Mock()
+    mock_repository.cast = lambda: mock_repository
+    mock_repository.remote = None
     mock_version = Mock()
     mock_publication = Mock()
 
@@ -165,5 +173,85 @@ def test_validate_repo_remote_sync(monkeypatch):
 
     serializer = RepositorySyncURLSerializer(data=data, context=context)
     error_msg = r"Type for Remote .* does not match Repository .*."
+    with pytest.raises(serializers.ValidationError, match=error_msg):
+        serializer.validate(data)
+
+
+@pytest.mark.parametrize("tested_serializer", [PublicationSerializer, DistributionSerializer])
+def test_validate_repo_remote_via_repository(monkeypatch, tested_serializer):
+    """
+    Test that the publication/distribution fails if
+    "repository" has a remote of an incompatible type.
+    """
+    monkeypatch.setattr(tested_serializer, "check_cross_domains", lambda self, data: None)
+
+    mock_repository = Mock(spec=models.Repository)
+    mock_repository.cast = lambda: mock_repository
+    mock_repository.REMOTE_TYPES = list()
+    mock_repository.remote = Mock(spec=models.Remote)
+    data = {"repository": mock_repository}
+
+    serializer = tested_serializer()
+    error_msg = r"Type for Remote .* does not match Repository .*."
+    with pytest.raises(serializers.ValidationError, match=error_msg):
+        serializer.validate(data)
+
+
+@pytest.mark.parametrize("tested_serializer", [PublicationSerializer, DistributionSerializer])
+def test_validate_repo_remote_via_repository_version(monkeypatch, tested_serializer):
+    """
+    Test that the publication/distribution fails if repository within
+    "repository_version" has a remote of an incompatible type.
+    """
+    monkeypatch.setattr(tested_serializer, "check_cross_domains", lambda self, data: None)
+
+    mock_repository = Mock(spec=models.Repository)
+    mock_repository.cast = lambda: mock_repository
+    mock_repository.REMOTE_TYPES = list()
+    mock_repository.remote = Mock(spec=models.Remote)
+
+    mock_repository_version = Mock(spec=models.RepositoryVersion)
+    mock_repository_version.repository = mock_repository
+    data = {"repository_version": mock_repository_version}
+
+    serializer = tested_serializer()
+    error_msg = r"Type for Remote .* does not match Repository .* from RepositoryVersion .*."
+    with pytest.raises(serializers.ValidationError, match=error_msg):
+        serializer.validate(data)
+
+
+@pytest.mark.parametrize("field", ["repository", "repository_version"])
+def test_validate_repo_remote_via_publication(monkeypatch, field):
+    """
+    Test that the distribution fails if "publication.repository" has a remote
+    of an incompatible type or if repository within "publication.repository_version"
+    has a remote of an incompatible type.
+    """
+    monkeypatch.setattr(DistributionSerializer, "check_cross_domains", lambda self, data: None)
+
+    mock_repository = Mock(spec=models.Repository)
+    mock_repository.cast = lambda: mock_repository
+    mock_repository.REMOTE_TYPES = list()
+    mock_repository.remote = Mock(spec=models.Remote)
+
+    mock_publication = Mock(spec=models.Publication)
+
+    if field == "repository_version":
+        mock_repository_version = Mock(spec=models.RepositoryVersion)
+        mock_repository_version.repository = mock_repository
+        mock_publication.repository = None
+        mock_publication.repository_version = mock_repository_version
+        error_msg = (
+            r"Type for Remote .* does not match Repository .* "
+            r"from RepositoryVersion .* from Publication .*."
+        )
+    else:  # repository
+        mock_publication.repository = mock_repository
+        mock_publication.repository_version = None
+        error_msg = r"Type for Remote .* does not match Repository .* from Publication .*."
+
+    data = {"publication": mock_publication}
+
+    serializer = DistributionSerializer()
     with pytest.raises(serializers.ValidationError, match=error_msg):
         serializer.validate(data)


### PR DESCRIPTION
This PR adds validation to the `PublicationSerializer` and `DistributionSerializer` to check if the repo and remote are from different plugins. If they are, an error is raised before the task is spawned.

Follow-up to #6391

Fixes #6174