### PR TITLE
Update tests to account for existing data

### DIFF
--- a/pulpcore/tests/functional/api/test_crd_artifacts.py
+++ b/pulpcore/tests/functional/api/test_crd_artifacts.py
@@ -20,7 +20,12 @@ def pulpcore_random_file(tmp_path):
 
 def _do_upload_valid_attrs(pulpcore_bindings, file, data):
     """Upload a file with the given attributes."""
-    artifact = pulpcore_bindings.ArtifactsApi.create(str(file), **data)
+    # Create or get artifact if it already exists
+    try:
+        artifact = pulpcore_bindings.ArtifactsApi.create(str(file), **data)
+    except pulpcore_bindings.ApiException:
+        artifact = pulpcore_bindings.ArtifactsApi.list(sha256=data.get("sha256")).results[0]
+
     # assumes ALLOWED_CONTENT_CHECKSUMS does NOT contain "md5"
     assert artifact.md5 is None, "MD5 {}".format(artifact.md5)
     read_artifact = pulpcore_bindings.ArtifactsApi.read(artifact.pulp_href)

--- a/pulpcore/tests/functional/api/using_plugin/test_reclaim_disk_space.py
+++ b/pulpcore/tests/functional/api/using_plugin/test_reclaim_disk_space.py
@@ -149,11 +149,15 @@ def test_immediate_reclaim_becomes_on_demand(
 
 def test_specified_all_repos(
     pulpcore_bindings,
+    file_bindings,
     file_repository_factory,
     monitor_task,
 ):
     """Tests that specifying all repos w/ '*' properly grabs all the repos."""
-    repos = [file_repository_factory().pulp_href.split("/")[-2] for _ in range(10)]
+    # Get existing file repositories or create new ones
+    repos = [
+        r.pulp_href.split("/")[-2] for r in file_bindings.RepositoriesFileApi.list().results
+    ] or [file_repository_factory().pulp_href.split("/")[-2] for _ in range(10)]
 
     reclaim_response = pulpcore_bindings.RepositoriesReclaimSpaceApi.reclaim({"repo_hrefs": ["*"]})
     task_status = monitor_task(reclaim_response.task)


### PR DESCRIPTION
This PR updates the `test_specified_all_repos` and `test_upload_empty_file` tests to account for existing data (repositories and artifacts) that may already be present on the system.