### PR TITLE
Fix add_roles_for_object_creator handling of AnonymousUser

### DIFF
--- a/CHANGES/plugin_api/+anon-user-object-create.bugfix
+++ b/CHANGES/plugin_api/+anon-user-object-create.bugfix
@@ -1,0 +1,1 @@
+Fixed `add_roles_for_object_creator` not handling anonymous users.

--- a/pulpcore/app/models/access_policy.py
+++ b/pulpcore/app/models/access_policy.py
@@ -140,7 +140,7 @@ class AutoAddObjPermsMixin:
 
         roles = _ensure_iterable(roles)
         current_user = get_current_authenticated_user()
-        if current_user:
+        if current_user and isinstance(current_user, get_user_model()):
             for role in roles:
                 assign_role(role, current_user, self)
 


### PR DESCRIPTION
Sometimes our auth (pulp_container) can return an AnonymousUser which will make `add_roles_for_object_creator` fail if they perform an action to create an object.