### PR TITLE
[PULP-239] Fixed a memory issue triggered by ACS usage

### DIFF
--- a/CHANGES/6500.bugfix
+++ b/CHANGES/6500.bugfix
@@ -1,0 +1,1 @@
+Fixed a memory consumption issue that was triggered by the use of the Alternate Content Source feature.


### PR DESCRIPTION
Satellite hits this worse than others because their remotes are fully populated with certificates and CAs. select_related() produces new copies of each of those strings per-remote-artifact.

closes #6500