### PR TITLE
Fix incorrect use of f-strings in gettext

### DIFF
--- a/CHANGES/6521.bugfix
+++ b/CHANGES/6521.bugfix
@@ -1,0 +1,1 @@
+Fixed incorrect use of f-strings in gettext.

--- a/pulpcore/app/serializers/repository.py
+++ b/pulpcore/app/serializers/repository.py
@@ -365,9 +365,8 @@ class RepositorySyncURLSerializer(ValidateFieldsMixin, serializers.Serializer):
         if repository and type(remote.cast()) not in repository.cast().REMOTE_TYPES:
             raise serializers.ValidationError(
                 {
-                    "remote": _(
-                        f"Type for Remote '{get_prn(remote)}' "
-                        f"does not match Repository '{get_prn(repository)}'."
+                    "remote": _("Type for Remote '{}' does not match Repository '{}'.").format(
+                        get_prn(remote), get_prn(repository)
                     )
                 }
             )


### PR DESCRIPTION
This PR replaces f-strings in `_()` calls with `.format()` to ensure proper `gettext` support.

Fixes #6521