### PR TITLE
Update deprecated general_update task

### DIFF
--- a/pulpcore/app/replica.py
+++ b/pulpcore/app/replica.py
@@ -8,7 +8,7 @@ from pulp_glue.common.context import PulpContext
 from pulpcore.app.models import UpstreamPulp
 from pulpcore.tasking.tasks import dispatch
 from pulpcore.app.tasks.base import (
-    general_update,
+    ageneral_update,
     general_create,
     general_multi_delete,
 )
@@ -133,7 +133,7 @@ class Replicator:
             needs_update = self.needs_update(remote_fields_dict, remote)
             if needs_update:
                 dispatch(
-                    general_update,
+                    ageneral_update,
                     task_group=self.task_group,
                     shared_resources=[self.server],
                     exclusive_resources=[remote],
@@ -162,7 +162,7 @@ class Replicator:
             needs_update = self.needs_update(repo_fields_dict, repository)
             if needs_update:
                 dispatch(
-                    general_update,
+                    ageneral_update,
                     task_group=self.task_group,
                     shared_resources=[self.server],
                     exclusive_resources=[repository],
@@ -197,7 +197,7 @@ class Replicator:
             if needs_update:
                 # Update the distribution
                 dispatch(
-                    general_update,
+                    ageneral_update,
                     task_group=self.task_group,
                     shared_resources=[repository, self.server],
                     exclusive_resources=self.distros_uris,

--- a/pulpcore/app/tasks/__init__.py
+++ b/pulpcore/app/tasks/__init__.py
@@ -1,11 +1,11 @@
 from pulpcore.app.tasks import base, repository, upload
 
 from .base import (
+    ageneral_update,
     general_create,
     general_create_from_temp_file,
     general_delete,
     general_multi_delete,
-    general_update,
 )
 
 from .export import fs_publication_export, fs_repo_version_export

--- a/pulpcore/plugin/tasking.py
+++ b/pulpcore/plugin/tasking.py
@@ -2,13 +2,13 @@
 from pulpcore.tasking.tasks import dispatch
 
 from pulpcore.app.tasks import (
+    ageneral_update,
     fs_publication_export,
     fs_repo_version_export,
     general_create,
     general_create_from_temp_file,
     general_delete,
     general_multi_delete,
-    general_update,
     orphan_cleanup,
     reclaim_space,
 )
@@ -16,6 +16,7 @@ from pulpcore.app.tasks.repository import add_and_remove
 
 
 __all__ = [
+    "ageneral_update",
     "dispatch",
     "fs_publication_export",
     "fs_repo_version_export",
@@ -23,7 +24,6 @@ __all__ = [
     "general_create_from_temp_file",
     "general_delete",
     "general_multi_delete",
-    "general_update",
     "orphan_cleanup",
     "reclaim_space",
     "add_and_remove",


### PR DESCRIPTION
This PR replaces the deprecated `pulpcore.app.tasks.base.general_update` with `pulpcore.app.tasks.base.ageneral_update`. This change is required to prevent CI failures in all new PRs.