### PR TITLE
Fix WorkerNameMetricsExporter to not export unless otel is enabled.

### DIFF
--- a/CHANGES/6529.bugfix
+++ b/CHANGES/6529.bugfix
@@ -1,0 +1,1 @@
+Fixed to not use the OpenTelemetryMiddleware when PULP_OTEL_ENABLED is not set.

--- a/pulpcore/app/wsgi.py
+++ b/pulpcore/app/wsgi.py
@@ -7,6 +7,7 @@ For more information on this file, see
 https://docs.djangoproject.com/en/3.2/howto/deployment/wsgi/
 """
 
+import os
 from django.core.wsgi import get_wsgi_application
 from opentelemetry.instrumentation.wsgi import OpenTelemetryMiddleware
 
@@ -16,7 +17,8 @@ if not using_pulp_api_worker.get(False):
     raise RuntimeError("This app must be executed using pulpcore-api entrypoint.")
 
 application = get_wsgi_application()
-application = OpenTelemetryMiddleware(application)
+if os.getenv("PULP_OTEL_ENABLED", "").lower() == "true":
+    application = OpenTelemetryMiddleware(application)
 
 from pulpcore.app.util import init_domain_metrics_exporter  # noqa: E402
 


### PR DESCRIPTION
- **Fix WorkerNameMetricsExporter to not export unless otel is enabled.**
