### PR TITLE
Reapply "[PULP-270] Validate and clean comments from Remote certs."

### DIFF
--- a/CHANGES/6510.bugfix
+++ b/CHANGES/6510.bugfix
@@ -1,1 +1,0 @@
-Reverted fix for #6491, it broke certificate-chains.


### PR DESCRIPTION
This reverts and reworks commit 1cf684a. Multi-cert PEMs are handled correctly, and openssl use is replaced with using python-cryptography directly.