### PR TITLE
Reapply "[PULP-270] Validate and clean comments from Remote certs."

### DIFF
--- a/pulpcore/app/serializers/repository.py
+++ b/pulpcore/app/serializers/repository.py
@@ -1,4 +1,5 @@
 import os
+from cryptography.x509 import load_pem_x509_certificate
 from gettext import gettext as _
 from urllib.parse import urlparse
 
@@ -69,6 +70,46 @@ class RepositorySerializer(ModelSerializer):
             "retain_repo_versions",
             "remote",
         )
+
+
+def validate_certificate(which_cert, value):
+    """
+    Validate and return *just* the certs and not any commentary that came along with them.
+
+    Args:
+        which_cert: The attribute-name whose cert we're validating (only used for error-message).
+        value: The string being proposed as a certificate-containing PEM.
+
+    Raises:
+        ValidationError: When the provided value has no or an invalid certificate.
+
+    Returns:
+        The pem-string with *just* the validated BEGIN/END CERTIFICATE segments.
+    """
+    if value:
+        try:
+            # Find any/all CERTIFICATE entries in the proposed PEM and let crypto validate them.
+            # NOTE: crypto/39 includes load_certificates(), which will let us remove this whole
+            # loop. But we want to fix the current problem on older supported branches that
+            # allow 38, so we do it ourselves for now
+            certs = list()
+            a_cert = ""
+            for line in value.split("\n"):
+                if "-----BEGIN CERTIFICATE-----" in line or a_cert:
+                    a_cert += line + "\n"
+                if "-----END CERTIFICATE-----" in line:
+                    load_pem_x509_certificate(bytes(a_cert, "ASCII"))
+                    certs.append(a_cert.strip())
+                    a_cert = ""
+            if not certs:
+                raise serializers.ValidationError(
+                    "No {} specified in string {}".format(which_cert, value)
+                )
+            return "\n".join(certs) + "\n"
+        except ValueError as e:
+            raise serializers.ValidationError(
+                "Invalid {} specified, error '{}'".format(which_cert, e.args)
+            )
 
 
 class RemoteSerializer(ModelSerializer, HiddenFieldsMixin):
@@ -267,6 +308,12 @@ class RemoteSerializer(ModelSerializer, HiddenFieldsMixin):
         if value and "@" in value:
             raise serializers.ValidationError(_("proxy_url must not contain credentials"))
         return value
+
+    def validate_ca_cert(self, value):
+        return validate_certificate("ca_cert", value)
+
+    def validate_client_cert(self, value):
+        return validate_certificate("client_cert", value)
 
     def validate(self, data):
         """


### PR DESCRIPTION
This reverts and reworks commit 1cf684a. Multi-cert PEMs are handled correctly, and openssl use is replaced with using python-cryptography directly.

(cherry picked from commit b8b39d10346fbcd9decdd6f1dc7572b5fdd116a0)