### PR TITLE
Add uvloop usage as an optional feature on the content-app

### DIFF
--- a/CHANGES/6021.feature
+++ b/CHANGES/6021.feature
@@ -1,0 +1,2 @@
+Added the optional feature to enable uvloop library as a replacement of asyncio eventloop.
+The feature is activated through the UVLOOP_ENABLED feature flag settings and the 'uvloop' optional dependency.

--- a/docs/admin/reference/settings.md
+++ b/docs/admin/reference/settings.md
@@ -367,6 +367,14 @@ If set to `0`, automatic cleanup is disabled.
 
 Each one defaults to `0`.
 
+### UVLOOP\_ENABLED
+
+Enable using the [uvloop] event loop in the content-app workers.
+This is [recommended by aiohttp] for performance improvements.
+
+The `uvloop` python package must be installed in the content-app's system.
+That's available as an optional dependency for pulpcore: `pulpcore[uvloop]`.
+
 ### WORKER\_TTL
 
 The number of seconds before a worker should be considered lost.
@@ -490,5 +498,7 @@ Defaults to `pulpcore.tasking.status`.
 [Django warning at the end of this section in their docs]: https://docs.djangoproject.com/en/4.2/howto/auth-remote-user/#configuration
 [Enabling Debug Logging]: site:pulpcore/docs/admin/guides/troubleshooting/#enabling-debug-logging
 [librdkafka configuration documentation]: https://github.com/confluentinc/librdkafka/blob/master/CONFIGURATION.md
+[recommended by aiohttp]: https://docs.aiohttp.org/en/stable/third_party.html#approved-third-party-libraries
 [task diagnostics documentation]: site:pulpcore/docs/dev/learn/tasks/diagnostics.md
+[uvloop]: https://github.com/MagicStack/uvloop
 [Webserver Auth with Reverse Proxy]: site:pulpcore/docs/admin/guides/auth/external/#webserver-auth-with-reverse-proxy

--- a/pulpcore/app/settings.py
+++ b/pulpcore/app/settings.py
@@ -425,6 +425,9 @@ KAFKA_SASL_PASSWORD = None
 # opentelemetry settings
 OTEL_ENABLED = False
 
+# Replaces asyncio event loop with uvloop
+UVLOOP_ENABLED = False
+
 # HERE STARTS DYNACONF EXTENSION LOAD (Keep at the very bottom of settings.py)
 # Read more at https://www.dynaconf.com/django/
 

--- a/pulpcore/content/__init__.py
+++ b/pulpcore/content/__init__.py
@@ -1,6 +1,7 @@
 import asyncio
 from contextlib import suppress
 from importlib import import_module
+from importlib.util import find_spec
 import logging
 import os
 
@@ -34,6 +35,13 @@ if settings.OTEL_ENABLED:
     app = web.Application(middlewares=[guid, authenticate, instrumentation()])
 else:
     app = web.Application(middlewares=[guid, authenticate])
+
+
+if settings.UVLOOP_ENABLED:
+    if not find_spec("uvloop"):
+        raise RuntimeError("The library 'uvloop' must be installed if UVLOOP_ENABLED is true.")
+    log.info("Using uvloop as the asyncio event loop.")
+
 
 CONTENT_MODULE_NAME = "content"
 

--- a/pulpcore/content/entrypoint.py
+++ b/pulpcore/content/entrypoint.py
@@ -1,11 +1,17 @@
 import click
 from pulpcore.app.pulpcore_gunicorn_application import PulpcoreGunicornApplication
+from django.conf import settings
 
 
 class PulpcoreContentApplication(PulpcoreGunicornApplication):
     def load_app_specific_config(self):
+        worker_class = (
+            "aiohttp.GunicornUVLoopWebWorker"
+            if settings.UVLOOP_ENABLED
+            else "aiohttp.GunicornWebWorker"
+        )
         self.set_option("default_proc_name", "pulpcore-content", enforced=True)
-        self.set_option("worker_class", "aiohttp.GunicornWebWorker", enforced=True)
+        self.set_option("worker_class", worker_class, enforced=True)
 
     def load(self):
         import pulpcore.content

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -82,6 +82,7 @@ kafka = [
   "confluent-kafka>=2.4.0,<2.10.0",
 ]
 diagnostics = ["pyinstrument~=5.0", "memray~=1.17"]
+uvloop = ["uvloop>=0.20,<0.22"]
 
 [project.urls]
 Homepage = "https://pulpproject.org"


### PR DESCRIPTION
The uvloop replaces the asyncio builtin event loop. To enable it, one must set the UVLOOP_ENABLED=True and have the uvloop package installed in the system where the content-app is deployed.

Closes: #6021