### PR TITLE
Teach tasks to clean up their ProgressReports states on fail/cancel.

### DIFF
--- a/CHANGES/3609.bugfix
+++ b/CHANGES/3609.bugfix
@@ -1,0 +1,3 @@
+Taught tasks to update the state of associated progress-reports when canceled/failed.
+
+Added a management-task, `clean-up-progress-reports`, to clean up existing reports.

--- a/pulpcore/app/management/commands/clean-up-progress-reports.py
+++ b/pulpcore/app/management/commands/clean-up-progress-reports.py
@@ -1,0 +1,52 @@
+from gettext import gettext as _
+
+from django.core.management import BaseCommand
+from django.db.models import F
+
+from pulpcore.app.models import ProgressReport
+from pulpcore.constants import TASK_STATES
+
+
+class Command(BaseCommand):
+    """
+    Django management command for repairing progress-reports in inconsistent states.
+    """
+
+    help = (
+        "Repairs issue #3609. Long-running tasks that utilize ProgressReports, which "
+        "fail or are cancelled, can leave their associated reports in state 'running'. "
+        "This script finds the ProgressReports marked as 'running', whose owning task "
+        "is in either 'cancelled or 'failed', and moves the state of the ProgressReport "
+        "to match that of the task."
+    )
+
+    def add_arguments(self, parser):
+        """Set up arguments."""
+        parser.add_argument(
+            "--dry-run",
+            action="store_true",
+            help=_(
+                "Don't modify anything, just collect results on how many ProgressReports "
+                "are impacted."
+            ),
+        )
+
+    def handle(self, *args, **options):
+        dry_run = options["dry_run"]
+        for state in [TASK_STATES.CANCELED, TASK_STATES.FAILED]:
+            if dry_run:
+                to_be_updated = ProgressReport.objects.filter(
+                    task__state__ne=F("state"), state=TASK_STATES.RUNNING, task__state=state
+                ).count()
+                print(
+                    _("Number of ProgressReports in inconsistent state for {} tasks: {}").format(
+                        state, to_be_updated
+                    )
+                )
+            else:
+                updated = ProgressReport.objects.filter(
+                    task__state__ne=F("state"), state=TASK_STATES.RUNNING, task__state=state
+                ).update(state=state)
+                print(
+                    _("Number of ProgressReports updated for {} tasks: {}").format(state, updated)
+                )

--- a/pulpcore/app/models/task.py
+++ b/pulpcore/app/models/task.py
@@ -204,6 +204,10 @@ class Task(BaseModel, AutoAddObjPermsMixin):
                 )
             )
 
+    def _cleanup_progress_reports(self, state):
+        """Find any running progress-reports and set their states to the specified end-state."""
+        self.progress_reports.filter(state=TASK_STATES.RUNNING).update(state=state)
+
     def set_completed(self):
         """
         Set this Task to the completed state, save it, and log output in warning cases.
@@ -232,6 +236,7 @@ class Task(BaseModel, AutoAddObjPermsMixin):
                         self.pk, self.state
                     )
                 )
+        self._cleanup_progress_reports(TASK_STATES.COMPLETED)
 
     def set_failed(self, exc, tb):
         """
@@ -264,6 +269,7 @@ class Task(BaseModel, AutoAddObjPermsMixin):
                     self.pk, self.state
                 )
             )
+        self._cleanup_progress_reports(TASK_STATES.FAILED)
 
     def set_canceling(self):
         """
@@ -317,6 +323,7 @@ class Task(BaseModel, AutoAddObjPermsMixin):
                     self.pk, self.state
                 )
             )
+        self._cleanup_progress_reports(final_state)
 
     def unblock(self):
         # This should be safe to be called without holding the lock.

--- a/pulpcore/tests/unit/models/test_task.py
+++ b/pulpcore/tests/unit/models/test_task.py
@@ -1,0 +1,44 @@
+import pytest
+import sys
+from pulpcore.app.models import Task, ProgressReport
+from pulpcore.constants import TASK_STATES
+
+
+@pytest.mark.parametrize(
+    "to_state,use_canceled",
+    [
+        (TASK_STATES.FAILED, False),
+        (TASK_STATES.CANCELED, False),
+        (TASK_STATES.CANCELED, True),
+    ],
+)
+@pytest.mark.django_db
+def test_report_state_changes(to_state, use_canceled):
+    task = Task.objects.create(name="test", state=TASK_STATES.RUNNING)
+    reports = {}
+    for state in vars(TASK_STATES):
+        report = ProgressReport(message="test", code="test", state=state, task=task)
+        report.save()
+        reports[state] = report
+
+    if TASK_STATES.FAILED == to_state:
+        # Two ways to fail a task - set_failed and set_canceled("failed")
+        if use_canceled:
+            task.set_cancelling()
+            task.set_canceled(TASK_STATES.FAILED)
+        else:
+            try:
+                raise ValueError("test")
+            except ValueError:
+                exc_type, exc, tb = sys.exc_info()
+                task.set_failed(exc, tb)
+    elif TASK_STATES.CANCELED == to_state:
+        task.set_canceling()
+        task.set_canceled()
+
+    for state in vars(TASK_STATES):
+        report = ProgressReport.objects.get(pk=reports[state].pulp_id)
+        if TASK_STATES.RUNNING == state:  # report *was* running, should be changed
+            assert to_state == report.state
+        else:
+            assert state == report.state


### PR DESCRIPTION
Added a manager-command to clean up current data in inconsistent states.

fixes #3609.