### PR TITLE
[PULP-423] Fix wrong downloader session close on on-demand streaming 

### DIFF
--- a/docs/admin/reference/settings.md
+++ b/docs/admin/reference/settings.md
@@ -324,6 +324,14 @@ When set to `False` artifacts are always served by the content app instead.
 
 Defaults to `True`; ignored for local file storage.
 
+### REMOTE\_CONTENT\_FETCH\_FAILURE\_COOLDOWN
+
+In the context of on-demand requests in the Content App,
+the time in seconds that a content source from a specific remote will be ignored after failing to download the correct binary from it.
+Learn more about [on-demand and streaming limitations].
+
+Defaults to `5` minutes.
+
 ### REMOTE\_USER\_ENVIRON\_NAME
 
 The name of the WSGI environment variable to read for [Webserver Auth with Reverse Proxy].
@@ -498,6 +506,7 @@ Defaults to `pulpcore.tasking.status`.
 [Django warning at the end of this section in their docs]: https://docs.djangoproject.com/en/4.2/howto/auth-remote-user/#configuration
 [Enabling Debug Logging]: site:pulpcore/docs/admin/guides/troubleshooting/#enabling-debug-logging
 [librdkafka configuration documentation]: https://github.com/confluentinc/librdkafka/blob/master/CONFIGURATION.md
+[on-demand and streaming limitations]: site:pulpcore/docs/user/learn/on-demand-downloading/#on-demand-and-streamed-limitations
 [recommended by aiohttp]: https://docs.aiohttp.org/en/stable/third_party.html#approved-third-party-libraries
 [task diagnostics documentation]: site:pulpcore/docs/dev/learn/tasks/diagnostics.md
 [uvloop]: https://github.com/MagicStack/uvloop

--- a/docs/user/learn/on-demand-downloading.md
+++ b/docs/user/learn/on-demand-downloading.md
@@ -73,21 +73,26 @@ On-demand and streamed content can be useful, but they come with some problems.
 
 There are two different types of errors that can occur with on-demand streaming:
 
-1. Pre-response: For some reason, Pulp can't get any data from the server (e.g, connectivity errors). A response is never started.
-2. Post-response: Pulp can get data from the remote and start streaming the response, but in the end the data doesn't match the expected digest.
+1. **Pre-response**: Pulp can't find or connect to the server. A response is never started.
+2. **Post-response**: Pulp can get data from the remote and start streaming the response, but the final digest is wrong.
 
-In the first case, Pulp will try all the available remote sources for the requested content and will return a 404 if all of them fail *with this same type of error*.
+(1) Pulp will try all the available remote sources for the requested content and will return a 404
+if all of them fail with pre-response retriable errors.
 
-In the second case, Pulp already sent the corrupted data to the client and can't recover from it, so it will close the connection to prevent the client from consolidating the file.
-When this happens, the content-app will ignore that remote source for a certain amount of time, which will enable future requests to select a different remote source.
-If all remote sources are ignored due to prior failure, then a 404 will be returned for all requests of that content until the cooldown period for one of those sources has expired.
+(2) Pulp already sent the corrupted data to the client and can't recover from it, so it will close the connection to prevent the client from consolidating the file.
+When this happens, the content-app will ignore that remote source for a [configurable cooldown interval],
+which will enable future requests to select a different remote source.
+If all remote sources are ignored due to prior failure, then a 404 will be returned for all requests of that content until the *cooldown interval* for one of those sources has expired.
 Pulp doesn't permanently invalidate the remote because it can't know if the error is transient or not.
 
-The second case is complex and can be confusing to the user.
-The core reason for this complexity lies in the very nature of on-demand serving, which imposes that Pulp must fetch and stream the content on request time, and has no way to know anything about the remote before that.
-This constraint great limits the range of actions Pulp can do to properly satisfy the request.
+!!! info
 
-If this behavior is prohibitive, consider using the immediate sync policy.
+    Case (2) is complex and can be confusing to the user.
+
+    The core reason for this complexity lies in the very nature of on-demand serving, which imposes that Pulp must fetch and stream the content on request time, and has no way to know anything about the remote before that.
+    This constrains the range of actions Pulp can do to satisfy the request properly.
+
+    **If this behavior is prohibitive, consider using the immediate sync policy.**
 
 Context: <https://github.com/pulp/pulpcore/issues/5012>.
 
@@ -120,3 +125,5 @@ An example:
 If a user doesn't want their registered Remotes to be indirectly used by other users, they should use a separate domain.
 
 Context: <https://github.com/pulp/pulpcore/issues/3212>.
+
+[configurable cooldown interval]: site:pulpcore/docs/admin/reference/settings/#remote_content_fetch_failure_cooldown

--- a/pulpcore/app/settings.py
+++ b/pulpcore/app/settings.py
@@ -342,9 +342,7 @@ CACHE_SETTINGS = {
     "EXPIRES_TTL": 600,  # 10 minutes
 }
 
-# The time a RemoteArtifact will be ignored after failure.
-# In on-demand, if a fetching content from a remote failed due to corrupt data,
-# the corresponding RemoteArtifact will be ignored for that time (seconds).
+# The time in seconds a RemoteArtifact will be ignored after failure.
 REMOTE_CONTENT_FETCH_FAILURE_COOLDOWN = 5 * 60  # 5 minutes
 
 SPECTACULAR_SETTINGS = {


### PR DESCRIPTION
**First commit:**
In the content app on-demand streaming error handler for digest errors, the TCP connection with the client must be closed. Possibly because of some confusion about what connection should be closed, the downloader
session was also closed.

Closing the session is unnecessary to the error handling and it's incompatible with some downloaders. E.g, `RpmFileDownloader` doesn't have a session at all. This causes unintented errors when using file:// remotes.

Also, there is no need to raise a runtime error from the error handling perspective, so a clean error log was used.

**Second commit:**
improves documentation about `REMOTE_CONTENT_FETCH_FAILURE_COOLDOWN`.