### PR TITLE
Resolve warnings of testing library

### DIFF
--- a/pulpcore/tests/unit/test_viewsets.py
+++ b/pulpcore/tests/unit/test_viewsets.py
@@ -33,7 +33,7 @@ class TestGetResource(TestCase):
             "{api_root}repositories/file/file/{pk}/".format(api_root=API_ROOT, pk=repo.pk),
             models.FileRepository,
         )
-        self.assertEquals(repo, resource)
+        self.assertEqual(repo, resource)
 
     def test_multiple_matches(self):
         """


### PR DESCRIPTION
# PR Summary
This small PR migrates from `unittest.assertEquals` to `unittest.assertEqual` which is deprecated from Python2.7:
```python
DeprecationWarning: Please use assertEqual instead.
```