### PR TITLE
[backport 3.63] Fix wrong downloader session close on on-demand streaming

### DIFF
--- a/pulpcore/content/handler.py
+++ b/pulpcore/content/handler.py
@@ -1173,10 +1173,9 @@ class Handler:
                 pulp_last_updated=timezone.now()
                 + timedelta(settings.REMOTE_CONTENT_FETCH_FAILURE_COOLDOWN)
             )
-            await downloader.session.close()
             close_tcp_connection(request.transport._sock)
             REMOTE_CONTENT_FETCH_FAILURE_COOLDOWN = settings.REMOTE_CONTENT_FETCH_FAILURE_COOLDOWN
-            raise RuntimeError(
+            log.error(
                 f"Pulp tried streaming {remote_artifact.url!r} to "
                 "the client, but it failed checksum validation.\n\n"
                 "We can't recover from wrong data already sent so we are:\n"
@@ -1186,8 +1185,10 @@ class Handler:
                 "If the Remote is known to be fixed, try resyncing the associated repository.\n"
                 "If the Remote is known to be permanently corrupted, try removing "
                 "affected Pulp Remote, adding a good one and resyncing.\n"
-                "If the problem persists, please contact the Pulp team."
+                "Learn more on <https://pulpproject.org/pulpcore/docs/user/learn/"
+                "on-demand-downloading/#on-demand-and-streamed-limitations>"
             )
+            return response
 
         if content_length := response.headers.get("Content-Length"):
             self._report_served_artifact_size(int(content_length))

--- a/pulpcore/tests/functional/api/using_plugin/test_content_delivery.py
+++ b/pulpcore/tests/functional/api/using_plugin/test_content_delivery.py
@@ -112,6 +112,7 @@ def test_remote_content_changed_with_on_demand(
     file_bindings,
     monitor_task,
     file_distribution_factory,
+    tmp_path,
 ):
     """
     GIVEN a remote synced on demand with fileA (e.g, digest=123),
@@ -119,6 +120,7 @@ def test_remote_content_changed_with_on_demand(
 
     WHEN the client first requests that content
     THEN the content app will start a response but close the connection before finishing
+    AND no file will be present in the filesystem
 
     WHEN the client requests that content again (within the RA cooldown interval)
     THEN the content app will return a 404
@@ -138,9 +140,12 @@ def test_remote_content_changed_with_on_demand(
     get_url = urljoin(distribution.base_url, expected_file_list[0][0])
 
     # WHEN (first request)
-    result = subprocess.run(["curl", "-v", get_url], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    output_file = tmp_path / "out.rpm"
+    cmd = ["curl", "-v", get_url, "-o", str(output_file)]
+    result = subprocess.run(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
 
     # THEN
+    assert not output_file.exists()
     assert result.returncode == 18
     assert b"* Closing connection 0" in result.stderr
     assert b"curl: (18) transfer closed with outstanding read data remaining" in result.stderr
@@ -205,10 +210,6 @@ def test_handling_remote_artifact_on_demand_streaming_failure(
         distribution = file_distribution_factory(repository=repo.pulp_href)
         return distribution
 
-    def refresh_acs(acs):
-        monitor_task_group(file_bindings.AcsFileApi.refresh(acs.pulp_href).task_group)
-        return acs
-
     def get_original_content_info(remote):
         expected_files = get_files_in_manifest(remote.url)
         content_unit = list(expected_files)[0]
@@ -225,8 +226,7 @@ def test_handling_remote_artifact_on_demand_streaming_failure(
     acs_manifest_path = write_3_iso_file_fixture_data_factory("acs", seed=123)
     remote = create_simple_remote(basic_manifest_path)
     distribution = sync_publish_and_distribute(remote)
-    acs = create_acs_remote(acs_manifest_path)
-    refresh_acs(acs)
+    create_acs_remote(acs_manifest_path)
     write_3_iso_file_fixture_data_factory("acs", overwrite=True)  # corrupt
 
     # WHEN/THEN (first request)


### PR DESCRIPTION
In the content app on-demand streaming error handler for digest errors, the TCP connection with the client must be closed. Possibly because of some confusion about what connection should be closed, the downloader session was also closed.
Closing the session is unnecessary to the error handling and it's incompatible with some downloaders. E.g, RpmFileDownloader doesn't have a session at all.

Also, there is no need to raise a runtime error from the error handling perspective, so a clean error log was used.

Backport from https://github.com/pulp/pulpcore/pull/6556