### PR TITLE
[bacport 3.73] Fix wrong downloader session close on on-demand streaming

### DIFF
--- a/pulpcore/content/handler.py
+++ b/pulpcore/content/handler.py
@@ -1151,10 +1151,9 @@ class Handler:
         except DigestValidationError:
             remote_artifact.failed_at = timezone.now()
             await remote_artifact.asave()
-            await downloader.session.close()
             close_tcp_connection(request.transport._sock)
             REMOTE_CONTENT_FETCH_FAILURE_COOLDOWN = settings.REMOTE_CONTENT_FETCH_FAILURE_COOLDOWN
-            raise RuntimeError(
+            log.error(
                 f"Pulp tried streaming {remote_artifact.url!r} to "
                 "the client, but it failed checksum validation.\n\n"
                 "We can't recover from wrong data already sent so we are:\n"
@@ -1164,8 +1163,10 @@ class Handler:
                 "If the Remote is known to be fixed, try resyncing the associated repository.\n"
                 "If the Remote is known to be permanently corrupted, try removing "
                 "affected Pulp Remote, adding a good one and resyncing.\n"
-                "If the problem persists, please contact the Pulp team."
+                "Learn more on <https://pulpproject.org/pulpcore/docs/user/learn/"
+                "on-demand-downloading/#on-demand-and-streamed-limitations>"
             )
+            return response
 
         if content_length := response.headers.get("Content-Length"):
             response.headers["X-PULP-ARTIFACT-SIZE"] = content_length


### PR DESCRIPTION
In the content app on-demand streaming error handler for digest errors, the TCP connection with the client must be closed. Possibly because of some confusion about what connection should be closed, the downloader session was also closed.
Closing the session is unnecessary to the error handling and it's incompatible with some downloaders. E.g, RpmFileDownloader doesn't have a session at all.

Also, there is no need to raise a runtime error from the error handling perspective, so a clean error log was used.

cherry-picked from: 3a3b6d4eee64a6e7d284208d24e47e1a8284751c (https://github.com/pulp/pulpcore/pull/6556)
