### PR TITLE
use IPv4 or IPv6 for api and content server depending on system capabilities

### DIFF
--- a/CHANGES/6606.bugfix
+++ b/CHANGES/6606.bugfix
@@ -1,0 +1,1 @@
+Changed default http bind address from `[::]` to `0.0.0.0` if IPv6 is not available.

--- a/pulpcore/app/entrypoint.py
+++ b/pulpcore/app/entrypoint.py
@@ -11,6 +11,7 @@ from django.db.utils import InterfaceError, DatabaseError
 from gunicorn.workers.sync import SyncWorker
 
 from pulpcore.app.apps import pulp_plugin_configs
+from pulpcore.app.netutil import has_ipv6
 from pulpcore.app.pulpcore_gunicorn_application import PulpcoreGunicornApplication
 
 logger = getLogger(__name__)
@@ -102,7 +103,9 @@ class PulpcoreApiApplication(PulpcoreGunicornApplication):
 # https://github.com/benoitc/gunicorn/blob/master/gunicorn/config.py
 
 
-@click.option("--bind", "-b", default=["[::]:24817"], multiple=True)
+@click.option(
+    "--bind", "-b", default=[f"{ '[::]' if has_ipv6() else '0.0.0.0' }:24817"], multiple=True
+)
 @click.option("--workers", "-w", type=int)
 # @click.option("--threads", "-w", type=int)  # We don't use a threaded worker...
 @click.option("--name", "-n", "proc_name")

--- a/pulpcore/app/netutil.py
+++ b/pulpcore/app/netutil.py
@@ -1,0 +1,20 @@
+"""
+network utility functions
+"""
+
+import socket
+
+
+def has_ipv6():
+    """
+    check if host can use IPv6
+    """
+    # if python has IPv6 support we need to check if we can bind an IPv6 socket
+    if socket.has_ipv6:
+        try:
+            with socket.socket(socket.AF_INET6) as sock:
+                sock.bind(("::1", 0))
+                return True
+        except OSError:
+            pass
+    return False

--- a/pulpcore/content/entrypoint.py
+++ b/pulpcore/content/entrypoint.py
@@ -1,4 +1,5 @@
 import click
+from pulpcore.app.netutil import has_ipv6
 from pulpcore.app.pulpcore_gunicorn_application import PulpcoreGunicornApplication
 from django.conf import settings
 
@@ -19,7 +20,9 @@ class PulpcoreContentApplication(PulpcoreGunicornApplication):
         return pulpcore.content.server
 
 
-@click.option("--bind", "-b", default=["[::]:24816"], multiple=True)
+@click.option(
+    "--bind", "-b", default=[f"{ '[::]' if has_ipv6() else '0.0.0.0' }:24816"], multiple=True
+)
 @click.option("--workers", "-w", type=int)
 # @click.option("--threads", "-w", type=int)  # We don't use a threaded worker...
 @click.option("--name", "-n", "proc_name")


### PR DESCRIPTION
This adds a function inspired by urllib3.util.connection._has_ipv6 to detect if a system can bind IPv6 sockets and use this information to bind the default listening address to either an IPV4 or an IPv6 address.

This should address https://github.com/pulp/pulp-oci-images/issues/582

I've decided to add my helper function in netutil.py because when i put in in util.py a lot of unnecessary code is executed when importing pulpcore.app.util. Tell me if there is a better place or name for this has_ipv6 function.

With this helper function it will also be ease to fix https://github.com/pulp/pulp-oci-images/issues/595:
We can set a variable in https://github.com/pulp/pulp-oci-images/blob/latest/images/s6_assets/template_nginx.py and modify the jinja template to add the IPv6 listener when IPv6 is usable.