### PR TITLE
Experiment with docstrings formatter

### DIFF
--- a/pulpcore/__init__.py
+++ b/pulpcore/__init__.py
@@ -1,6 +1,4 @@
-"""
-Base pulpcore module.
-"""
+"""Base pulpcore module."""
 
 from pkgutil import extend_path
 

--- a/pulpcore/app/access_policy.py
+++ b/pulpcore/app/access_policy.py
@@ -12,14 +12,11 @@ DEFAULT_ACCESS_POLICY = {"statements": [{"action": "*", "principal": "admin", "e
 
 
 class DefaultAccessPolicy(AccessPolicy):
-    """
-    An AccessPolicy that takes default statements from the view(set).
-    """
+    """An AccessPolicy that takes default statements from the view(set)."""
 
     @classmethod
     def get_access_policy(cls, view):
-        """
-        Retrieves the default access policy of a view.
+        """Retrieves the default access policy of a view.
 
         Args:
             view (subclass of rest_framework.view.APIView): The view or viewset to receive the
@@ -32,13 +29,11 @@ class DefaultAccessPolicy(AccessPolicy):
 
     @classmethod
     def handle_creation_hooks(cls, obj):
-        """
-        Handle the creation hooks defined in this policy for the passed in `obj`.
+        """Handle the creation hooks defined in this policy for the passed in `obj`.
 
         Args:
             cls: The class this method belongs to.
             obj: The model instance to have its creation hooks handled for.
-
         """
         viewset = get_viewset_for_model(obj)
         access_policy = cls.get_access_policy(viewset)
@@ -56,9 +51,7 @@ class DefaultAccessPolicy(AccessPolicy):
                 function(**kwargs)
 
     def scope_queryset(self, view, qs):
-        """
-        Scope the queryset based on the access policy `scope_queryset` method if present.
-        """
+        """Scope the queryset based on the access policy `scope_queryset` method if present."""
         if (queryset_scoping := self.get_access_policy(view).get("queryset_scoping")) is not None:
             scope = queryset_scoping["function"]
             if not (function := getattr(view, scope, None)):
@@ -70,8 +63,7 @@ class DefaultAccessPolicy(AccessPolicy):
         return qs
 
     def get_policy_statements(self, request, view):
-        """
-        Return the policy statements from an AccessPolicy instance matching the viewset name.
+        """Return the policy statements from an AccessPolicy instance matching the viewset name.
 
         This is an implementation of a method that will be called by
         `rest_access_policy.AccessPolicy`. See the drf-access-policy docs for more info:
@@ -99,16 +91,14 @@ class DefaultAccessPolicy(AccessPolicy):
 
 
 class AccessPolicyFromSettings(DefaultAccessPolicy):
-    """
-    An AccessPolicy that loads statements from settings.
+    """An AccessPolicy that loads statements from settings.
 
     If an access policy cannot be found this falls back to the default one.
     """
 
     @classmethod
     def get_access_policy(cls, view):
-        """
-        Retrieves the AccessPolicy from the DB or None if it doesn't exist.
+        """Retrieves the AccessPolicy from the DB or None if it doesn't exist.
 
         Args:
             view (subclass of rest_framework.view.APIView): The view or viewset to receive the
@@ -126,16 +116,14 @@ class AccessPolicyFromSettings(DefaultAccessPolicy):
 
 
 class AccessPolicyFromDB(DefaultAccessPolicy):
-    """
-    An AccessPolicy that loads statements from an `AccessPolicy` model instance.
+    """An AccessPolicy that loads statements from an `AccessPolicy` model instance.
 
     If an access policy cannot be found this falls back to the default one.
     """
 
     @classmethod
     def get_access_policy(cls, view):
-        """
-        Retrieves the AccessPolicy from the DB or None if it doesn't exist.
+        """Retrieves the AccessPolicy from the DB or None if it doesn't exist.
 
         Args:
             view (subclass of rest_framework.view.APIView): The view or viewset to receive the

--- a/pulpcore/app/apps.py
+++ b/pulpcore/app/apps.py
@@ -23,11 +23,10 @@ MODULE_PLUGIN_VERSIONS = {}
 
 
 def pulp_plugin_configs():
-    """
-    A generator of Pulp plugin AppConfigs
+    """A generator of Pulp plugin AppConfigs.
 
-    This makes it easy to iterate over just the installed Pulp plugins when working
-    with discovered plugin components.
+    This makes it easy to iterate over just the installed Pulp plugins when working with discovered
+    plugin components.
     """
     for app_config in apps.apps.get_app_configs():
         if isinstance(app_config, PulpPluginAppConfig):
@@ -35,8 +34,7 @@ def pulp_plugin_configs():
 
 
 def get_plugin_config(plugin_app_label):
-    """
-    A getter of specific pulp plugin config
+    """A getter of specific pulp plugin config.
 
     This makes it easy to retrieve a config for a specific Pulp plugin when looking for a
     registered model.
@@ -57,7 +55,10 @@ def get_plugin_config(plugin_app_label):
 
 
 class PulpPluginAppConfig(apps.AppConfig):
-    """AppConfig class. Use this in plugins to identify your app as a Pulp plugin."""
+    """AppConfig class.
+
+    Use this in plugins to identify your app as a Pulp plugin.
+    """
 
     # Plugin behavior loading should happen in ready(), not in __init__().
     # ready() is called after all models are initialized, and at that point we should
@@ -195,16 +196,13 @@ class PulpPluginAppConfig(apps.AppConfig):
                     continue
 
     def import_urls(self):
-        """
-        If a plugin defines a urls.py, include it.
-        """
+        """If a plugin defines a urls.py, include it."""
         if module_has_submodule(self.module, URLS_MODULE_NAME) and self.name != "pulpcore.app":
             urls_module_name = "{name}.{module}".format(name=self.name, module=URLS_MODULE_NAME)
             self.urls_module = import_module(urls_module_name)
 
     def import_modelresources(self):
-        """
-        If a plugin has a modelresource.py, import it
+        """If a plugin has a modelresource.py, import it.
 
         (This exists when a plugin knows how to import-export itself)
         """
@@ -219,8 +217,7 @@ class PulpPluginAppConfig(apps.AppConfig):
             self.exportable_classes = self.modelresource_module.IMPORT_ORDER
 
     def import_replicators(self):
-        """
-        If a plugin has a replicator.py, import it.
+        """If a plugin has a replicator.py, import it.
 
         This exists when a plugin supports replication from an upstream Pulp.
         """
@@ -353,8 +350,7 @@ def _populate_roles(sender, apps, verbosity, **kwargs):
 
 
 def adjust_roles(apps, role_prefix, desired_roles, verbosity=1):
-    """
-    Adjust all roles with a given prefix.
+    """Adjust all roles with a given prefix.
 
     Args:
         apps (django.apps.registry.Apps): Django app registry

--- a/pulpcore/app/authentication.py
+++ b/pulpcore/app/authentication.py
@@ -38,8 +38,7 @@ class PulpNoCreateRemoteUserBackend(RemoteUserBackend):
 
 
 class JSONHeaderRemoteAuthentication(BaseAuthentication):
-    """
-    Authenticate users based on a jq filter applied to a specific header.
+    """Authenticate users based on a jq filter applied to a specific header.
 
     For users logging in first time it creates User record.
     """
@@ -48,10 +47,7 @@ class JSONHeaderRemoteAuthentication(BaseAuthentication):
     jq_filter = settings.AUTHENTICATION_JSON_HEADER_JQ_FILTER
 
     def authenticate(self, request):
-        """
-        Checks for the presence of a header, and if its content is able
-        to be filtered by JQ.
-        """
+        """Checks for the presence of a header, and if its content is able to be filtered by JQ."""
         if self.header not in request.META:
             _logger.debug(
                 "Access not allowed. Header {header} not found.".format(header=self.header)

--- a/pulpcore/app/files.py
+++ b/pulpcore/app/files.py
@@ -10,9 +10,7 @@ from pulpcore.app import pulp_hashlib
 
 
 class PulpTemporaryUploadedFile(TemporaryUploadedFile):
-    """
-    A file uploaded to a temporary location in Pulp.
-    """
+    """A file uploaded to a temporary location in Pulp."""
 
     def __init__(self, name, content_type, size, charset, content_type_extra=None):
         self.hashers = {}
@@ -22,8 +20,7 @@ class PulpTemporaryUploadedFile(TemporaryUploadedFile):
 
     @classmethod
     def from_file(cls, file):
-        """
-        Create a PulpTemporaryUploadedFile from a file system file
+        """Create a PulpTemporaryUploadedFile from a file system file.
 
         Args:
             file (File): a filesystem file
@@ -52,9 +49,7 @@ class PulpTemporaryUploadedFile(TemporaryUploadedFile):
 
 
 class HashingFileUploadHandler(TemporaryFileUploadHandler):
-    """
-    Upload handler that streams data into a temporary file.
-    """
+    """Upload handler that streams data into a temporary file."""
 
     def new_file(
         self,
@@ -65,8 +60,7 @@ class HashingFileUploadHandler(TemporaryFileUploadHandler):
         charset=None,
         content_type_extra=None,
     ):
-        """
-        Signal that a new file has been started.
+        """Signal that a new file has been started.
 
         Args:
             field_name (str): Name of the model field that this file is associated with. This
@@ -90,8 +84,7 @@ class HashingFileUploadHandler(TemporaryFileUploadHandler):
 
 
 class TemporaryDownloadedFile(TemporaryUploadedFile):
-    """
-    A temporary downloaded file.
+    """A temporary downloaded file.
 
     The FileSystemStorage backend treats this object the same as a TemporaryUploadedFile. The
     storage backend attempts to link the file to its final location. If the final location is on a
@@ -99,8 +92,7 @@ class TemporaryDownloadedFile(TemporaryUploadedFile):
     """
 
     def __init__(self, file, name=None):
-        """
-        A constructor that does not create a blank temporary file.
+        """A constructor that does not create a blank temporary file.
 
         The __init__ for TemporaryUploadedFile creates an empty temporary file. This constructor
         is designed to handle files that have already been written to disk.
@@ -116,8 +108,7 @@ class TemporaryDownloadedFile(TemporaryUploadedFile):
 
 
 def validate_file_paths(paths):
-    """
-    Check for valid POSIX paths (ie ones that aren't duplicated and don't overlap).
+    """Check for valid POSIX paths (ie ones that aren't duplicated and don't overlap).
 
     Overlapping paths are where one path terminates inside another (e.g. a/b and a/b/c).
 

--- a/pulpcore/app/global_access_conditions.py
+++ b/pulpcore/app/global_access_conditions.py
@@ -10,8 +10,7 @@ from pulpcore.app.models import Group, Repository
 
 
 def has_model_perms(request, view, action, permission):
-    """
-    Checks if the current user has a model-level permission.
+    """Checks if the current user has a model-level permission.
 
     This is usable as a conditional check in an AccessPolicy. Here is an example checking for
     "file.add_fileremote" permission at the model-level.
@@ -39,8 +38,7 @@ def has_model_perms(request, view, action, permission):
 
 
 def has_domain_perms(request, view, action, permission):
-    """
-    Checks if the user has current domain-level permission.
+    """Checks if the user has current domain-level permission.
 
     If DOMAIN_ENABLED, use the incoming request's domain for the permission check, else return
     False.
@@ -51,8 +49,7 @@ def has_domain_perms(request, view, action, permission):
 
 
 def has_obj_perms(request, view, action, permission):
-    """
-    Checks if the current user has object-level permission on the specific object.
+    """Checks if the current user has object-level permission on the specific object.
 
     The object in this case is the one the action is operating on, e.g. the URL
     ``/pulp/api/v3/tasks/15939b47-6b6d-4613-a441-939ca4ba6e63/`` is operating on the Task object
@@ -85,17 +82,14 @@ def has_obj_perms(request, view, action, permission):
 
 
 def has_model_or_domain_perms(request, view, action, permission):
-    """
-    Checks if the current user has either model-level (global) or domain-level permissions.
-    """
+    """Checks if the current user has either model-level (global) or domain-level permissions."""
     return has_model_perms(request, view, action, permission) or has_domain_perms(
         request, view, action, permission
     )
 
 
 def has_model_or_domain_or_obj_perms(request, view, action, permission):
-    """
-    Checks if the current user has the permission across all levels of Pulp.
+    """Checks if the current user has the permission across all levels of Pulp.
 
     This checks all three levels of permissions in Pulp: model, domain, and object level. Returns
     True if the user has the permission on any of those levels, False otherwise.
@@ -106,8 +100,7 @@ def has_model_or_domain_or_obj_perms(request, view, action, permission):
 
 
 def has_model_or_obj_perms(request, view, action, permission):
-    """
-    Checks if the current user has either model-level or object-level permissions.
+    """Checks if the current user has either model-level or object-level permissions.
 
     The object in this case is the one the action is operating on, e.g. the URL
     ``/pulp/api/v3/tasks/15939b47-6b6d-4613-a441-939ca4ba6e63/`` is operating on the Task object
@@ -144,8 +137,7 @@ def has_model_or_obj_perms(request, view, action, permission):
 
 
 def has_remote_param_obj_perms(request, view, action, permission):
-    """
-    Checks if the current user has object-level permission on the ``remote`` object.
+    """Checks if the current user has object-level permission on the ``remote`` object.
 
     The object in this case is the one specified by the ``remote`` parameter. For example when
     syncing the ``remote`` parameter is passed in as an argument.
@@ -193,17 +185,15 @@ def has_remote_param_obj_perms(request, view, action, permission):
 
 
 def has_remote_param_model_or_domain_or_obj_perms(request, view, action, permission):
-    """
-    Checks if the current user has the permission on the ``remote`` param.
-    """
+    """Checks if the current user has the permission on the ``remote`` param."""
     return has_model_or_domain_perms(
         request, view, action, permission
     ) or has_remote_param_obj_perms(request, view, action, permission)
 
 
 def has_remote_param_model_or_obj_perms(request, view, action, permission):
-    """
-    Checks if the current user has either model-level or object-level permissions on the ``remote``.
+    """Checks if the current user has either model-level or object-level permissions on the
+    ``remote``.
 
     The object in this case is the one specified by the ``remote`` parameter. For example when
     syncing the ``remote`` parameter is passed in as an argument.
@@ -245,8 +235,7 @@ def has_remote_param_model_or_obj_perms(request, view, action, permission):
 
 
 def has_repo_attr_obj_perms(request, view, action, permission):
-    """
-    Checks if the current user has object-level permission on a ``repository`` attribute.
+    """Checks if the current user has object-level permission on a ``repository`` attribute.
 
     The object in this case is the one specified by the ``repository`` attribute of a resource
     which is being operated on. For example, when deleting a repository version, a ``repository``
@@ -287,17 +276,14 @@ def has_repo_attr_obj_perms(request, view, action, permission):
 
 
 def has_repo_attr_model_or_domain_or_obj_perms(request, view, action, permission):
-    """
-    Checks if the current user has the permission on the ``repository`` attribute.
-    """
+    """Checks if the current user has the permission on the ``repository`` attribute."""
     return has_model_or_domain_perms(request, view, action, permission) or has_repo_attr_obj_perms(
         request, view, action, permission
     )
 
 
 def has_repo_attr_model_or_obj_perms(request, view, action, permission):
-    """
-    Checks if the current user has model-level or object-level permissions on a ``repository``.
+    """Checks if the current user has model-level or object-level permissions on a ``repository``.
 
     The object in this case is the one specified by the ``repository`` attribute of a resource
     which is being operated on. For example, when deleting a repository version, a ``repository``
@@ -339,8 +325,7 @@ def has_repo_attr_model_or_obj_perms(request, view, action, permission):
 
 
 def has_repository_obj_perms(request, view, action, permission):
-    """
-    Checks whether a user has the requested object permission on the repository in the URL.
+    """Checks whether a user has the requested object permission on the repository in the URL.
 
     This check is meant to be used for relations nested beneath a repository endpoint, e.g. the
     list of repository versions belonging to that repository. It will fail for other endpoints.
@@ -369,17 +354,14 @@ def has_repository_obj_perms(request, view, action, permission):
 
 
 def has_repository_model_or_domain_or_obj_perms(request, view, action, permission):
-    """
-    Checks if the current user has the permission for the repository in the URL.
-    """
+    """Checks if the current user has the permission for the repository in the URL."""
     return has_model_or_domain_perms(request, view, action, permission) or has_repository_obj_perms(
         request, view, action, permission
     )
 
 
 def has_repository_model_or_obj_perms(request, view, action, permission):
-    """
-    Checks whether a user has the requested model or object permission on the repository in the
+    """Checks whether a user has the requested model or object permission on the repository in the
     URL.
 
     This check is meant to be used for relations nested beneath a repository endpoint, e.g. the
@@ -410,9 +392,7 @@ def has_repository_model_or_obj_perms(request, view, action, permission):
 
 
 def has_repo_or_repo_ver_param_model_or_domain_or_obj_perms(request, view, action, permission):
-    """
-    Checks if the current user has permission on the ``repository`` or ``repository_version``.
-    """
+    """Checks if the current user has permission on the ``repository`` or ``repository_version``."""
     if has_model_or_domain_perms(request, view, action, permission):
         return True
     kwargs = {}
@@ -431,8 +411,7 @@ def has_repo_or_repo_ver_param_model_or_domain_or_obj_perms(request, view, actio
 
 
 def has_repo_or_repo_ver_param_model_or_obj_perms(request, view, action, permission):
-    """
-    Checks if the current user has object-level permission on the ``repository`` object.
+    """Checks if the current user has object-level permission on the ``repository`` object.
 
     The object in this case is the one specified by the ``repository`` or ``repository_version``
     parameter. For example when publishing the ``repository`` parameter is passed in as an argument.
@@ -486,8 +465,7 @@ def has_repo_or_repo_ver_param_model_or_obj_perms(request, view, action, permiss
 
 
 def has_required_repo_perms_on_upload(request, view, action, permission):
-    """
-    Checks if the current user has permission to upload content to the ``repository`` object.
+    """Checks if the current user has permission to upload content to the ``repository`` object.
 
     Since content queryset scoping prevents users from seeing orphaned content by default this
     also checks to make sure that any user that isn't an admin has also supplied the ``repository``
@@ -560,9 +538,7 @@ def has_required_repo_perms_on_upload(request, view, action, permission):
 
 
 def has_publication_param_model_or_domain_or_obj_perms(request, view, action, permission):
-    """
-    Checks if the current user has permission on the ``Publication`` param.
-    """
+    """Checks if the current user has permission on the ``Publication`` param."""
     if has_model_or_domain_perms(request, view, action, permission):
         return True
     kwargs = {}
@@ -579,8 +555,7 @@ def has_publication_param_model_or_domain_or_obj_perms(request, view, action, pe
 
 
 def has_publication_param_model_or_obj_perms(request, view, action, permission):
-    """
-    Checks if the current user has permission on the ``Publication`` object.
+    """Checks if the current user has permission on the ``Publication`` object.
 
     The object in this case is the one specified by the ``publication`` parameter. For example when
     distributing the ``publication`` parameter is passed in as an argument.
@@ -629,9 +604,7 @@ def has_publication_param_model_or_obj_perms(request, view, action, permission):
 
 
 def has_upload_param_model_or_domain_or_obj_perms(request, view, action, permission):
-    """
-    Checks if the current user has permission on the ``Upload`` param.
-    """
+    """Checks if the current user has permission on the ``Upload`` param."""
     if has_model_or_domain_perms(request, view, action, permission):
         return True
     kwargs = {}
@@ -648,8 +621,7 @@ def has_upload_param_model_or_domain_or_obj_perms(request, view, action, permiss
 
 
 def has_upload_param_model_or_obj_perms(request, view, action, permission):
-    """
-    Checks if the current user has permission on the ``Upload`` object.
+    """Checks if the current user has permission on the ``Upload`` object.
 
     The object in this case is the one specified by the ``upload`` parameter, for example to a
     one-shot content creation call.
@@ -701,8 +673,7 @@ def has_upload_param_model_or_obj_perms(request, view, action, permission):
 
 
 def has_group_obj_perms(request, view, action, permission):
-    """
-    Checks whether a user has the requested object permission on the Group in the URL.
+    """Checks whether a user has the requested object permission on the Group in the URL.
 
     This check is meant to be used for relations nested beneath the group endpoint, e.g. the list
     of users to belong to that group. It will fail for other endpoints.
@@ -731,8 +702,7 @@ def has_group_obj_perms(request, view, action, permission):
 
 
 def has_group_model_or_obj_perms(request, view, action, permission):
-    """
-    Checks whether a user has the requested object or model permission on the Group in the URL.
+    """Checks whether a user has the requested object or model permission on the Group in the URL.
 
     This check is meant to be used for relations nested beneath the group endpoint, e.g. the list
     of users to belong to that group. It will fail for other endpoints.

--- a/pulpcore/app/importexport.py
+++ b/pulpcore/app/importexport.py
@@ -23,8 +23,7 @@ log = logging.getLogger(__name__)
 
 
 def _write_export(the_tarfile, resource, dest_dir=None):
-    """
-    Write the JSON export for the specified resource to the specified tarfile.
+    """Write the JSON export for the specified resource to the specified tarfile.
 
     The resulting file will be found at <dest_dir>/<resource.__class__.__name__>.json. If dest_dir
     is None, the file will be added at the 'top level' of the_tarfile.
@@ -81,8 +80,7 @@ def _write_export(the_tarfile, resource, dest_dir=None):
 
 
 def export_versions(export, version_info):
-    """
-    Write a JSON list of plugins and their versions as 'versions.json' to export.tarfile
+    """Write a JSON list of plugins and their versions as 'versions.json' to export.tarfile.
 
     Output format is [{"component": "<pluginname>", "version": "<pluginversion>"},...]
 
@@ -100,8 +98,7 @@ def export_versions(export, version_info):
 
 
 def export_artifacts(export, artifact_pks):
-    """
-    Export a set of Artifacts, ArtifactResources, and RepositoryResources
+    """Export a set of Artifacts, ArtifactResources, and RepositoryResources.
 
     Args:
         export (django.db.models.PulpExport): export instance that's doing the export
@@ -149,8 +146,7 @@ def export_artifacts(export, artifact_pks):
 
 
 def export_content(export, repository_version):
-    """
-    Export db-content, and the db-content of the owning repositories
+    """Export db-content, and the db-content of the owning repositories.
 
     Args:
         export (django.db.models.PulpExport): export instance that's doing the export

--- a/pulpcore/app/management/commands/add-signing-service.py
+++ b/pulpcore/app/management/commands/add-signing-service.py
@@ -15,9 +15,7 @@ from pulpcore.app.models.content import SigningService as BaseSigningService
 
 
 class Command(BaseCommand):
-    """
-    Django management command for adding a signing service.
-    """
+    """Django management command for adding a signing service."""
 
     help = "Adds a new SigningService."
 

--- a/pulpcore/app/management/commands/clean-up-progress-reports.py
+++ b/pulpcore/app/management/commands/clean-up-progress-reports.py
@@ -8,9 +8,7 @@ from pulpcore.constants import TASK_STATES
 
 
 class Command(BaseCommand):
-    """
-    Django management command for repairing progress-reports in inconsistent states.
-    """
+    """Django management command for repairing progress-reports in inconsistent states."""
 
     help = (
         "Repairs issue #3609. Long-running tasks that utilize ProgressReports, which "

--- a/pulpcore/app/management/commands/datarepair-2327.py
+++ b/pulpcore/app/management/commands/datarepair-2327.py
@@ -12,9 +12,7 @@ from pulpcore.app.models import Remote
 
 
 class Command(BaseCommand):
-    """
-    Django management command for repairing incorrectly migrated remote data.
-    """
+    """Django management command for repairing incorrectly migrated remote data."""
 
     help = (
         "Repairs issue #2327. A small number of configuration settings may have been "

--- a/pulpcore/app/management/commands/dump-permissions.py
+++ b/pulpcore/app/management/commands/dump-permissions.py
@@ -157,9 +157,7 @@ def _get_group_object_permissions():
 
 
 class Command(BaseCommand):
-    """
-    Django management command for getting a data dump of deprecated permission.
-    """
+    """Django management command for getting a data dump of deprecated permission."""
 
     help = _("Dumps deprecated permissions.")
 

--- a/pulpcore/app/management/commands/handle-artifact-checksums.py
+++ b/pulpcore/app/management/commands/handle-artifact-checksums.py
@@ -23,9 +23,7 @@ CHUNK_SIZE = 1024 * 1024  # 1 Mb
 
 
 class Command(BaseCommand):
-    """
-    Django management command for populating or removing checksums on artifacts.
-    """
+    """Django management command for populating or removing checksums on artifacts."""
 
     help = "Handle missing and forbidden checksums on the artifacts"
 
@@ -34,8 +32,7 @@ class Command(BaseCommand):
         parser.add_argument("--checksums", help=_("Comma separated list of checksums to evaluate"))
 
     def _print_out_repository_version_hrefs(self, repo_versions):
-        """
-        Print out repository version href from a query of repo versions.
+        """Print out repository version href from a query of repo versions.
 
         Args:
             repo_versions (django.db.models.QuerySet): repository versions query

--- a/pulpcore/app/management/commands/migrationstat.py
+++ b/pulpcore/app/management/commands/migrationstat.py
@@ -6,9 +6,7 @@ from django.core.management import BaseCommand
 
 
 class Command(BaseCommand):
-    """
-    Django management command to dump static informations about a migration.
-    """
+    """Django management command to dump static informations about a migration."""
 
     help = _("Dump static informations about a migration.")
 

--- a/pulpcore/app/management/commands/rebasemigrations.py
+++ b/pulpcore/app/management/commands/rebasemigrations.py
@@ -7,9 +7,7 @@ from django.core.management import BaseCommand
 
 
 class Command(BaseCommand):
-    """
-    Django management command to adjust migration dependencies to rebase on another plugin.
-    """
+    """Django management command to adjust migration dependencies to rebase on another plugin."""
 
     help = _("Adjust migration dependencies to rebase on another plugin.")
 

--- a/pulpcore/app/management/commands/remove-plugin.py
+++ b/pulpcore/app/management/commands/remove-plugin.py
@@ -30,9 +30,7 @@ $$;
 
 
 class Command(BaseCommand):
-    """
-    Django management command for removing a plugin.
-    """
+    """Django management command for removing a plugin."""
 
     help = "Disable a Pulp plugin and remove all the relevant data from the database. Destructive!"
 
@@ -43,9 +41,7 @@ class Command(BaseCommand):
         )
 
     def _check_pulp_services(self):
-        """
-        Check if any pulp services are running and error out if they are.
-        """
+        """Check if any pulp services are running and error out if they are."""
         is_pulp_running = True
         waiting_time = max(settings.CONTENT_APP_TTL, settings.WORKER_TTL)
         check_started = time.time()
@@ -66,8 +62,7 @@ class Command(BaseCommand):
             )
 
     def _remove_indirect_plugin_data(self, app_label):
-        """
-        Remove plugin data not accessible via plugin models.
+        """Remove plugin data not accessible via plugin models.
 
         Specifically,
             - remove django content type by app_label (also auth permissions are removed by cascade)
@@ -87,11 +82,10 @@ class Command(BaseCommand):
         Role.objects.filter(name__in=role_names, locked=True).delete()
 
     def _remove_plugin_data(self, app_label):
-        """
-        Remove all plugin data.
+        """Remove all plugin data.
 
-        Removal happens via ORM to be sure that all relations are cleaned properly as well,
-        e.g. Master-Detail, FKs to various content plugins in pulp-2to3-migration.
+        Removal happens via ORM to be sure that all relations are cleaned properly as well, e.g.
+        Master-Detail, FKs to various content plugins in pulp-2to3-migration.
 
         In some cases, the order in which models are removed matters, e.g. FK is a part of
         uniqueness constraint. Try to remove such problematic models later.
@@ -126,15 +120,12 @@ class Command(BaseCommand):
         self._remove_indirect_plugin_data(app_label)
 
     def _drop_plugin_tables(self, app_label):
-        """
-        Drop plugin table with raw SQL.
-        """
+        """Drop plugin table with raw SQL."""
         with connection.cursor() as cursor:
             cursor.execute(DROP_PLUGIN_TABLES_QUERY.format(app_label=app_label))
 
     def _unapply_migrations(self, app_label):
-        """
-        Unapply migrations so the plugin can be installed/run django migrations again if needed.
+        """Unapply migrations so the plugin can be installed/run django migrations again if needed.
 
         Make sure no post migration signals are connected/run (it's enough to disable only
         `populate_access_policy` and `populate_roles` for the requested plugin, so after

--- a/pulpcore/app/management/commands/remove-signing-service.py
+++ b/pulpcore/app/management/commands/remove-signing-service.py
@@ -11,9 +11,7 @@ from pulpcore.app.models.content import SigningService as BaseSigningService
 
 
 class Command(BaseCommand):
-    """
-    Django management command for removing a signing service.
-    """
+    """Django management command for removing a signing service."""
 
     help = "Removes an existing SigningService."
 

--- a/pulpcore/app/management/commands/repository-size.py
+++ b/pulpcore/app/management/commands/repository-size.py
@@ -12,8 +12,7 @@ from pulpcore.app.util import get_url, extract_pk
 
 
 def gather_repository_sizes(repositories, include_versions=False, include_on_demand=False):
-    """
-    Creates a list containing the size report for given repositories.
+    """Creates a list containing the size report for given repositories.
 
     Each entry in the list will contain a dict with following minimal fields:
         - name: name of the repository

--- a/pulpcore/app/management/commands/reset-admin-password.py
+++ b/pulpcore/app/management/commands/reset-admin-password.py
@@ -8,9 +8,7 @@ User = get_user_model()
 
 
 class Command(BaseCommand):
-    """
-    Django management command for resetting the password of the 'admin' user in Pulp.
-    """
+    """Django management command for resetting the password of the 'admin' user in Pulp."""
 
     help = 'Resets "admin" user\'s password.'
 

--- a/pulpcore/app/management/commands/rotate-db-key.py
+++ b/pulpcore/app/management/commands/rotate-db-key.py
@@ -14,9 +14,7 @@ class DryRun(Exception):
 
 
 class Command(BaseCommand):
-    """
-    Django management command for db key rotation.
-    """
+    """Django management command for db key rotation."""
 
     help = _(
         "Rotate the db encryption key. "

--- a/pulpcore/app/migrations/0104_delete_label.py
+++ b/pulpcore/app/migrations/0104_delete_label.py
@@ -5,8 +5,8 @@ from django.db.models.expressions import OuterRef, RawSQL
 
 
 def migrate_remaining_labels(apps, schema_editor):
-    """
-    This data migration handles the "but what about plugins" problem noted in the issue [0], with only two caveats:
+    """This data migration handles the "but what about plugins" problem noted in the issue [0], with
+    only two caveats:
 
     Case 1: If there were to exist a plugin containing a Model whose model-name ended in (for example) "Repository",
     that was NOT a detail-model of a Repository master-model, AND that plugin allowed Labels for such a model - then,

--- a/pulpcore/app/migrations/0123_upstreampulp_q_select.py
+++ b/pulpcore/app/migrations/0123_upstreampulp_q_select.py
@@ -4,12 +4,13 @@ from django.db import migrations, models
 
 
 def move_label_select_to_q(apps, schema_editor):
-    """
-    To keep ZDU, the pulp_label_select field will be moved, but not deleted during this
-    migration. Old tasks will still be able to access the field and new tasks will use the new
-    q_select field. Any new UpstreamPulps will only use q_select (label_select is being removed
-    from the serializer), so on the next breaking change release we can add a migration to remove
-    the pulp_label_select field.
+    """To keep ZDU, the pulp_label_select field will be moved, but not deleted during this
+    migration.
+
+    Old tasks will still be able to access the field and new tasks will use the new q_select field.
+    Any new UpstreamPulps will only use q_select (label_select is being removed from the
+    serializer), so on the next breaking change release we can add a migration to remove the
+    pulp_label_select field.
     """
     UpstreamPulp = apps.get_model("core", "UpstreamPulp")
     batch = []

--- a/pulpcore/app/modelresource.py
+++ b/pulpcore/app/modelresource.py
@@ -23,13 +23,11 @@ class ArtifactResource(QueryModelResource):
     """Resource for import/export of artifacts."""
 
     def before_import_row(self, row, **kwargs):
-        """
-        Sets digests to None if they are blank strings.
+        """Sets digests to None if they are blank strings.
 
         Args:
             row (tablib.Dataset row): incoming import-row representing a single Variant.
             kwargs: args passed along from the import() call.
-
         """
         super().before_import_row(row, **kwargs)
 
@@ -73,15 +71,14 @@ class RepositoryResource(QueryModelResource):
 
 
 class ContentArtifactResource(QueryModelResource):
-    """
-    Handles import/export of the ContentArtifact model.
+    """Handles import/export of the ContentArtifact model.
 
     ContentArtifact is different from other import-export entities because it has no 'natural key'
     other than a pulp_id, which aren't shared across instances. We do some magic to link up
     ContentArtifacts to their matching (already-imported) Content.
 
-    Some plugin-models have sub-repositories. We take advantage of the content-mapping
-    machinery to account for those contentartifacts as well.
+    Some plugin-models have sub-repositories. We take advantage of the content-mapping machinery to
+    account for those contentartifacts as well.
     """
 
     artifact = fields.Field(
@@ -96,8 +93,7 @@ class ContentArtifactResource(QueryModelResource):
         super().__init__(repo_version)
 
     def before_import_row(self, row, **kwargs):
-        """
-        Fixes the content-ptr of an incoming content-artifact row at import time.
+        """Fixes the content-ptr of an incoming content-artifact row at import time.
 
         Finds the 'original uuid' of the Content for this row, looks it up as the
         'upstream_id' of imported Content, and then replaces the Content-pk with its

--- a/pulpcore/app/models/access_policy.py
+++ b/pulpcore/app/models/access_policy.py
@@ -14,8 +14,8 @@ def _ensure_iterable(obj):
 
 
 class AccessPolicy(BaseModel):
-    """
-    A model storing a viewset authorization policy and permission assignment of new objects created.
+    """A model storing a viewset authorization policy and permission assignment of new objects
+    created.
 
     Fields:
 
@@ -30,7 +30,6 @@ class AccessPolicy(BaseModel):
             Defaults to False.
         queryset_scoping (models.JSONField): A dictionary identifying a callable to perform the
             queryset scoping. This field can be null if the user doesn't want to perform scoping.
-
     """
 
     creation_hooks = models.JSONField(null=True)
@@ -41,8 +40,7 @@ class AccessPolicy(BaseModel):
 
 
 class AutoAddObjPermsMixin:
-    """
-    A mixin that automatically adds roles based on the ``creation_hooks`` data.
+    """A mixin that automatically adds roles based on the ``creation_hooks`` data.
 
     To use this mixin, your model must support ``django-lifecycle``.
 
@@ -54,7 +52,6 @@ class AutoAddObjPermsMixin:
     * ``add_roles_for_object_creator`` will add the roles to the creator of the object.
     * ``add_roles_for_users`` will add the roles for one or more users by name.
     * ``add_roles_for_groups`` will add the roles for one or more groups by name.
-
     """
 
     def __init__(self, *args, **kwargs):
@@ -77,8 +74,7 @@ class AutoAddObjPermsMixin:
                     permission_class.handle_creation_hooks(self)
 
     def add_roles_for_users(self, roles, users):
-        """
-        Adds object-level roles for one or more users for this newly created object.
+        """Adds object-level roles for one or more users for this newly created object.
 
         Args:
             roles (str or list): One or more roles to be added at object-level for the users.
@@ -88,7 +84,6 @@ class AutoAddObjPermsMixin:
 
         Raises:
             ObjectDoesNotExist: If any of the users do not exist.
-
         """
         from pulpcore.app.role_util import assign_role
 
@@ -100,8 +95,7 @@ class AutoAddObjPermsMixin:
                 assign_role(role, user, self)
 
     def add_roles_for_groups(self, roles, groups):
-        """
-        Adds object-level roles for one or more groups for this newly created object.
+        """Adds object-level roles for one or more groups for this newly created object.
 
         Args:
             roles (str or list): One or more object-level roles to be added for the groups. This
@@ -111,7 +105,6 @@ class AutoAddObjPermsMixin:
 
         Raises:
             ObjectDoesNotExist: If any of the groups do not exist.
-
         """
         from pulpcore.app.role_util import assign_role
 
@@ -123,8 +116,7 @@ class AutoAddObjPermsMixin:
                 assign_role(role, group, self)
 
     def add_roles_for_object_creator(self, roles):
-        """
-        Adds object-level roles for the user creating the newly created object.
+        """Adds object-level roles for the user creating the newly created object.
 
         If the ``get_current_authenticated_user`` returns None because the API client did not
         provide authentication credentials, *no* permissions are added and this passes silently.
@@ -134,7 +126,6 @@ class AutoAddObjPermsMixin:
         Args:
             roles (list or str): One or more roles to be added at the object-level for the user.
                 This can either be a single role as a string, or list of role names.
-
         """
         from pulpcore.app.role_util import assign_role
 

--- a/pulpcore/app/models/acs.py
+++ b/pulpcore/app/models/acs.py
@@ -1,6 +1,4 @@
-"""
-Repository related Django models.
-"""
+"""Repository related Django models."""
 
 from django.db import models
 
@@ -9,8 +7,7 @@ from pulpcore.app.util import get_domain_pk
 
 
 class AlternateContentSource(MasterModel):
-    """
-    Alternate sources of content.
+    """Alternate sources of content.
 
     Fields:
 
@@ -38,8 +35,7 @@ class AlternateContentSource(MasterModel):
 
 
 class AlternateContentSourcePath(BaseModel):
-    """
-    Alternate sources of content.
+    """Alternate sources of content.
 
     Fields:
 

--- a/pulpcore/app/models/base.py
+++ b/pulpcore/app/models/base.py
@@ -18,8 +18,7 @@ def pulp_uuid():
 
 
 class BaseModel(LifecycleModel):
-    """
-    Base model class for all Pulp models.
+    """Base model class for all Pulp models.
 
     This model inherits from `LifecycleModel` which allows all Pulp models to be used with
     `django-lifecycle`.
@@ -36,7 +35,6 @@ class BaseModel(LifecycleModel):
 
         * https://docs.djangoproject.com/en/3.2/topics/db/models/#automatic-primary-key-fields
         * https://rsinger86.github.io/django-lifecycle/
-
     """
 
     pulp_id = models.UUIDField(primary_key=True, default=pulp_uuid, editable=False)
@@ -98,8 +96,7 @@ class MasterModelMeta(ModelBase):
 
 
 class MasterModel(BaseModel, metaclass=MasterModelMeta):
-    """
-    Base model for the "Master" model in a "Master-Detail" relationship.
+    """Base model for the "Master" model in a "Master-Detail" relationship.
 
     Provides methods for casting down to detail types, back up to the master type,
     as well as a model field for tracking the type.
@@ -119,7 +116,6 @@ class MasterModel(BaseModel, metaclass=MasterModelMeta):
         only abstract Model base classes for MasterModel to behave properly.
         Specifically, OneToOneField relationships must not be used in any MasterModel
         subclass.
-
     """
 
     # TYPE is the user-facing string that describes this type. It is used to construct API
@@ -189,8 +185,7 @@ class MasterModel(BaseModel, metaclass=MasterModelMeta):
 
     @property
     def master(self):
-        """
-        The "Master" model instance of this master-detail pair
+        """The "Master" model instance of this master-detail pair.
 
         If this is already the master model instance, it will return itself.
         """
@@ -211,12 +206,11 @@ class MasterModel(BaseModel, metaclass=MasterModelMeta):
 # on Model classes, but it's easy enough to use the model's _meta namespace to do this, since
 # that's where other methods like this exist in Django.
 def master_model(options):
-    """
-    The Master model class of this Model's Master/Detail relationship.
+    """The Master model class of this Model's Master/Detail relationship.
 
     Accessible at ``<model_class>._meta.master_model``, the Master model class in a Master/Detail
-    relationship is the most generic non-abstract Model in this model's multiple-table chain
-    of inheritance.
+    relationship is the most generic non-abstract Model in this model's multiple-table chain of
+    inheritance.
 
     If this model is not a detail model, None will be returned.
     """

--- a/pulpcore/app/models/content.py
+++ b/pulpcore/app/models/content.py
@@ -1,6 +1,4 @@
-"""
-Content related Django models.
-"""
+"""Content related Django models."""
 
 from gettext import gettext as _
 
@@ -60,13 +58,10 @@ _FORBIDDEN_DIGESTS = set(ALL_KNOWN_CONTENT_CHECKSUMS).difference(settings.ALLOWE
 
 
 class BulkCreateManager(models.Manager):
-    """
-    A manager that provides a bulk_get_or_create()
-    """
+    """A manager that provides a bulk_get_or_create()"""
 
     def bulk_get_or_create(self, objs, batch_size=None):
-        """
-        Insert the list of objects into the database and get existing objects from the database.
+        """Insert the list of objects into the database and get existing objects from the database.
 
         Do *not* call save() on each of the instances, do not send any pre/post_save signals,
         and do not set the primary key attribute if it is an autoincrement field (except if
@@ -99,20 +94,17 @@ class BulkCreateManager(models.Manager):
 
 
 class BulkTouchQuerySet(models.QuerySet):
-    """
-    A query set that provides ``touch()``.
-    """
+    """A query set that provides ``touch()``."""
 
     def touch(self):
-        """
-        Update the ``timestamp_of_interest`` on all objects of the query.
+        """Update the ``timestamp_of_interest`` on all objects of the query.
 
         Postgres' UPDATE call doesn't support order-by. This can (and does) result in deadlocks in
         high-concurrency environments, when using touch() on overlapping data sets. In order to
-        prevent this, we choose to SELECT FOR UPDATE with SKIP LOCKS == True, and only update
-        the rows that we were able to get locks on. Since a previously-locked-row implies
-        that updating that row's timestamp-of-interest is the responsibility of whoever currently
-        owns it, this results in correct data, while closing the window on deadlocks.
+        prevent this, we choose to SELECT FOR UPDATE with SKIP LOCKS == True, and only update the
+        rows that we were able to get locks on. Since a previously-locked-row implies that updating
+        that row's timestamp-of-interest is the responsibility of whoever currently owns it, this
+        results in correct data, while closing the window on deadlocks.
         """
         with transaction.atomic():
             sub_q = self.order_by("pk").select_for_update(skip_locked=True)
@@ -120,14 +112,10 @@ class BulkTouchQuerySet(models.QuerySet):
 
 
 class QueryMixin:
-    """
-    A mixin that provides models with querying utilities.
-    """
+    """A mixin that provides models with querying utilities."""
 
     def q(self):
-        """
-        Returns a Q object that represents the model
-        """
+        """Returns a Q object that represents the model."""
         if not self._state.adding:
             return models.Q(pk=self.pk)
         try:
@@ -139,13 +127,10 @@ class QueryMixin:
 
 
 class HandleTempFilesMixin:
-    """
-    A mixin that provides methods for handling temporary files.
-    """
+    """A mixin that provides methods for handling temporary files."""
 
     def save(self, *args, **kwargs):
-        """
-        Saves Model and closes the file associated with the Model
+        """Saves Model and closes the file associated with the Model.
 
         Args:
             args (list): list of positional arguments for Model.save()
@@ -157,8 +142,7 @@ class HandleTempFilesMixin:
             self.file.close()
 
     def delete(self, *args, **kwargs):
-        """
-        Deletes Model and the file associated with the Model
+        """Deletes Model and the file associated with the Model.
 
         Args:
             args (list): list of positional arguments for Model.delete()
@@ -182,8 +166,7 @@ class ArtifactQuerySet(BulkTouchQuerySet):
 
 
 class Artifact(HandleTempFilesMixin, BaseModel):
-    """
-    A file associated with a piece of content.
+    """A file associated with a piece of content.
 
     When calling `save()` on an Artifact, if the file is not stored in Django's storage backend, it
     is moved into place then.
@@ -207,8 +190,7 @@ class Artifact(HandleTempFilesMixin, BaseModel):
     """
 
     def storage_path(self, name):
-        """
-        Callable used by FileField to determine where the uploaded file should be stored.
+        """Callable used by FileField to determine where the uploaded file should be stored.
 
         Args:
             name (str): Original name of uploaded file. It is ignored by this method because the
@@ -253,8 +235,7 @@ class Artifact(HandleTempFilesMixin, BaseModel):
 
     @hook(BEFORE_SAVE)
     def before_save(self):
-        """
-        Pre-save hook that validates checksum rules prior to allowing an Artifact to be saved.
+        """Pre-save hook that validates checksum rules prior to allowing an Artifact to be saved.
 
         An Artifact with any checksums from the FORBIDDEN set will fail to save while raising
         an UnsupportedDigestValidationError exception.
@@ -290,8 +271,7 @@ class Artifact(HandleTempFilesMixin, BaseModel):
         return models.Q()
 
     def is_equal(self, other):
-        """
-        Is equal by matching digest.
+        """Is equal by matching digest.
 
         Args:
             other (pulpcore.app.models.Artifact): A artifact to match.
@@ -309,8 +289,7 @@ class Artifact(HandleTempFilesMixin, BaseModel):
 
     @staticmethod
     def init_and_validate(file, expected_digests=None, expected_size=None):
-        """
-        Initialize an in-memory Artifact from a file, and validate digest and size info.
+        """Initialize an in-memory Artifact from a file, and validate digest and size info.
 
         This accepts both a path to a file on-disk or a
         [pulpcore.app.files.PulpTemporaryUploadedFile][].
@@ -372,8 +351,7 @@ class Artifact(HandleTempFilesMixin, BaseModel):
 
     @classmethod
     def from_pulp_temporary_file(cls, temp_file):
-        """
-        Creates an Artifact from PulpTemporaryFile.
+        """Creates an Artifact from PulpTemporaryFile.
 
         Returns:
             An saved [pulpcore.plugin.models.Artifact][]
@@ -394,8 +372,7 @@ class Artifact(HandleTempFilesMixin, BaseModel):
 
 
 class PulpTemporaryFile(HandleTempFilesMixin, BaseModel):
-    """
-    A temporary file saved to the storage backend.
+    """A temporary file saved to the storage backend.
 
     Commonly used to pass data to one or more tasks.
 
@@ -410,8 +387,7 @@ class PulpTemporaryFile(HandleTempFilesMixin, BaseModel):
     """
 
     def storage_path(self, name):
-        """
-        Callable used by FileField to determine where the uploaded file should be stored.
+        """Callable used by FileField to determine where the uploaded file should be stored.
 
         Args:
             name (str): Original name of uploaded file. It is ignored by this method because the
@@ -426,8 +402,7 @@ class PulpTemporaryFile(HandleTempFilesMixin, BaseModel):
 
     @staticmethod
     def init_and_validate(file, expected_digests=None, expected_size=None):
-        """
-        Initialize an in-memory PulpTemporaryFile from a file, and validate digest and size info.
+        """Initialize an in-memory PulpTemporaryFile from a file, and validate digest and size info.
 
         This accepts both a path to a file on-disk or a
         [pulpcore.app.files.PulpTemporaryUploadedFile][].
@@ -511,8 +486,7 @@ ContentManager = BulkCreateManager.from_queryset(ContentQuerySet)
 
 
 class Content(MasterModel, QueryMixin):
-    """
-    A piece of managed content.
+    """A piece of managed content.
 
     Fields:
         upstream_id (models.UUIDField) : identifier of content imported from an 'upstream' Pulp
@@ -548,8 +522,7 @@ class Content(MasterModel, QueryMixin):
 
     @classmethod
     def repository_types(cls):
-        """
-        Tuple of the repository models that can store this content type.
+        """Tuple of the repository models that can store this content type.
 
         Populated at start up time. Read only.
         """
@@ -557,8 +530,8 @@ class Content(MasterModel, QueryMixin):
 
     @classmethod
     def natural_key_fields(cls):
-        """
-        Returns a tuple of the natural key fields which usually equates to unique_together fields.
+        """Returns a tuple of the natural key fields which usually equates to unique_together
+        fields.
 
         This can be overwritten in subclasses and should return a tuple of field names.
         """
@@ -567,8 +540,7 @@ class Content(MasterModel, QueryMixin):
     @classmethod
     @lru_cache(typed=True)
     def _sanitized_natural_key_fields(cls):
-        """
-        This function translates the names of the key fields to their attname.
+        """This function translates the names of the key fields to their attname.
 
         In case of foreign keys, this decodes to the corresponding `<...>_id` field preventing
         extra DB accesses to fetch the related objects.
@@ -576,8 +548,7 @@ class Content(MasterModel, QueryMixin):
         return tuple(getattr(cls, field).field.attname for field in cls.natural_key_fields())
 
     def natural_key(self):
-        """
-        Get the model's natural key based on natural_key_fields.
+        """Get the model's natural key based on natural_key_fields.
 
         Returns:
             tuple: The natural key.
@@ -585,15 +556,12 @@ class Content(MasterModel, QueryMixin):
         return tuple(getattr(self, f) for f in self._sanitized_natural_key_fields())
 
     def natural_key_dict(self):
-        """
-        Get the model's natural key as a dictionary of keys and values.
-        """
+        """Get the model's natural key as a dictionary of keys and values."""
         return {f: getattr(self, f) for f in self._sanitized_natural_key_fields()}
 
     @staticmethod
     def init_from_artifact_and_relative_path(artifact, relative_path):
-        """
-        Return an instance of the specific content by inspecting an artifact.
+        """Return an instance of the specific content by inspecting an artifact.
 
         Plugin writers are expected to override this method with an implementation for a specific
         content type. If the content type is stored with multiple artifacts plugin writers can
@@ -626,11 +594,10 @@ class Content(MasterModel, QueryMixin):
 
 
 class ContentArtifact(BaseModel, QueryMixin):
-    """
-    A relationship between a Content and an Artifact.
+    """A relationship between a Content and an Artifact.
 
-    Serves as a through model for the '_artifacts' ManyToManyField in Content.
-    Artifact is protected from deletion if it's present in a ContentArtifact relationship.
+    Serves as a through model for the '_artifacts' ManyToManyField in Content. Artifact is protected
+    from deletion if it's present in a ContentArtifact relationship.
     """
 
     artifact = models.ForeignKey(
@@ -647,8 +614,7 @@ class ContentArtifact(BaseModel, QueryMixin):
 
     @staticmethod
     def sort_key(ca):
-        """
-        Static method for defining a sort-key for a specified ContentArtifact.
+        """Static method for defining a sort-key for a specified ContentArtifact.
 
         Sorting lists of ContentArtifacts is critical for avoiding deadlocks in high-concurrency
         environments, when multiple workers may be operating on similar sets of content at the
@@ -691,8 +657,7 @@ class RemoteArtifactQuerySet(models.QuerySet):
 
 
 class RemoteArtifact(BaseModel, QueryMixin):
-    """
-    Represents a content artifact that is provided by a remote (external) repository.
+    """Represents a content artifact that is provided by a remote (external) repository.
 
     Remotes that want to support deferred download policies should use this model to store
     information required for downloading an Artifact at some point in the future. At a minimum this
@@ -766,8 +731,7 @@ class RemoteArtifact(BaseModel, QueryMixin):
 
 
 class SigningService(BaseModel):
-    """
-    A model used for producing signatures.
+    """A model used for producing signatures.
 
     Fields:
         name (models.TextField):
@@ -776,7 +740,6 @@ class SigningService(BaseModel):
             The value of the public key.
         script (models.TextField):
             An absolute path to an external signing script (or executable).
-
     """
 
     name = models.TextField(db_index=True, unique=True)
@@ -795,8 +758,7 @@ class SigningService(BaseModel):
         return {**os.environ, **env}
 
     def sign(self, filename, env_vars=None):
-        """
-        Signs the file provided via 'filename' by invoking an external script (or executable).
+        """Signs the file provided via 'filename' by invoking an external script (or executable).
 
         The external script is run as a subprocess. This is done in the expectation that the script
         has been validated as an external signing service by the validate() method. This validation
@@ -851,8 +813,7 @@ class SigningService(BaseModel):
         return return_value
 
     def validate(self):
-        """
-        Ensure that the external signing script produces the desired behaviour.
+        """Ensure that the external signing script produces the desired behaviour.
 
         With desired behaviour we mean the behaviour as validated by this method. Subclasses are
         required to implement this method. Works by calling the sign() method on some test data, and
@@ -865,9 +826,7 @@ class SigningService(BaseModel):
         raise NotImplementedError("Subclasses must implement a validate() method.")
 
     def save(self, *args, **kwargs):
-        """
-        Save a signing service to the database (unless it fails to validate).
-        """
+        """Save a signing service to the database (unless it fails to validate)."""
         if not self.public_key:
             raise RuntimeError(
                 _(
@@ -891,13 +850,10 @@ class SigningService(BaseModel):
 
 
 class AsciiArmoredDetachedSigningService(SigningService):
-    """
-    A model used for creating detached ASCII armored signatures.
-    """
+    """A model used for creating detached ASCII armored signatures."""
 
     def validate(self):
-        """
-        Validate a signing service for a detached ASCII armored signature.
+        """Validate a signing service for a detached ASCII armored signature.
 
         The validation seeks to ensure that the sign() method returns a dict as follows:
 

--- a/pulpcore/app/models/domain.py
+++ b/pulpcore/app/models/domain.py
@@ -13,8 +13,7 @@ storages = {}
 
 
 class Domain(BaseModel, AutoAddObjPermsMixin):
-    """
-    A namespace-like object applied to most Pulp models to allow for multi-tenancy.
+    """A namespace-like object applied to most Pulp models to allow for multi-tenancy.
 
     Pulp models have a domain as a part of their uniqueness-constraint to provide isolation from
     other domains. Domains each have their own storage backend for storing and deduplicating

--- a/pulpcore/app/models/exporter.py
+++ b/pulpcore/app/models/exporter.py
@@ -13,8 +13,7 @@ from pulpcore.constants import FS_EXPORT_CHOICES, FS_EXPORT_METHODS
 
 
 class Export(BaseModel):
-    """
-    A model that represents an Export.
+    """A model that represents an Export.
 
     Fields:
 
@@ -32,8 +31,7 @@ class Export(BaseModel):
 
 
 class ExportedResource(GenericRelationModel):
-    """
-    A model to represent anything that was exported in an Export.
+    """A model to represent anything that was exported in an Export.
 
     Resource can be a repo version, publication, etc.
 
@@ -46,8 +44,7 @@ class ExportedResource(GenericRelationModel):
 
 
 class Exporter(MasterModel):
-    """
-    A base model that provides logic to export a set of content and keep track of Exports.
+    """A base model that provides logic to export a set of content and keep track of Exports.
 
     Fields:
 
@@ -58,16 +55,13 @@ class Exporter(MasterModel):
 
 
 class FilesystemExport(Export):
-    """
-    A model that represents an export to the filesystem.
-    """
+    """A model that represents an export to the filesystem."""
 
     pass
 
 
 class FilesystemExporter(Exporter):
-    """
-    A base model that provides logic to export a set of content to the filesystem.
+    """A base model that provides logic to export a set of content to the filesystem.
 
     Fields:
 
@@ -84,8 +78,7 @@ class FilesystemExporter(Exporter):
 
 
 class PulpExport(Export):
-    """
-    A model that provides export-files that can be imported into other Pulp instances.
+    """A model that provides export-files that can be imported into other Pulp instances.
 
     Fields:
 
@@ -109,9 +102,7 @@ class PulpExport(Export):
     toc_info = models.JSONField(null=True)
 
     def export_tarfile_path(self):
-        """
-        Return the full tarfile name where the specified PulpExport should store its export
-        """
+        """Return the full tarfile name where the specified PulpExport should store its export."""
         # EXPORTER-PATH/export-EXPORTID-YYYYMMDD_HHMM.tar
         return os.path.normpath(
             "{}/export-{}-{}.tar".format(
@@ -124,8 +115,7 @@ class PulpExport(Export):
 
 
 class PulpExporter(Exporter):
-    """
-    A model that controls creating exports that can be imported into other Pulp instances.
+    """A model that controls creating exports that can be imported into other Pulp instances.
 
     Fields:
 

--- a/pulpcore/app/models/fields.py
+++ b/pulpcore/app/models/fields.py
@@ -30,16 +30,14 @@ def _fernet():
 
 
 class ArtifactFileField(FileField):
-    """
-    A custom FileField that always saves files to location specified by 'upload_to'.
+    """A custom FileField that always saves files to location specified by 'upload_to'.
 
     The field can be set as either a path to the file or File object. In both cases the file is
     moved or copied to the location specified by 'upload_to' field parameter.
     """
 
     def pre_save(self, model_instance, add):
-        """
-        Return FieldFile object which specifies path to the file to be stored in database.
+        """Return FieldFile object which specifies path to the file to be stored in database.
 
         There are two ways to get artifact into Pulp: sync and upload.
 
@@ -60,7 +58,6 @@ class ArtifactFileField(FileField):
 
         Returns:
             FieldFile object just before saving.
-
         """
         file = model_instance.file
         artifact_storage_path = self.upload_to(model_instance, "")

--- a/pulpcore/app/models/generic.py
+++ b/pulpcore/app/models/generic.py
@@ -1,5 +1,4 @@
-"""
-Container for models using generic relations provided by Django's ContentTypes framework.
+"""Container for models using generic relations provided by Django's ContentTypes framework.
 
 References:
     https://docs.djangoproject.com/en/3.2/ref/contrib/contenttypes/#generic-relations
@@ -15,9 +14,9 @@ from pulpcore.app.models.base import BaseModel
 class GenericRelationModel(BaseModel):
     """Base model class for implementing Generic Relations.
 
-    This class provides the required fields to implement generic relations. Instances of
-    this class can only be related models with a primary key, such as those subclassing
-    Pulp's base Model class.
+    This class provides the required fields to implement generic relations. Instances of this class
+    can only be related models with a primary key, such as those subclassing Pulp's base Model
+    class.
     """
 
     content_type = models.ForeignKey(ContentType, on_delete=models.CASCADE)

--- a/pulpcore/app/models/importer.py
+++ b/pulpcore/app/models/importer.py
@@ -9,8 +9,7 @@ from .repository import Repository
 
 
 class Import(BaseModel):
-    """
-    A model that represents imports into Pulp.
+    """A model that represents imports into Pulp.
 
     Fields:
         params (models.JSONField): A set of parameters used to run the import
@@ -26,8 +25,7 @@ class Import(BaseModel):
 
 
 class Importer(MasterModel):
-    """
-    A base model that provides logic to import data into Pulp.
+    """A base model that provides logic to import data into Pulp.
 
     Can be extended by plugins to provide import functionality.
 
@@ -39,9 +37,7 @@ class Importer(MasterModel):
 
 
 class PulpImporter(Importer):
-    """
-    A model that can be used to import exports from other Pulp instances.
-    """
+    """A model that can be used to import exports from other Pulp instances."""
 
     TYPE = "pulp"
 
@@ -77,8 +73,7 @@ class PulpImporter(Importer):
 
 
 class PulpImporterRepository(BaseModel):
-    """
-    A model that maps repo names in an export to repos in Pulp.
+    """A model that maps repo names in an export to repos in Pulp.
 
     Fields:
         source_repo (models.TextField): The name of the repo in the export

--- a/pulpcore/app/models/openpgp.py
+++ b/pulpcore/app/models/openpgp.py
@@ -159,9 +159,7 @@ class OpenPGPSignature(_OpenPGPContent):
 
 
 class OpenPGPKeyring(Repository, AutoAddObjPermsMixin):
-    """
-    A Repository to hold OpenPGP (rfc4880bis) public key material.
-    """
+    """A Repository to hold OpenPGP (rfc4880bis) public key material."""
 
     TYPE = "openpgp"
     CONTENT_TYPES = [
@@ -191,9 +189,7 @@ class OpenPGPKeyring(Repository, AutoAddObjPermsMixin):
 
 
 class OpenPGPDistribution(Distribution, AutoAddObjPermsMixin):
-    """
-    A Distribution to allow downloading OpenPGP keys.
-    """
+    """A Distribution to allow downloading OpenPGP keys."""
 
     TYPE = "openpgp"
     SERVE_FROM_PUBLICATION = False

--- a/pulpcore/app/models/progress.py
+++ b/pulpcore/app/models/progress.py
@@ -1,6 +1,4 @@
-"""
-Django models related to progress reporting
-"""
+"""Django models related to progress reporting."""
 
 import datetime
 import logging
@@ -17,8 +15,7 @@ _logger = logging.getLogger(__name__)
 
 
 class ProgressReport(BaseModel):
-    """
-    A model for all progress reporting.
+    """A model for all progress reporting.
 
     All progress reports have a message, state, and are related to a Task.
 
@@ -122,14 +119,13 @@ class ProgressReport(BaseModel):
     _last_save_time = None
 
     def save(self, *args, **kwargs):
-        """
-        Auto-set the task_id if running inside a task
+        """Auto-set the task_id if running inside a task.
 
         If the task_id is already set it will not be updated. If it is unset and this is running
         inside of a task it will be auto-set prior to saving.
 
-        args (list): positional arguments to be passed on to the real save
-        kwargs (dict): keyword arguments to be passed on to the real save
+        args (list): positional arguments to be passed on to the real save kwargs (dict): keyword
+        arguments to be passed on to the real save
         """
         now = timezone.now()
 
@@ -145,14 +141,13 @@ class ProgressReport(BaseModel):
             self._last_save_time = now
 
     async def asave(self, *args, **kwargs):
-        """
-        Auto-set the task_id if running inside a task
+        """Auto-set the task_id if running inside a task.
 
         If the task_id is already set it will not be updated. If it is unset and this is running
         inside of a task it will be auto-set prior to saving.
 
-        args (list): positional arguments to be passed on to the real save
-        kwargs (dict): keyword arguments to be passed on to the real save
+        args (list): positional arguments to be passed on to the real save kwargs (dict): keyword
+        arguments to be passed on to the real save
         """
         now = timezone.now()
 
@@ -168,9 +163,7 @@ class ProgressReport(BaseModel):
             self._last_save_time = now
 
     def __enter__(self):
-        """
-        Saves the progress report state as RUNNING
-        """
+        """Saves the progress report state as RUNNING."""
         self.state = TASK_STATES.RUNNING
         self.save()
 
@@ -179,9 +172,7 @@ class ProgressReport(BaseModel):
         return self
 
     async def __aenter__(self):
-        """
-        Async implementation of __enter__
-        """
+        """Async implementation of __enter__"""
         self.state = TASK_STATES.RUNNING
         await self.asave()
 
@@ -190,8 +181,7 @@ class ProgressReport(BaseModel):
         return self
 
     def __exit__(self, type, value, traceback):
-        """
-        Update the progress report state to COMPLETED, CANCELED, or FAILED.
+        """Update the progress report state to COMPLETED, CANCELED, or FAILED.
 
         If an exception occurs the progress report state is saved as:
         - CANCELED if the exception is `asyncio.CancelledError`
@@ -212,8 +202,7 @@ class ProgressReport(BaseModel):
         self.save()
 
     async def __aexit__(self, type, value, traceback):
-        """
-        Async implementation of __exit__
+        """Async implementation of __exit__
 
         Update the progress report state to COMPLETED, CANCELED, or FAILED.
 
@@ -236,8 +225,7 @@ class ProgressReport(BaseModel):
         await self.asave()
 
     def increment(self):
-        """
-        Increment done count and save the progress report.
+        """Increment done count and save the progress report.
 
         This will increment and save the self.done attribute which is useful to put into a loop
         processing items.
@@ -245,8 +233,7 @@ class ProgressReport(BaseModel):
         self.increase_by(1)
 
     async def aincrement(self):
-        """
-        Increment done count and save the progress report.
+        """Increment done count and save the progress report.
 
         This will increment and save the self.done attribute which is useful to put into a loop
         processing items.
@@ -254,8 +241,7 @@ class ProgressReport(BaseModel):
         await self.aincrease_by(1)
 
     def increase_by(self, count):
-        """
-        Increase the done count and save the progress report.
+        """Increase the done count and save the progress report.
 
         This will increment and save the self.done attribute which is useful to put into a loop
         processing items.
@@ -267,8 +253,7 @@ class ProgressReport(BaseModel):
         self.save()
 
     async def aincrease_by(self, count):
-        """
-        Increase the done count and save the progress report.
+        """Increase the done count and save the progress report.
 
         This will increment and save the self.done attribute which is useful to put into a loop
         processing items.
@@ -280,8 +265,7 @@ class ProgressReport(BaseModel):
         await self.asave()
 
     def iter(self, iter):
-        """
-        Iterate and automatically call increment().
+        """Iterate and automatically call increment().
 
             >>> progress_bar = ProgressReport(message='Publishing files', code='publish', total=23)
             >>> progress_bar.save()
@@ -300,8 +284,7 @@ class ProgressReport(BaseModel):
 
 
 class GroupProgressReport(BaseModel):
-    """
-    A model for all progress reporting in a Task Group.
+    """A model for all progress reporting in a Task Group.
 
     All progress reports have a message, code and are related to a Task Group.
 
@@ -348,7 +331,6 @@ class GroupProgressReport(BaseModel):
     Relations:
 
         task_group: The task group associated with this group progress report.
-
     """
 
     message = models.TextField()

--- a/pulpcore/app/models/publication.py
+++ b/pulpcore/app/models/publication.py
@@ -39,8 +39,7 @@ class PublicationQuerySet(models.QuerySet):
     """A queryset that provides publication filtering methods."""
 
     def with_content(self, content):
-        """
-        Filters publictions that contain the provided content units.
+        """Filters publictions that contain the provided content units.
 
         Args:
             content (django.db.models.QuerySet): query of content
@@ -60,9 +59,8 @@ class PublicationQuerySet(models.QuerySet):
 
 
 class Publication(MasterModel):
-    """
-    A publication contains metadata and artifacts associated with content
-    contained within a RepositoryVersion.
+    """A publication contains metadata and artifacts associated with content contained within a
+    RepositoryVersion.
 
     Using as a context manager is highly encouraged.  On context exit, the complete attribute
     is set True provided that an exception has not been raised.  In the event and exception
@@ -106,8 +104,7 @@ class Publication(MasterModel):
 
     @classmethod
     def create(cls, repository_version, pass_through=False, checkpoint=False):
-        """
-        Create a publication.
+        """Create a publication.
 
         This should be used to create a publication.  Using Publication() directly
         is highly discouraged.
@@ -139,8 +136,7 @@ class Publication(MasterModel):
 
     @property
     def repository(self):
-        """
-        Return the associated repository
+        """Return the associated repository.
 
         Returns:
             pulpcore.app.models.Repository: The repository associated to this publication
@@ -148,8 +144,7 @@ class Publication(MasterModel):
         return self.repository_version.repository
 
     def delete(self, **kwargs):
-        """
-        Delete the publication.
+        """Delete the publication.
 
         Args:
             **kwargs (dict): Delete options.
@@ -186,8 +181,7 @@ class Publication(MasterModel):
             return super().delete(**kwargs)
 
     def finalize_new_publication(self):
-        """
-        Finalize the incomplete Publication with plugin-provided code.
+        """Finalize the incomplete Publication with plugin-provided code.
 
         This method should be overridden by plugin writers for an opportunity for plugin input. This
         method is intended to be used to validate or modify the content.
@@ -199,8 +193,7 @@ class Publication(MasterModel):
         pass
 
     def __enter__(self):
-        """
-        Enter context.
+        """Enter context.
 
         Returns:
             Publication: self
@@ -208,8 +201,7 @@ class Publication(MasterModel):
         return self
 
     def __exit__(self, exc_type, exc_val, exc_tb):
-        """
-        Set the complete=True, create the publication.
+        """Set the complete=True, create the publication.
 
         Args:
             exc_type (Type): (optional) Type of exception raised.
@@ -244,8 +236,7 @@ class Publication(MasterModel):
 
 
 class PublishedArtifact(BaseModel):
-    """
-    An artifact that is part of a publication.
+    """An artifact that is part of a publication.
 
     Fields:
         relative_path (models.TextField): The (relative) path component of the published url.
@@ -266,8 +257,7 @@ class PublishedArtifact(BaseModel):
 
 
 class PublishedMetadata(Content):
-    """
-    Metadata file that is part of a publication.
+    """Metadata file that is part of a publication.
 
     Fields:
         relative_path (models.TextField): The (relative) path component of the published url.
@@ -284,8 +274,7 @@ class PublishedMetadata(Content):
 
     @classmethod
     def create_from_file(cls, file, publication, relative_path=None):
-        """
-        Creates PublishedMetadata along with Artifact, ContentArtifact, and PublishedArtifact.
+        """Creates PublishedMetadata along with Artifact, ContentArtifact, and PublishedArtifact.
 
         Args:
             file (django.core.files.File): an open File that contains metadata
@@ -324,8 +313,7 @@ class PublishedMetadata(Content):
 
 
 class ContentGuard(MasterModel):
-    """
-    Defines a named content guard.
+    """Defines a named content guard.
 
     This is meant to be subclassed by plugin authors as an opportunity to provide
     plugin-specific persistent attributes and additional validation for those attributes.
@@ -340,7 +328,6 @@ class ContentGuard(MasterModel):
         name (models.TextField): Unique guard name per domain.
         description (models.TextField): An optional description.
         pulp_domain (models.ForeignKey): The domain the ContentGuard is a part of.
-
     """
 
     name = models.TextField(db_index=True)
@@ -348,8 +335,7 @@ class ContentGuard(MasterModel):
     pulp_domain = models.ForeignKey("Domain", default=get_domain_pk, on_delete=models.PROTECT)
 
     def permit(self, request):
-        """
-        Authorize the specified web request.
+        """Authorize the specified web request.
 
         Args:
             request (aiohttp.web.Request): A request for a published file.
@@ -371,15 +357,14 @@ class ContentGuard(MasterModel):
 
 
 class RBACContentGuard(ContentGuard, AutoAddObjPermsMixin):
-    """
-    A content guard that protects content based on RBAC permissions.
-    """
+    """A content guard that protects content based on RBAC permissions."""
 
     TYPE = "rbac"
 
     def permit(self, request):
-        """
-        Authorize the specified web request. Expects the request to have already been authenticated.
+        """Authorize the specified web request.
+
+        Expects the request to have already been authenticated.
         """
         if not (drequest := request.get("drf_request", None)):
             raise PermissionError("Content app didn't properly authenticate this request")
@@ -406,9 +391,7 @@ def _gen_secret():
 
 
 class ContentRedirectContentGuard(ContentGuard, AutoAddObjPermsMixin):
-    """
-    Content guard to allow preauthenticated redirects to the content app.
-    """
+    """Content guard to allow preauthenticated redirects to the content app."""
 
     TYPE = "content_redirect"
 
@@ -417,9 +400,7 @@ class ContentRedirectContentGuard(ContentGuard, AutoAddObjPermsMixin):
     shared_secret = models.BinaryField(max_length=32, default=_gen_secret)
 
     def permit(self, request):
-        """
-        Permit preauthenticated redirects from pulp-api.
-        """
+        """Permit preauthenticated redirects from pulp-api."""
         try:
             expires = request.query["expires"]
             if int(timezone.now().timestamp()) > int(expires):
@@ -436,9 +417,7 @@ class ContentRedirectContentGuard(ContentGuard, AutoAddObjPermsMixin):
             raise PermissionError("Access not authenticated")
 
     def preauthenticate_url(self, url, salt=None):
-        """
-        Add validate_token to urls query string.
-        """
+        """Add validate_token to urls query string."""
         if not salt:
             salt = _gen_secret()
         hex_salt = salt.hex()
@@ -472,9 +451,7 @@ class ContentRedirectContentGuard(ContentGuard, AutoAddObjPermsMixin):
 
 
 class HeaderContentGuard(ContentGuard, AutoAddObjPermsMixin):
-    """
-    Content guard to protect content based on a header value.
-    """
+    """Content guard to protect content based on a header value."""
 
     TYPE = "header"
 
@@ -528,8 +505,7 @@ class HeaderContentGuard(ContentGuard, AutoAddObjPermsMixin):
 
 
 class CompositeContentGuard(ContentGuard, AutoAddObjPermsMixin):
-    """
-    Content guard to allow a list of contentguards to be evaluated on access.
+    """Content guard to allow a list of contentguards to be evaluated on access.
 
     Content-guards in the `guards` list have their permit() calls issued in order. At the
     first "pass" result, access is permitted. Only if ALL guards in the list forbid access,
@@ -543,9 +519,7 @@ class CompositeContentGuard(ContentGuard, AutoAddObjPermsMixin):
     guards = models.ManyToManyField(ContentGuard, related_name="+", symmetrical=False)
 
     def permit(self, request):
-        """
-        Permit if ANY content-guard allows (OR permissions).
-        """
+        """Permit if ANY content-guard allows (OR permissions)."""
         errors = []
         if not self.guards.all():
             # No guards specified? PASS
@@ -577,8 +551,7 @@ class CompositeContentGuard(ContentGuard, AutoAddObjPermsMixin):
 
 
 class BaseDistribution(MasterModel):
-    """
-    A distribution defines how a publication is distributed by the Content App.
+    """A distribution defines how a publication is distributed by the Content App.
 
     This abstract model can be used by plugin writers to create concrete distributions that are
     stored in separate tables from the Distributions provided by pulpcore.
@@ -618,8 +591,7 @@ class BaseDistribution(MasterModel):
 
 
 class Distribution(MasterModel):
-    """
-    A Distribution defines how the Content App distributes a publication or repository_version.
+    """A Distribution defines how the Content App distributes a publication or repository_version.
 
     This master model can be used by plugin writers to create detail Distribution objects.
 
@@ -673,8 +645,7 @@ class Distribution(MasterModel):
         unique_together = (("name", "pulp_domain"), ("base_path", "pulp_domain"))
 
     def content_handler(self, path):
-        """
-        Handler to serve extra, non-Artifact content for this Distribution
+        """Handler to serve extra, non-Artifact content for this Distribution.
 
         Args:
             path (str): The path being requested
@@ -685,8 +656,7 @@ class Distribution(MasterModel):
         return None
 
     def content_handler_list_directory(self, rel_path):
-        """
-        Generate the directory listing entries for content_handler
+        """Generate the directory listing entries for content_handler.
 
         Args:
             rel_path (str): relative path inside the distribution's base_path. For example,
@@ -697,8 +667,7 @@ class Distribution(MasterModel):
         return set()
 
     def content_headers_for(self, path):
-        """
-        Opportunity for Distribution to specify response-headers for a specific path
+        """Opportunity for Distribution to specify response-headers for a specific path.
 
         Args:
             path (str): The path being requested

--- a/pulpcore/app/models/replica.py
+++ b/pulpcore/app/models/replica.py
@@ -1,5 +1,4 @@
-"""
-Check `Plugin Writer's Guide`_ for more details.
+"""Check `Plugin Writer's Guide`_ for more details.
 
 Plugin Writer's Guide:
 https://pulpproject.org/pulpcore/docs/dev/learn/plugin-concepts/

--- a/pulpcore/app/models/repository.py
+++ b/pulpcore/app/models/repository.py
@@ -1,6 +1,4 @@
-"""
-Repository related Django models.
-"""
+"""Repository related Django models."""
 
 from contextlib import suppress
 from gettext import gettext as _
@@ -42,8 +40,7 @@ _logger = logging.getLogger(__name__)
 
 
 class Repository(MasterModel):
-    """
-    Collection of content.
+    """Collection of content.
 
     Fields:
 
@@ -123,8 +120,7 @@ class Repository(MasterModel):
         pass
 
     def save(self, *args, **kwargs):
-        """
-        Saves Repository model and creates an initial repository version.
+        """Saves Repository model and creates an initial repository version.
 
         Args:
             args (list): list of positional arguments for Model.save()
@@ -152,8 +148,7 @@ class Repository(MasterModel):
                     raise RuntimeError(f"The repository '{self.name}' could not be locked")
 
     def create_initial_version(self):
-        """
-        Create an initial repository version (version 0).
+        """Create an initial repository version (version 0).
 
         This method can be overriden by plugins if they require custom logic.
         """
@@ -163,8 +158,7 @@ class Repository(MasterModel):
         version.save()
 
     def new_version(self, base_version=None):
-        """
-        Create a new RepositoryVersion for this Repository
+        """Create a new RepositoryVersion for this Repository.
 
         Creation of a RepositoryVersion should be done in a RQ Job.
 
@@ -201,8 +195,7 @@ class Repository(MasterModel):
             return version
 
     def initialize_new_version(self, new_version):
-        """
-        Initialize the new RepositoryVersion with plugin-provided code.
+        """Initialize the new RepositoryVersion with plugin-provided code.
 
         This method should be overridden by plugin writers for an opportunity for plugin input. This
         method is intended to be called with the incomplete
@@ -215,13 +208,11 @@ class Repository(MasterModel):
         Args:
             new_version (pulpcore.app.models.RepositoryVersion): The incomplete RepositoryVersion to
                 finalize.
-
         """
         pass
 
     def finalize_new_version(self, new_version):
-        """
-        Finalize the incomplete RepositoryVersion with plugin-provided code.
+        """Finalize the incomplete RepositoryVersion with plugin-provided code.
 
         This method should be overridden by plugin writers for an opportunity for plugin input. This
         method is intended to be called with the incomplete
@@ -236,53 +227,45 @@ class Repository(MasterModel):
                 finalize.
 
         Returns:
-
         """
         pass
 
     def latest_version(self):
-        """
-        Get the latest RepositoryVersion on a repository
+        """Get the latest RepositoryVersion on a repository.
 
         Args:
             repository (pulpcore.app.models.Repository): to get the latest version of
 
         Returns:
             pulpcore.app.models.RepositoryVersion: The latest RepositoryVersion
-
         """
         with suppress(RepositoryVersion.DoesNotExist):
             model = self.versions.complete().latest()
             return model
 
     async def alatest_version(self):
-        """
-        Get the latest RepositoryVersion on a repository asynchronously
+        """Get the latest RepositoryVersion on a repository asynchronously.
 
         Args:
             repository (pulpcore.app.models.Repository): to get the latest version of
 
         Returns:
             pulpcore.app.models.RepositoryVersion: The latest RepositoryVersion
-
         """
         with suppress(RepositoryVersion.DoesNotExist):
             model = await self.versions.complete().alatest()
             return model
 
     def natural_key(self):
-        """
-        Get the model's natural key.
+        """Get the model's natural key.
 
-        :return: The model's natural key.
-        :rtype: tuple
+        :return: The model's natural key. :rtype: tuple
         """
         return (self.name,)
 
     @staticmethod
     def on_demand_artifacts_for_version(version):
-        """
-        Returns the remote artifacts of on-demand content for a repository version.
+        """Returns the remote artifacts of on-demand content for a repository version.
 
         Provides a method that plugins can override since RepositoryVersions aren't typed.
         Note: this only returns remote artifacts that have a non-null size.
@@ -297,8 +280,7 @@ class Repository(MasterModel):
 
     @staticmethod
     def artifacts_for_version(version):
-        """
-        Return the artifacts for a repository version.
+        """Return the artifacts for a repository version.
 
         Provides a method that plugins can override since RepositoryVersions aren't typed.
 
@@ -311,8 +293,7 @@ class Repository(MasterModel):
         return Artifact.objects.filter(content__pk__in=version.content)
 
     def protected_versions(self):
-        """
-        Return repository versions that are protected.
+        """Return repository versions that are protected.
 
         A protected version is one that is being served by a distro directly or via publication.
 
@@ -355,8 +336,7 @@ class Repository(MasterModel):
         return qs.distinct()
 
     def pull_through_add_content(self, content_artifact):
-        """
-        Dispatch a task to add the passed in content_artifact from the content app's pull-through
+        """Dispatch a task to add the passed in content_artifact from the content app's pull-through
         feature to this repository.
 
         Defaults to adding the associated content of the passed in content_artifact to the
@@ -406,8 +386,7 @@ class Repository(MasterModel):
                 version.delete()
 
     def delete(self, **kwargs):
-        """
-        Delete the repository.
+        """Delete the repository.
 
         Args:
             **kwargs (dict): Delete options.
@@ -465,8 +444,7 @@ class Repository(MasterModel):
 
 
 class Remote(MasterModel):
-    """
-    A remote source for content.
+    """A remote source for content.
 
     This is meant to be subclassed by plugin authors as an opportunity to provide plugin-specific
     persistent data attributes for a plugin remote subclass.
@@ -579,8 +557,7 @@ class Remote(MasterModel):
 
     @property
     def download_factory(self):
-        """
-        Return the DownloaderFactory which can be used to generate asyncio capable downloaders.
+        """Return the DownloaderFactory which can be used to generate asyncio capable downloaders.
 
         Upon first access, the DownloaderFactory is instantiated and saved internally.
 
@@ -599,8 +576,7 @@ class Remote(MasterModel):
 
     @property
     def download_throttler(self):
-        """
-        Return the Throttler which can be used to rate limit downloaders.
+        """Return the Throttler which can be used to rate limit downloaders.
 
         Upon first access, the Throttler is instantiated and saved internally.
         Plugin writers are expected to override when additional configuration of the
@@ -608,7 +584,6 @@ class Remote(MasterModel):
 
         Returns:
             Throttler: The instantiated Throttler to be used by get_downloader()
-
         """
         try:
             return self._download_throttler
@@ -618,8 +593,7 @@ class Remote(MasterModel):
                 return self._download_throttler
 
     def get_downloader(self, remote_artifact=None, url=None, download_factory=None, **kwargs):
-        """
-        Get a downloader from either a RemoteArtifact or URL that is configured with this Remote.
+        """Get a downloader from either a RemoteArtifact or URL that is configured with this Remote.
 
         This method accepts either `remote_artifact` or `url` but not both. At least one is
         required. If neither or both are passed a ValueError is raised.
@@ -663,8 +637,7 @@ class Remote(MasterModel):
         return download_factory.build(url, **kwargs)
 
     def get_remote_artifact_url(self, relative_path=None, request=None):
-        """
-        Get the full URL for a RemoteArtifact from relative path and request.
+        """Get the full URL for a RemoteArtifact from relative path and request.
 
         This method returns the URL for a RemoteArtifact by concatenating the Remote's url and the
         relative path. Plugin writers are expected to override this method when a more complex
@@ -685,8 +658,7 @@ class Remote(MasterModel):
         return path.join(self.url, relative_path)
 
     def get_remote_artifact_content_type(self, relative_path=None):
-        """
-        Get the type of content that should be available at the relative path.
+        """Get the type of content that should be available at the relative path.
 
         Plugin writers are expected to implement this method. This method can return None if the
         relative path is for metadata that should only be streamed from the remote and not saved.
@@ -714,8 +686,7 @@ class Remote(MasterModel):
 
 
 class RepositoryContent(BaseModel):
-    """
-    Association between a repository and its contained content.
+    """Association between a repository and its contained content.
 
     Fields:
 
@@ -762,8 +733,7 @@ class RepositoryVersionQuerySet(models.QuerySet):
         return self.filter(complete=True)
 
     def with_content(self, content):
-        """
-        Filters repository versions that contain the provided content units.
+        """Filters repository versions that contain the provided content units.
 
         Args:
             content (django.db.models.QuerySet): query of content
@@ -788,8 +758,7 @@ class RepositoryVersionQuerySet(models.QuerySet):
 
 
 class RepositoryVersion(BaseModel):
-    """
-    A version of a repository's content set.
+    """A version of a repository's content set.
 
     Plugin Writers are strongly encouraged to use RepositoryVersion as a context manager to provide
     transactional safety, working directory set up, plugin finalization, and cleaning up the
@@ -830,8 +799,7 @@ class RepositoryVersion(BaseModel):
         ordering = ("number",)
 
     def _content_relationships(self):
-        """
-        Returns a set of repository_content for a repository version
+        """Returns a set of repository_content for a repository version.
 
         Returns:
             django.db.models.QuerySet: The repository_content that is contained within this version.
@@ -841,8 +809,7 @@ class RepositoryVersion(BaseModel):
         ).exclude(version_removed__number__lte=self.number)
 
     def get_content(self, content_qs=None):
-        """
-        Returns a set of content for a repository version
+        """Returns a set of content for a repository version.
 
         Args:
             content_qs (django.db.models.QuerySet): The queryset for Content that will be
@@ -867,8 +834,7 @@ class RepositoryVersion(BaseModel):
 
     @property
     def content(self):
-        """
-        Returns a set of content for a repository version
+        """Returns a set of content for a repository version.
 
         Returns:
             django.db.models.QuerySet: The content that is contained within this version.
@@ -888,8 +854,7 @@ class RepositoryVersion(BaseModel):
         return self.get_content()
 
     def content_batch_qs(self, content_qs=None, order_by_params=("pk",), batch_size=1000):
-        """
-        Generate content batches to efficiently iterate over all content.
+        """Generate content batches to efficiently iterate over all content.
 
         Generates query sets that span the `content_qs` content of the repository
         version. Each yielded query set evaluates to at most `batch_size` content records.
@@ -936,15 +901,13 @@ class RepositoryVersion(BaseModel):
                     content_batch_qs.prefetch_related("contentartifact_set")
                     for content in content_batch_qs:
                         ...
-
         """
         version_content_qs = self.get_content(content_qs).order_by(*order_by_params)
         yield from batch_qs(version_content_qs, batch_size=batch_size)
 
     @property
     def artifacts(self):
-        """
-        Returns a set of artifacts for a repository version.
+        """Returns a set of artifacts for a repository version.
 
         Returns:
             django.db.models.QuerySet: The artifacts that are contained within this version.
@@ -997,8 +960,7 @@ class RepositoryVersion(BaseModel):
         ).exclude(version_memberships__in=self._content_relationships())
 
     def contains(self, content):
-        """
-        Check whether a content exists in this repository version's set of content
+        """Check whether a content exists in this repository version's set of content.
 
         Returns:
             bool: True if the repository version contains the content, False otherwise
@@ -1006,8 +968,7 @@ class RepositoryVersion(BaseModel):
         return self.content.filter(pk=content.pk).exists()
 
     def add_content(self, content):
-        """
-        Add a content unit to this version.
+        """Add a content unit to this version.
 
         Args:
            content (django.db.models.QuerySet): Set of Content to add
@@ -1050,8 +1011,7 @@ class RepositoryVersion(BaseModel):
         RepositoryContent.objects.bulk_create(repo_content)
 
     def remove_content(self, content):
-        """
-        Remove content from the repository.
+        """Remove content from the repository.
 
         Args:
             content (django.db.models.QuerySet): Set of Content to remove
@@ -1087,8 +1047,7 @@ class RepositoryVersion(BaseModel):
         q_set.update(version_removed=self)
 
     def set_content(self, content):
-        """
-        Sets the repo version content by calling remove_content() then add_content().
+        """Sets the repo version content by calling remove_content() then add_content().
 
         Args:
             content (django.db.models.QuerySet): Set of desired content
@@ -1139,9 +1098,7 @@ class RepositoryVersion(BaseModel):
             raise self.DoesNotExist
 
     def _squash(self, repo_relations, next_version):
-        """
-        Squash a complete repo version into the next version
-        """
+        """Squash a complete repo version into the next version."""
         # delete any relationships added in the version being deleted and removed in the next one.
         repo_relations.filter(version_added=self, version_removed=next_version).delete()
 
@@ -1191,8 +1148,7 @@ class RepositoryVersion(BaseModel):
             raise Exception(PROTECTED_REPO_VERSION_MESSAGE)
 
     def delete(self, **kwargs):
-        """
-        Deletes a RepositoryVersion
+        """Deletes a RepositoryVersion.
 
         If RepositoryVersion is complete and has a successor, squash RepositoryContent changes into
         the successor. If version is incomplete, delete and and clean up RepositoryContent,
@@ -1238,8 +1194,7 @@ class RepositoryVersion(BaseModel):
                 super().delete(**kwargs)
 
     def _compute_counts(self):
-        """
-        Compute and save content unit counts by type.
+        """Compute and save content unit counts by type.
 
         Count records are stored as [pulpcore.app.models.RepositoryVersionContentDetails][].
         This method deletes existing [pulpcore.app.models.RepositoryVersionContentDetails][]
@@ -1267,8 +1222,7 @@ class RepositoryVersion(BaseModel):
             RepositoryVersionContentDetails.objects.bulk_create(counts_list)
 
     def __enter__(self):
-        """
-        Create the repository version
+        """Create the repository version.
 
         Returns:
             RepositoryVersion: self
@@ -1282,9 +1236,7 @@ class RepositoryVersion(BaseModel):
         return self
 
     def __exit__(self, exc_type, exc_value, traceback):
-        """
-        Finalize and save the RepositoryVersion if no errors are raised, delete it if not
-        """
+        """Finalize and save the RepositoryVersion if no errors are raised, delete it if not."""
         if exc_value:
             self.delete()
         else:
@@ -1342,8 +1294,7 @@ class RepositoryVersionContentDetails(models.Model):
     count = models.IntegerField()
 
     def get_content_href(self, request=None):
-        """
-        Generate URLs for the content types added, removed, or present in the RepositoryVersion.
+        """Generate URLs for the content types added, removed, or present in the RepositoryVersion.
 
         For each content type present in or removed from this RepositoryVersion, create the URL of
         the viewset of that variety of content along with a query parameter which filters it by

--- a/pulpcore/app/models/role.py
+++ b/pulpcore/app/models/role.py
@@ -8,8 +8,7 @@ from pulpcore.app.models import BaseModel, Group
 
 
 class Role(BaseModel):
-    """
-    A model for the "role" part in RBAC.
+    """A model for the "role" part in RBAC.
 
     Fields:
 
@@ -28,8 +27,7 @@ class Role(BaseModel):
 
 
 class UserRole(BaseModel):
-    """
-    Join table for user to role associations with optional content object.
+    """Join table for user to role associations with optional content object.
 
     Relations:
 
@@ -58,8 +56,7 @@ class UserRole(BaseModel):
 
 
 class GroupRole(BaseModel):
-    """
-    Join table for group to role associations with optional content object.
+    """Join table for group to role associations with optional content object.
 
     Relations:
 

--- a/pulpcore/app/models/status.py
+++ b/pulpcore/app/models/status.py
@@ -1,6 +1,4 @@
-"""
-Django models related to the Status API
-"""
+"""Django models related to the Status API."""
 
 from datetime import timedelta
 
@@ -14,8 +12,7 @@ from pulpcore.app.models import BaseModel
 
 class AppStatusManager(models.Manager):
     def online(self):
-        """
-        Returns a queryset of objects that are online.
+        """Returns a queryset of objects that are online.
 
         To be considered 'online', a AppStatus must have a heartbeat timestamp within
         ``self.model.APP_TTL`` from now.
@@ -28,8 +25,7 @@ class AppStatusManager(models.Manager):
         return self.filter(last_heartbeat__gte=age_threshold)
 
     def missing(self, age=None):
-        """
-        Returns a queryset of workers meeting the criteria to be considered 'missing'
+        """Returns a queryset of workers meeting the criteria to be considered 'missing'.
 
         To be considered missing, a AppsStatus must have a stale timestamp.  By default, stale is
         defined here as longer than the ``self.model.APP_TTL``, or you can specify age as a
@@ -48,8 +44,7 @@ class AppStatusManager(models.Manager):
 
 
 class BaseAppStatus(BaseModel):
-    """
-    Represents an AppStatus.
+    """Represents an AppStatus.
 
     This class is abstract. Subclasses must define `APP_TTL` as a `timedelta`.
 
@@ -68,8 +63,7 @@ class BaseAppStatus(BaseModel):
 
     @property
     def online(self):
-        """
-        Whether an app can be considered 'online'
+        """Whether an app can be considered 'online'.
 
         To be considered 'online', an app must have a timestamp more recent than ``self.APP_TTL``.
 
@@ -81,8 +75,7 @@ class BaseAppStatus(BaseModel):
 
     @property
     def missing(self):
-        """
-        Whether an app can be considered 'missing'
+        """Whether an app can be considered 'missing'.
 
         To be considered 'missing', an App must have a timestamp older than ``self.APP_TTL``.
 
@@ -92,8 +85,7 @@ class BaseAppStatus(BaseModel):
         return not self.online
 
     def save_heartbeat(self):
-        """
-        Update the last_heartbeat field to now and save it.
+        """Update the last_heartbeat field to now and save it.
 
         Only the last_heartbeat field will be saved. No other changes will be saved.
 
@@ -108,16 +100,12 @@ class BaseAppStatus(BaseModel):
 
 
 class ApiAppStatus(BaseAppStatus):
-    """
-    Represents a Api App Status
-    """
+    """Represents a Api App Status."""
 
     APP_TTL = timedelta(seconds=settings.API_APP_TTL)
 
 
 class ContentAppStatus(BaseAppStatus):
-    """
-    Represents a Content App Status
-    """
+    """Represents a Content App Status."""
 
     APP_TTL = timedelta(seconds=settings.CONTENT_APP_TTL)

--- a/pulpcore/app/models/storage.py
+++ b/pulpcore/app/models/storage.py
@@ -10,8 +10,7 @@ from pulpcore.app.util import get_domain
 
 
 class FileSystem(FileSystemStorage):
-    """
-    Django's FileSystemStorage with modified _save() and get_available_name behaviors
+    """Django's FileSystemStorage with modified _save() and get_available_name behaviors.
 
     The _save() will check if the file is saved in WORKING_DIRECTORY first. If it is, a move is
     used. This will move all files created by the Downloaders and uploaded files from the user. If
@@ -20,8 +19,7 @@ class FileSystem(FileSystemStorage):
     """
 
     def get_available_name(self, name, max_length=None):
-        """
-        Returns a filename for the file even if it already exists.
+        """Returns a filename for the file even if it already exists.
 
         Content adressable storage must be saved with the expected filename.
 
@@ -35,8 +33,8 @@ class FileSystem(FileSystemStorage):
         return name
 
     def _save(self, name, content, max_length=None):
-        """
-        Create dirs to the destination, move the file if already in MEDIA_ROOT, or copy otherwise.
+        """Create dirs to the destination, move the file if already in MEDIA_ROOT, or copy
+        otherwise.
 
         Args:
             name (str): Target path to which the file is copied.
@@ -106,8 +104,7 @@ try:
         """Upstream class is missing the file_overwrite option."""
 
         def get_available_name(self, name, max_length=None):
-            """
-            Returns a filename for the file even if it already exists.
+            """Returns a filename for the file even if it already exists.
 
             Content adressable storage must be saved with the expected filename.
 
@@ -136,8 +133,7 @@ class DomainStorage:
 
 
 def get_artifact_path(sha256digest):
-    """
-    Determine the relative path where a file backing the Artifact should be stored.
+    """Determine the relative path where a file backing the Artifact should be stored.
 
     Args:
         sha256digest (str): sha256 digest of the file for the Artifact
@@ -155,8 +151,7 @@ def get_artifact_path(sha256digest):
 
 
 def get_temp_file_path(pulp_id):
-    """
-    Determine the relative path where a file backing the PulpTemporaryFile should be stored.
+    """Determine the relative path where a file backing the PulpTemporaryFile should be stored.
 
     Args:
         pulp_id (uuid): An identifier identifying the file for the PulpTemporaryFile
@@ -170,8 +165,7 @@ def get_temp_file_path(pulp_id):
 
 
 def get_upload_chunk_file_path(pulp_id):
-    """
-    Determine the relative path where a file backing an uploaded chunk should be stored.
+    """Determine the relative path where a file backing an uploaded chunk should be stored.
 
     Args:
         pulp_id (uuid): An identifier identifying the file for UploadChunk

--- a/pulpcore/app/models/task.py
+++ b/pulpcore/app/models/task.py
@@ -1,6 +1,4 @@
-"""
-Django models related to the Tasking system
-"""
+"""Django models related to the Tasking system."""
 
 import logging
 import traceback
@@ -29,16 +27,13 @@ _logger = logging.getLogger(__name__)
 
 
 class Worker(BaseAppStatus):
-    """
-    Represents a worker
-    """
+    """Represents a worker."""
 
     APP_TTL = timedelta(seconds=settings.WORKER_TTL)
 
     @property
     def current_task(self):
-        """
-        The task this worker is currently executing, if any.
+        """The task this worker is currently executing, if any.
 
         Returns:
             Task: The currently executing task
@@ -51,9 +46,7 @@ def _uuid_to_advisory_lock(value):
 
 
 class ProfileArtifact(BaseModel):
-    """
-    A model encapsulating profiled artifact data
-    """
+    """A model encapsulating profiled artifact data."""
 
     artifact = models.ForeignKey("Artifact", on_delete=models.CASCADE)
     task = models.ForeignKey("Task", on_delete=models.CASCADE)
@@ -72,8 +65,7 @@ class TaskManager(models.Manager):
 
 
 class Task(BaseModel, AutoAddObjPermsMixin):
-    """
-    Represents a task
+    """Represents a task.
 
     The Tasks state machine works like a finite automaton without loops:
     The initial state is WAITING.
@@ -199,8 +191,7 @@ class Task(BaseModel, AutoAddObjPermsMixin):
         self.progress_reports.filter(state=TASK_STATES.RUNNING).update(state=state)
 
     def set_running(self):
-        """
-        Set this Task to the running state, save it, and log output in warning cases.
+        """Set this Task to the running state, save it, and log output in warning cases.
 
         This updates the :attr:`started_at` and sets the :attr:`state` to :attr:`RUNNING`.
         """
@@ -221,8 +212,7 @@ class Task(BaseModel, AutoAddObjPermsMixin):
             )
 
     def set_completed(self):
-        """
-        Set this Task to the completed state, save it, and log output in warning cases.
+        """Set this Task to the completed state, save it, and log output in warning cases.
 
         This updates the :attr:`finished_at` and sets the :attr:`state` to :attr:`COMPLETED`.
         """
@@ -249,8 +239,7 @@ class Task(BaseModel, AutoAddObjPermsMixin):
         self._cleanup_progress_reports(TASK_STATES.COMPLETED)
 
     def set_failed(self, exc, tb):
-        """
-        Set this Task to the failed state and save it.
+        """Set this Task to the failed state and save it.
 
         This updates the :attr:`finished_at` attribute, sets the :attr:`state` to
         :attr:`FAILED`, and sets the :attr:`error` attribute.
@@ -281,8 +270,7 @@ class Task(BaseModel, AutoAddObjPermsMixin):
         self._cleanup_progress_reports(TASK_STATES.FAILED)
 
     def set_canceling(self):
-        """
-        Set this task to canceling from either waiting, running or canceling.
+        """Set this task to canceling from either waiting, running or canceling.
 
         This is the only valid transition without holding the task lock.
         """
@@ -300,9 +288,7 @@ class Task(BaseModel, AutoAddObjPermsMixin):
             )
 
     def set_canceled(self, final_state=TASK_STATES.CANCELED, reason=None):
-        """
-        Set this task to canceled or failed from canceling.
-        """
+        """Set this task to canceled or failed from canceling."""
         # Make sure this function was called with a proper final state
         assert final_state in [TASK_STATES.CANCELED, TASK_STATES.FAILED]
         finished_at = timezone.now()
@@ -372,19 +358,17 @@ class TaskGroup(BaseModel):
         return task_group
 
     def finish(self):
-        """
-        Finalize the task group.
+        """Finalize the task group.
 
-        Set 'all_tasks_dispatched' to True so that API users can know that there are no
-        tasks in the group yet to be created.
+        Set 'all_tasks_dispatched' to True so that API users can know that there are no tasks in the
+        group yet to be created.
         """
         self.all_tasks_dispatched = True
         self.save()
 
 
 class CreatedResource(GenericRelationModel):
-    """
-    Resources created by the task.
+    """Resources created by the task.
 
     Relations:
         task (models.ForeignKey): The task that created the resource.

--- a/pulpcore/app/models/upload.py
+++ b/pulpcore/app/models/upload.py
@@ -14,8 +14,7 @@ from pulpcore.app.util import get_domain_pk
 
 
 class Upload(BaseModel, AutoAddObjPermsMixin):
-    """
-    A chunked upload. Stores chunks until used to create an artifact, etc.
+    """A chunked upload. Stores chunks until used to create an artifact, etc.
 
     Fields:
 
@@ -30,8 +29,7 @@ class Upload(BaseModel, AutoAddObjPermsMixin):
     pulp_domain = models.ForeignKey("Domain", default=get_domain_pk, on_delete=models.PROTECT)
 
     def append(self, chunk, offset, sha256=None):
-        """
-        Append a chunk to an upload.
+        """Append a chunk to an upload.
 
         Args:
             chunk (File): Binary data to append to the upload file.
@@ -54,8 +52,7 @@ class Upload(BaseModel, AutoAddObjPermsMixin):
 
 
 class UploadChunk(BaseModel):
-    """
-    A chunk for an uploaded file.
+    """A chunk for an uploaded file.
 
     Fields:
 
@@ -66,8 +63,7 @@ class UploadChunk(BaseModel):
     """
 
     def storage_path(self, name):
-        """
-        Callable used by FileField to determine where the uploaded file should be stored.
+        """Callable used by FileField to determine where the uploaded file should be stored.
 
         Args:
             name (str): Original name of uploaded file. It is ignored by this method because the

--- a/pulpcore/app/pulp_hashlib.py
+++ b/pulpcore/app/pulp_hashlib.py
@@ -1,4 +1,4 @@
-"""A wrapper around `hashlib` providing only hashers named in settings.ALLOWED_CONTENT_CHECKSUMS"""
+"""A wrapper around `hashlib` providing only hashers named in settings.ALLOWED_CONTENT_CHECKSUMS."""
 
 from gettext import gettext as _
 import hashlib as the_real_hashlib
@@ -7,8 +7,7 @@ from django.conf import settings
 
 
 def new(name, *args, **kwargs):
-    """
-    A wrapper around the real `hashlib.new()` providing only trusted hashers.
+    """A wrapper around the real `hashlib.new()` providing only trusted hashers.
 
     The `ALLOWED_CONTENT_CHECKSUMS` setting identifies which hashers are allowed for use by Pulp.
     This function raises an exception if a hasher is requested which is not allowed, and otherwise,
@@ -24,7 +23,6 @@ def new(name, *args, **kwargs):
 
     Raises:
         An exception if the name of the hasher is not in the `ALLOWED_CONTENT_CHECKSUMS` settings.
-
     """
     if name not in settings.ALLOWED_CONTENT_CHECKSUMS:
         raise Exception(

--- a/pulpcore/app/pulpcore_gunicorn_application.py
+++ b/pulpcore/app/pulpcore_gunicorn_application.py
@@ -4,11 +4,12 @@ from gunicorn.app.base import Application
 
 
 class PulpcoreGunicornApplication(Application):
-    """
-    A common class for the api and content applications to inherit from that loads the default
+    """A common class for the api and content applications to inherit from that loads the default
     gunicorn configs (including from a config file if one exists) and then overrides with the values
-    specified in the init scripts. With warnings / errors if the user overrides something that won't
-    take effect or cannot be changed.
+    specified in the init scripts.
+
+    With warnings / errors if the user overrides something that won't take effect or cannot be
+    changed.
     """
 
     def __init__(self, options):
@@ -16,10 +17,8 @@ class PulpcoreGunicornApplication(Application):
         super().__init__()
 
     def init(self, *args, **kwargs):
-        """
-        A hook for setting application-specific configs, which we instead do below in load_config
-        where it's non-overridable.
-        """
+        """A hook for setting application-specific configs, which we instead do below in load_config
+        where it's non-overridable."""
         pass
 
     def set_option(self, key, value, enforced=False):

--- a/pulpcore/app/replica.py
+++ b/pulpcore/app/replica.py
@@ -65,10 +65,8 @@ class Replicator:
 
     @staticmethod
     def needs_update(fields_dict, model_instance):
-        """
-        Compares a Model instance's attributes against a dictionary where keys are attribute
-        names and values are expected values.
-        """
+        """Compares a Model instance's attributes against a dictionary where keys are attribute
+        names and values are expected values."""
         needs_update = False
         for field_name, value in fields_dict.items():
             if isinstance(getattr(model_instance, field_name), Model):
@@ -175,9 +173,7 @@ class Replicator:
         return repository
 
     def distribution_extra_fields(self, repository, upstream_distribution):
-        """
-        Return the fields that need to be updated/cleared on distributions for idempotence.
-        """
+        """Return the fields that need to be updated/cleared on distributions for idempotence."""
         return {
             "repository": get_url(repository),
             "publication": None,

--- a/pulpcore/app/response.py
+++ b/pulpcore/app/response.py
@@ -3,8 +3,7 @@ from pulpcore.app.util import reverse
 
 
 class OperationPostponedResponse(Response):
-    """
-    An HTTP response class for returning 202 and a spawned task.
+    """An HTTP response class for returning 202 and a spawned task.
 
     This response object should be used by views that dispatch asynchronous tasks. The most common
     use case is for sync and publish operations. When JSON is requested, the response will look
@@ -28,8 +27,7 @@ class OperationPostponedResponse(Response):
 
 
 class TaskGroupOperationResponse(Response):
-    """
-    An HTTP response class for returning 202 and a task group.
+    """An HTTP response class for returning 202 and a task group.
 
     This response object should be used by views that create a task group and dispatch one or more
     tasks for that group. When JSON is requested, the response will look like the following::

--- a/pulpcore/app/role_util.py
+++ b/pulpcore/app/role_util.py
@@ -21,8 +21,7 @@ def get_user_model():
 
 
 def assign_role(rolename, entity, obj=None, domain=None):
-    """
-    Assign a role to a user or a group.
+    """Assign a role to a user or a group.
 
     Args:
         rolename (str): Name of the role to assign.
@@ -63,8 +62,7 @@ def assign_role(rolename, entity, obj=None, domain=None):
 
 
 def remove_role(rolename, entity, obj=None, domain=None):
-    """
-    Remove a role from a user or a group.
+    """Remove a role from a user or a group.
 
     Args:
         rolename (str): Name of the role to assign.

--- a/pulpcore/app/serializers/access_policy.py
+++ b/pulpcore/app/serializers/access_policy.py
@@ -64,8 +64,7 @@ class AccessPolicySerializer(ModelSerializer):
         )
 
     def validate(self, data):
-        """
-        Validate the AccessPolicy.
+        """Validate the AccessPolicy.
 
         This ensures that the customized boolean will be set to True anytime the user modifies it.
         """

--- a/pulpcore/app/serializers/acs.py
+++ b/pulpcore/app/serializers/acs.py
@@ -21,8 +21,7 @@ class AlternateContentSourcePathField(serializers.ListField):
     child = serializers.CharField()
 
     def to_representation(self, paths):
-        """
-        A serializer field for AlternateContentSourcePath models.
+        """A serializer field for AlternateContentSourcePath models.
 
         Args:
             acs_pk (pk of AlternateContentSource instance): UUID of AlternateContentSource
@@ -34,9 +33,7 @@ class AlternateContentSourcePathField(serializers.ListField):
 
 
 class AlternateContentSourceSerializer(ModelSerializer):
-    """
-    Serializer for the AlternateContentSource.
-    """
+    """Serializer for the AlternateContentSource."""
 
     pulp_href = DetailIdentityField(view_name_pattern=r"acs(-.*/.*)-detail")
     name = serializers.CharField(
@@ -146,9 +143,7 @@ class AlternateContentSourceSerializer(ModelSerializer):
 
 
 class AlternateContentSourcePathSerializer(ModelSerializer):
-    """
-    Serializer for the AlternateContentSourcePath.
-    """
+    """Serializer for the AlternateContentSourcePath."""
 
     alternate_content_source = DetailRelatedField(
         view_name_pattern=r"acs(-.*/.*)-detail",

--- a/pulpcore/app/serializers/base.py
+++ b/pulpcore/app/serializers/base.py
@@ -101,7 +101,7 @@ class _MatchingRegexViewName(object):
 
 
 class _DetailFieldMixin(HrefPrnFieldMixin):
-    """Mixin class containing code common to DetailIdentityField and DetailRelatedField"""
+    """Mixin class containing code common to DetailIdentityField and DetailRelatedField."""
 
     def __init__(self, view_name=None, view_name_pattern=None, **kwargs):
         if view_name is None:
@@ -155,7 +155,7 @@ class RelatedField(
     HrefPrnFieldMixin,
     serializers.HyperlinkedRelatedField,
 ):
-    """RelatedField when relating to non-Master/Detail models
+    """RelatedField when relating to non-Master/Detail models.
 
     When using this field on a serializer, it will serialize the related resource as a relative URL.
     """
@@ -179,9 +179,8 @@ PKDomainObject = namedtuple("PKDomainObject", ["pk", "pulp_domain"])
 class RelatedResourceField(RelatedField):
     """RelatedResourceField when relating a Resource object models.
 
-    This field should be used to relate a list of non-homogeneous resources. e.g.:
-    CreatedResource and ExportedResource models that store relationships to arbitrary
-    resources.
+    This field should be used to relate a list of non-homogeneous resources. e.g.: CreatedResource
+    and ExportedResource models that store relationships to arbitrary resources.
 
     Specific implementation requires the model to be defined in the Meta:.
     """
@@ -242,25 +241,25 @@ class RelatedResourceField(RelatedField):
 
 
 class DetailIdentityField(_DetailFieldMixin, serializers.HyperlinkedIdentityField):
-    """IdentityField for use in the pulp_href field of Master/Detail Serializers
+    """IdentityField for use in the pulp_href field of Master/Detail Serializers.
 
     When using this field on a Serializer, it will automatically cast objects to their Detail type
     base on the Serializer's Model before generating URLs for them.
 
-    Subclasses must indicate the Master model they represent by declaring a queryset
-    in their class body, usually <MasterModelImplementation>.objects.all().
+    Subclasses must indicate the Master model they represent by declaring a queryset in their class
+    body, usually <MasterModelImplementation>.objects.all().
     """
 
 
 class DetailRelatedField(_DetailFieldMixin, serializers.HyperlinkedRelatedField):
-    """RelatedField for use when relating to Master/Detail models
+    """RelatedField for use when relating to Master/Detail models.
 
-    When using this field on a Serializer, relate it to the Master model in a
-    Master/Detail relationship, and it will automatically cast objects to their Detail type
-    before generating URLs for them.
+    When using this field on a Serializer, relate it to the Master model in a Master/Detail
+    relationship, and it will automatically cast objects to their Detail type before generating URLs
+    for them.
 
-    Subclasses must indicate the Master model they represent by declaring a queryset
-    in their class body, usually <MasterModelImplementation>.objects.all().
+    Subclasses must indicate the Master model they represent by declaring a queryset in their class
+    body, usually <MasterModelImplementation>.objects.all().
     """
 
     def get_object(self, *args, **kwargs):
@@ -268,8 +267,9 @@ class DetailRelatedField(_DetailFieldMixin, serializers.HyperlinkedRelatedField)
         return super().get_object(*args, **kwargs).cast()
 
     def use_pk_only_optimization(self):
-        """
-        If the lookup field is `pk`, DRF substitutes a PKOnlyObject as an optimization. This
+        """If the lookup field is `pk`, DRF substitutes a PKOnlyObject as an optimization.
+
+        This
         optimization breaks with Detail fields like this one which need access to their Meta
         class to get the relevant `view_name`.
         """
@@ -297,8 +297,8 @@ class NestedRelatedField(
 
 
 def validate_unknown_fields(initial_data, defined_fields):
-    """
-    This will raise a `ValidationError` if a serializer is passed fields that are unknown.
+    """This will raise a `ValidationError` if a serializer is passed fields that are unknown.
+
     The `csrfmiddlewaretoken` field is silently ignored.
     """
     ignored_fields = {"csrfmiddlewaretoken"}
@@ -346,9 +346,9 @@ class ValidateFieldsMixin:
 
 
 class HiddenFieldsMixin(serializers.Serializer):
-    """
-    Adds a list field of hidden (write only) fields and whether their values are set
-    so clients can tell if they are overwriting an existing value.
+    """Adds a list field of hidden (write only) fields and whether their values are set so clients
+    can tell if they are overwriting an existing value.
+
     For example this could be any sensitive information such as a password, name or token.
     The list contains dictionaries with keys `name` and `is_set`.
     """
@@ -375,7 +375,7 @@ class HiddenFieldsMixin(serializers.Serializer):
 
 
 class GetOrCreateSerializerMixin:
-    """A mixin that provides a get_or_create with validation in the serializer"""
+    """A mixin that provides a get_or_create with validation in the serializer."""
 
     @classmethod
     def get_or_create(cls, natural_key, default_values=None):
@@ -436,7 +436,6 @@ class ModelSerializer(
     The class provides a default for the ``ref_name`` attribute in the
     ModelSerializers's ``Meta`` class. This ensures that the OpenAPI definitions
     of plugins are namespaced properly.
-
     """
 
     # default is 'fields!' which doesn't work in the bindings for some langs
@@ -457,9 +456,8 @@ class ModelSerializer(
     )
 
     def _validate_relative_path(self, path):
-        """
-        Validate a relative path (eg from a url) to ensure it forms a valid url and does not begin
-        or end with slashes nor contain spaces
+        """Validate a relative path (eg from a url) to ensure it forms a valid url and does not
+        begin or end with slashes nor contain spaces.
 
         Args:
             path (str): A relative path to validate
@@ -469,7 +467,6 @@ class ModelSerializer(
 
         Raises:
             django.core.exceptions.ValidationError: if the relative path is invalid
-
         """
         # in order to use django's URLValidator we need to construct a full url
         base = "http://localhost"  # use a scheme/hostname we know are valid
@@ -513,7 +510,6 @@ class ModelSerializer(
         The ``ref_name`` default value is computed using ``Meta.model``. If that
         is not defined (because the class must be subclassed to be useful),
         `ref_name` is not set.
-
         """
         super().__init_subclass__(**kwargs)
         meta = cls.Meta
@@ -527,9 +523,7 @@ class ModelSerializer(
 
 
 class AsyncOperationResponseSerializer(serializers.Serializer):
-    """
-    Serializer for asynchronous operations.
-    """
+    """Serializer for asynchronous operations."""
 
     task = RelatedField(
         required=True,
@@ -541,9 +535,7 @@ class AsyncOperationResponseSerializer(serializers.Serializer):
 
 
 class TaskGroupOperationResponseSerializer(serializers.Serializer):
-    """
-    Serializer for asynchronous operations that return a task group.
-    """
+    """Serializer for asynchronous operations that return a task group."""
 
     task_group = RelatedField(
         required=True,
@@ -555,18 +547,14 @@ class TaskGroupOperationResponseSerializer(serializers.Serializer):
 
 
 class SetLabelSerializer(serializers.Serializer):
-    """
-    Serializer for synchronously setting a label.
-    """
+    """Serializer for synchronously setting a label."""
 
     key = serializers.SlugField(required=True)
     value = serializers.CharField(required=True, allow_null=True, allow_blank=True)
 
 
 class UnsetLabelSerializer(serializers.Serializer):
-    """
-    Serializer for synchronously UNsetting a label.
-    """
+    """Serializer for synchronously UNsetting a label."""
 
     key = serializers.SlugField(required=True)
     value = serializers.CharField(read_only=True)

--- a/pulpcore/app/serializers/content.py
+++ b/pulpcore/app/serializers/content.py
@@ -29,8 +29,7 @@ class NoArtifactContentSerializer(base.ModelSerializer):
     )
 
     def get_artifacts(self, validated_data):
-        """
-        Extract artifacts from validated_data.
+        """Extract artifacts from validated_data.
 
         This function is supposed to extract the information about content artifacts from
         validated_data and return a dictionary with artifacts and relative paths as keys.
@@ -38,11 +37,10 @@ class NoArtifactContentSerializer(base.ModelSerializer):
         return {}
 
     def retrieve(self, validated_data):
-        """
-        Retrieve existing content unit if it exists, else return None.
+        """Retrieve existing content unit if it exists, else return None.
 
-        This method is plugin-specific and implementing it for a specific content type
-        allows for uploading already existing content units of that type.
+        This method is plugin-specific and implementing it for a specific content type allows for
+        uploading already existing content units of that type.
         """
         return None
 
@@ -59,8 +57,7 @@ class NoArtifactContentSerializer(base.ModelSerializer):
         return data
 
     def create(self, validated_data):
-        """
-        Create the content and associate it with its Artifacts, or retrieve the existing content.
+        """Create the content and associate it with its Artifacts, or retrieve the existing content.
 
         Args:
             validated_data (dict): Data to save to the database
@@ -131,9 +128,7 @@ class SingleArtifactContentSerializer(NoArtifactContentSerializer):
     )
 
     def __init__(self, *args, **kwargs):
-        """
-        Initializer for SingleArtifactContentSerializer
-        """
+        """Initializer for SingleArtifactContentSerializer."""
         super().__init__(*args, **kwargs)
 
         # If the content model has its own database field 'relative_path',
@@ -172,8 +167,7 @@ class MultipleArtifactContentSerializer(NoArtifactContentSerializer):
 
 
 class ContentChecksumSerializer(serializers.Serializer):
-    """
-    Provide a serializer with artifact checksum fields for single artifact content.
+    """Provide a serializer with artifact checksum fields for single artifact content.
 
     If you use this serializer, it's recommended that you prefetch artifacts:
 
@@ -264,8 +258,7 @@ class ArtifactSerializer(base.ModelSerializer):
     )
 
     def validate(self, data):
-        """
-        Validate file by size and by all checksums provided.
+        """Validate file by size and by all checksums provided.
 
         Args:
             data (django.http.QueryDict) QueryDict mapping Artifact model fields to their
@@ -326,9 +319,7 @@ class ArtifactSerializer(base.ModelSerializer):
 
 
 class SigningServiceSerializer(base.ModelSerializer):
-    """
-    A serializer for the model declaring a signing service.
-    """
+    """A serializer for the model declaring a signing service."""
 
     pulp_href = base.IdentityField(view_name="signing-services-detail")
     name = serializers.CharField(help_text=_("A unique name used to recognize a script."))

--- a/pulpcore/app/serializers/domain.py
+++ b/pulpcore/app/serializers/domain.py
@@ -79,8 +79,7 @@ class BaseSettingsClass(HiddenFieldsMixin, serializers.Serializer):
         return super().to_internal_value(data)
 
     def create(self, validated_data):
-        """
-        Create a storage instance based on the stored settings.
+        """Create a storage instance based on the stored settings.
 
         Subclasses can override this to instantiate objects needed for creation.
         """
@@ -229,7 +228,10 @@ class AmazonS3SettingsSerializer(BaseSettingsClass):
     client_config = serializers.HiddenField(default=None)
 
     def validate_verify(self, value):
-        """Verify can **only** be None or False. None=verify ssl."""
+        """Verify can **only** be None or False.
+
+        None=verify ssl.
+        """
         if value:
             value = None
         return value

--- a/pulpcore/app/serializers/exporter.py
+++ b/pulpcore/app/serializers/exporter.py
@@ -31,9 +31,7 @@ def parse_human_readable_file_size(size: str):
 
 
 class ExporterSerializer(ModelSerializer):
-    """
-    Base serializer for Exporters.
-    """
+    """Base serializer for Exporters."""
 
     pulp_href = DetailIdentityField(view_name_pattern=r"exporter(-.*/.*)-detail")
     name = serializers.CharField(
@@ -43,8 +41,7 @@ class ExporterSerializer(ModelSerializer):
 
     @staticmethod
     def validate_path(value, check_is_dir=False):
-        """
-        Check if path is in ALLOWED_EXPORT_PATHS.
+        """Check if path is in ALLOWED_EXPORT_PATHS.
 
         Args:
             value: The user-provided value path to be validated.
@@ -83,9 +80,7 @@ class ExportedResourceField(RelatedResourceField):
 
 
 class ExportSerializer(ModelSerializer):
-    """
-    Base serializer for Exports.
-    """
+    """Base serializer for Exports."""
 
     pulp_href = ExportIdentityField()
 
@@ -115,9 +110,7 @@ class ExportSerializer(ModelSerializer):
 
 
 class PulpExportSerializer(ExportSerializer):
-    """
-    Serializer for PulpExports.
-    """
+    """Serializer for PulpExports."""
 
     output_file_info = fields.JSONDictField(
         help_text=_("Dictionary of filename: sha256hash entries for export-output-file(s)"),
@@ -167,9 +160,8 @@ class PulpExportSerializer(ExportSerializer):
     )
 
     def _validate_versions_to_repos(self, the_versions):
-        """
-        If specifying repo-versions explicitly, must provide a version for each exporter-repository
-        """
+        """If specifying repo-versions explicitly, must provide a version for each exporter-
+        repository."""
         # make sure counts match
         the_exporter = self.context.get("exporter", None)
         num_repos = the_exporter.repositories.count()
@@ -252,9 +244,7 @@ class PulpExportSerializer(ExportSerializer):
 
 
 class PulpExporterSerializer(ExporterSerializer):
-    """
-    Serializer for pulp exporters.
-    """
+    """Serializer for pulp exporters."""
 
     path = serializers.CharField(help_text=_("File system directory to store exported tar.gzs."))
 
@@ -277,9 +267,7 @@ class PulpExporterSerializer(ExporterSerializer):
 
 
 class FilesystemExportSerializer(ExportSerializer):
-    """
-    Serializer for FilesystemExports.
-    """
+    """Serializer for FilesystemExports."""
 
     publication = DetailRelatedField(
         required=False,
@@ -320,9 +308,7 @@ class FilesystemExportSerializer(ExportSerializer):
 
 
 class FilesystemExporterSerializer(ExporterSerializer):
-    """
-    Serializer for FilesystemExporters.
-    """
+    """Serializer for FilesystemExporters."""
 
     path = serializers.CharField(help_text=_("File system location to export to."))
 

--- a/pulpcore/app/serializers/fields.py
+++ b/pulpcore/app/serializers/fields.py
@@ -67,9 +67,8 @@ class JSONListField(serializers.JSONField):
 
 
 class SingleContentArtifactField(RelatedField):
-    """
-    A serializer field for the '_artifacts' ManyToManyField on the Content model (single-artifact).
-    """
+    """A serializer field for the '_artifacts' ManyToManyField on the Content model (single-
+    artifact)."""
 
     lookup_field = "pk"
     view_name = "artifacts-detail"
@@ -77,8 +76,8 @@ class SingleContentArtifactField(RelatedField):
     allow_null = True
 
     def get_attribute(self, instance):
-        """
-        Returns the field from the instance that should be serialized using this serializer field.
+        """Returns the field from the instance that should be serialized using this serializer
+        field.
 
         This serializer looks up the list of artifacts and returns only one, if any exist. If more
         than one exist, it throws and exception because this serializer is being used in an
@@ -107,9 +106,7 @@ class SingleContentArtifactField(RelatedField):
 
 
 class ContentArtifactChecksumField(serializers.CharField):
-    """
-    A serializer field for the artifact checksum Content model (single-artifact).
-    """
+    """A serializer field for the artifact checksum Content model (single-artifact)."""
 
     def __init__(self, *args, **kwargs):
         kwargs["read_only"] = True
@@ -117,8 +114,8 @@ class ContentArtifactChecksumField(serializers.CharField):
         super().__init__(*args, **kwargs)
 
     def get_attribute(self, instance):
-        """
-        Returns the field from the instance that should be serialized using this serializer field.
+        """Returns the field from the instance that should be serialized using this serializer
+        field.
 
         This serializer looks up the checksum for single artifact content
 
@@ -148,13 +145,10 @@ class ContentArtifactChecksumField(serializers.CharField):
 
 
 class ContentArtifactsField(serializers.DictField):
-    """
-    A serializer field for the '_artifacts' ManyToManyField on the Content model.
-    """
+    """A serializer field for the '_artifacts' ManyToManyField on the Content model."""
 
     def run_validation(self, data):
-        """
-        Validates 'data' dict.
+        """Validates 'data' dict.
 
         Validates that all keys of 'data' are relative paths. Validates that all values of 'data'
         are URLs for an existing Artifact.
@@ -192,8 +186,8 @@ class ContentArtifactsField(serializers.DictField):
         return ret
 
     def get_attribute(self, instance):
-        """
-        Returns the field from the instance that should be serialized using this serializer field.
+        """Returns the field from the instance that should be serialized using this serializer
+        field.
 
         This serializer field serializes a ManyToManyField that is actually stored as a
         ContentArtifact model. Instead of returning the field, this method returns all the
@@ -209,8 +203,7 @@ class ContentArtifactsField(serializers.DictField):
         return instance.contentartifact_set.all()
 
     def to_representation(self, value):
-        """
-        Serializes list of ContentArtifacts.
+        """Serializes list of ContentArtifacts.
 
         Returns a dict mapping relative paths inside the Content to the corresponding Artifact
         URLs.
@@ -282,9 +275,9 @@ class LatestVersionField(RepositoryVersionRelatedField):
     queryset = None  # read-only relational fields should not provide a `queryset` argument
 
     def __init__(self, *args, **kwargs):
-        """
-        Unfortunately you can't just set read_only=True on the class. It has
-        to be done explicitly in the kwargs to __init__, or else DRF complains.
+        """Unfortunately you can't just set read_only=True on the class.
+
+        It has to be done explicitly in the kwargs to __init__, or else DRF complains.
         """
         kwargs["read_only"] = True
         super().__init__(*args, **kwargs)
@@ -307,9 +300,7 @@ class LatestVersionField(RepositoryVersionRelatedField):
 
 
 class BaseURLField(serializers.CharField):
-    """
-    Serializer Field for the base_url field of the Distribution.
-    """
+    """Serializer Field for the base_url field of the Distribution."""
 
     def to_representation(self, value):
 

--- a/pulpcore/app/serializers/importer.py
+++ b/pulpcore/app/serializers/importer.py
@@ -64,8 +64,7 @@ class PulpImporterSerializer(ImporterSerializer):
     )
 
     def create(self, validated_data):
-        """
-        Save the PulpImporter and handle saving repo mapping.
+        """Save the PulpImporter and handle saving repo mapping.
 
         Args:
             validated_data (dict): A dict of validated data to create the PulpImporter
@@ -125,8 +124,7 @@ class PulpImportSerializer(ModelSerializer):
         )
 
     def validate_path(self, value):
-        """
-        Check if path exists and is in ALLOWED_IMPORT_PATHS.
+        """Check if path exists and is in ALLOWED_IMPORT_PATHS.
 
         Args:
             value (str): The user-provided value path to be validated.
@@ -140,8 +138,7 @@ class PulpImportSerializer(ModelSerializer):
         return self._check_path_allowed("path", value)
 
     def validate_toc(self, value):
-        """
-        Check validity of provided 'toc' parameter.
+        """Check validity of provided 'toc' parameter.
 
         'toc' must be within ALLOWED_IMPORT_PATHS.
 
@@ -187,9 +184,7 @@ class PulpImportSerializer(ModelSerializer):
 
 
 class EvaluationSerializer(serializers.Serializer):
-    """
-    Results from evaluating a proposed parameter to a PulpImport call.
-    """
+    """Results from evaluating a proposed parameter to a PulpImport call."""
 
     context = serializers.CharField(
         help_text=_("Parameter value being evaluated."),
@@ -204,9 +199,7 @@ class EvaluationSerializer(serializers.Serializer):
 
 
 class PulpImportCheckResponseSerializer(serializers.Serializer):
-    """
-    Return the response to a PulpImport import-check call.
-    """
+    """Return the response to a PulpImport import-check call."""
 
     toc = EvaluationSerializer(
         help_text=_("Evaluation of proposed 'toc' file for PulpImport"),
@@ -223,11 +216,10 @@ class PulpImportCheckResponseSerializer(serializers.Serializer):
 
 
 class PulpImportCheckSerializer(ValidateFieldsMixin, serializers.Serializer):
-    """
-    Check validity of provided import-options.
+    """Check validity of provided import-options.
 
-    Provides the ability to check that an import is 'sane' without having to actually
-    create an importer.
+    Provides the ability to check that an import is 'sane' without having to actually create an
+    importer.
     """
 
     path = serializers.CharField(

--- a/pulpcore/app/serializers/orphans.py
+++ b/pulpcore/app/serializers/orphans.py
@@ -30,8 +30,8 @@ class OrphansCleanupSerializer(serializers.Serializer, ValidateFieldsMixin):
     )
 
     def validate_content_hrefs(self, value):
-        """
-        Check that the content_hrefs is not an empty list and contains all valid hrefs.
+        """Check that the content_hrefs is not an empty list and contains all valid hrefs.
+
         Args:
             value (list): The list supplied by the user
         Returns:

--- a/pulpcore/app/serializers/publication.py
+++ b/pulpcore/app/serializers/publication.py
@@ -141,18 +141,14 @@ class RBACContentGuardPermissionSerializer(serializers.Serializer):
 
 
 class ContentRedirectContentGuardSerializer(ContentGuardSerializer, GetOrCreateSerializerMixin):
-    """
-    A serializer for ContentRedirectContentGuard.
-    """
+    """A serializer for ContentRedirectContentGuard."""
 
     class Meta(ContentGuardSerializer.Meta):
         model = models.ContentRedirectContentGuard
 
 
 class HeaderContentGuardSerializer(ContentGuardSerializer, GetOrCreateSerializerMixin):
-    """
-    A serializer for HeaderContentGuard.
-    """
+    """A serializer for HeaderContentGuard."""
 
     header_name = serializers.CharField(help_text=_("The header name the guard will check on."))
     header_value = serializers.CharField(help_text=_("The value that will authorize the request."))
@@ -173,8 +169,7 @@ class HeaderContentGuardSerializer(ContentGuardSerializer, GetOrCreateSerializer
 
 
 class DistributionSerializer(ModelSerializer):
-    """
-    The Serializer for the Distribution model.
+    """The Serializer for the Distribution model.
 
     The serializer deliberately omits the `publication` and `repository_version` field due to
     plugins typically requiring one or the other but not both.
@@ -205,7 +200,6 @@ class DistributionSerializer(ModelSerializer):
           queryset=models.Remote.objects.all(),
           allow_null=True
       )
-
     """
 
     pulp_href = DetailIdentityField(view_name_pattern=r"distributions(-.*/.*)-detail")
@@ -376,9 +370,7 @@ class DistributionSerializer(ModelSerializer):
 
 
 class ArtifactDistributionSerializer(DistributionSerializer):
-    """
-    A serializer for ArtifactDistribution.
-    """
+    """A serializer for ArtifactDistribution."""
 
     class Meta:
         model = models.ArtifactDistribution
@@ -391,8 +383,7 @@ class ArtifactDistributionSerializer(DistributionSerializer):
 
 
 def validate_repo_and_remote(repository, field, **kwargs):
-    """
-    Validate that a repository has a remote of a compatible type.
+    """Validate that a repository has a remote of a compatible type.
 
     Args:
         repository: repository to check

--- a/pulpcore/app/serializers/reclaim.py
+++ b/pulpcore/app/serializers/reclaim.py
@@ -9,9 +9,7 @@ from pulpcore.app.util import get_domain
 
 
 class ReclaimSpaceSerializer(serializers.Serializer, ValidateFieldsMixin):
-    """
-    Serializer for reclaim disk space operation.
-    """
+    """Serializer for reclaim disk space operation."""
 
     repo_hrefs = fields.ListField(
         required=True,
@@ -26,8 +24,8 @@ class ReclaimSpaceSerializer(serializers.Serializer, ValidateFieldsMixin):
     )
 
     def validate_repo_hrefs(self, value):
-        """
-        Check that the repo_hrefs is not an empty list and contains all valid hrefs.
+        """Check that the repo_hrefs is not an empty list and contains all valid hrefs.
+
         Args:
             value (list): The list supplied by the user
         Returns:

--- a/pulpcore/app/serializers/replica.py
+++ b/pulpcore/app/serializers/replica.py
@@ -12,9 +12,7 @@ from pulpcore.app.models import UpstreamPulp
 
 
 class UpstreamPulpSerializer(ModelSerializer, HiddenFieldsMixin):
-    """
-    Serializer for a Server.
-    """
+    """Serializer for a Server."""
 
     pulp_href = IdentityField(view_name="upstream-pulps-detail")
     name = serializers.CharField(

--- a/pulpcore/app/serializers/repository.py
+++ b/pulpcore/app/serializers/repository.py
@@ -74,8 +74,7 @@ class RepositorySerializer(ModelSerializer):
 
 
 def validate_certificate(which_cert, value):
-    """
-    Validate and return *just* the certs and not any commentary that came along with them.
+    """Validate and return *just* the certs and not any commentary that came along with them.
 
     Args:
         which_cert: The attribute-name whose cert we're validating (only used for error-message).
@@ -114,9 +113,10 @@ def validate_certificate(which_cert, value):
 
 
 class RemoteSerializer(ModelSerializer, HiddenFieldsMixin):
-    """
-    Every remote defined by a plugin should have a Remote serializer that inherits from this
-    class. Please import from `pulpcore.plugin.serializers` rather than from this module directly.
+    """Every remote defined by a plugin should have a Remote serializer that inherits from this
+    class.
+
+    Please import from `pulpcore.plugin.serializers` rather than from this module directly.
     """
 
     pulp_href = DetailIdentityField(view_name_pattern=r"remotes(-.*/.*)-detail")
@@ -305,9 +305,7 @@ class RemoteSerializer(ModelSerializer, HiddenFieldsMixin):
         )
 
     def validate_proxy_url(self, value):
-        """
-        Check, that the proxy_url does not contain credentials.
-        """
+        """Check, that the proxy_url does not contain credentials."""
         if value and "@" in value:
             raise serializers.ValidationError(_("proxy_url must not contain credentials"))
         return value
@@ -319,9 +317,8 @@ class RemoteSerializer(ModelSerializer, HiddenFieldsMixin):
         return validate_certificate("client_cert", value)
 
     def validate(self, data):
-        """
-        Check, that proxy credentials are only provided completely and if a proxy is configured.
-        """
+        """Check, that proxy credentials are only provided completely and if a proxy is
+        configured."""
         data = super().validate(data)
 
         proxy_url = self.instance.proxy_url if self.partial else None
@@ -422,13 +419,10 @@ class RepositorySyncURLSerializer(ValidateFieldsMixin, serializers.Serializer):
 
 
 class ContentSummarySerializer(serializers.Serializer):
-    """
-    Serializer for the RepositoryVersion content summary
-    """
+    """Serializer for the RepositoryVersion content summary."""
 
     def to_representation(self, obj):
-        """
-        The summary of contained content.
+        """The summary of contained content.
 
         Returns:
             dict: The dictionary has the following format.::
@@ -438,7 +432,6 @@ class ContentSummarySerializer(serializers.Serializer):
                     'removed': {<pulp_type>: {'count': <count>, 'href': <href>},
                     'present': {<pulp_type>: {'count': <count>, 'href': <href>},
                 }
-
         """
         to_return = {"added": {}, "removed": {}, "present": {}}
         request = self.context.get("request")
@@ -453,9 +446,7 @@ class ContentSummarySerializer(serializers.Serializer):
         return to_return
 
     def to_internal_value(self, data):
-        """
-        Setting the internal value.
-        """
+        """Setting the internal value."""
         return {
             self.added: data["added"],
             self.removed: data["removed"],

--- a/pulpcore/app/serializers/status.py
+++ b/pulpcore/app/serializers/status.py
@@ -10,9 +10,7 @@ from pulpcore.app.serializers.task import (
 
 
 class VersionSerializer(serializers.Serializer):
-    """
-    Serializer for the version information of Pulp components
-    """
+    """Serializer for the version information of Pulp components."""
 
     component = serializers.CharField(help_text=_("Name of a versioned component of Pulp"))
 
@@ -28,9 +26,7 @@ class VersionSerializer(serializers.Serializer):
 
 
 class DatabaseConnectionSerializer(serializers.Serializer):
-    """
-    Serializer for the database connection information
-    """
+    """Serializer for the database connection information."""
 
     connected = serializers.BooleanField(
         help_text=_("Info about whether the app can connect to the database")
@@ -38,9 +34,7 @@ class DatabaseConnectionSerializer(serializers.Serializer):
 
 
 class RedisConnectionSerializer(serializers.Serializer):
-    """
-    Serializer for information about the Redis connection
-    """
+    """Serializer for information about the Redis connection."""
 
     connected = serializers.BooleanField(
         help_text=_("Info about whether the app can connect to Redis")
@@ -48,9 +42,7 @@ class RedisConnectionSerializer(serializers.Serializer):
 
 
 class StorageSerializer(serializers.Serializer):
-    """
-    Serializer for information about the storage system
-    """
+    """Serializer for information about the storage system."""
 
     total = serializers.IntegerField(
         min_value=0, help_text=_("Total number of bytes"), allow_null=True
@@ -66,9 +58,7 @@ class StorageSerializer(serializers.Serializer):
 
 
 class ContentSettingsSerializer(serializers.Serializer):
-    """
-    Serializer for information about content-app-settings for the pulp instance
-    """
+    """Serializer for information about content-app-settings for the pulp instance."""
 
     content_origin = serializers.CharField(
         help_text=_("The CONTENT_ORIGIN setting for this Pulp instance"),
@@ -82,9 +72,7 @@ class ContentSettingsSerializer(serializers.Serializer):
 
 
 class StatusSerializer(serializers.Serializer):
-    """
-    Serializer for the status information of the app
-    """
+    """Serializer for the status information of the app."""
 
     versions = VersionSerializer(help_text=_("Version information of Pulp components"), many=True)
 

--- a/pulpcore/app/serializers/task.py
+++ b/pulpcore/app/serializers/task.py
@@ -285,8 +285,7 @@ class TaskScheduleSerializer(ModelSerializer):
 
 
 class TaskStatusMessageSerializer(TaskSerializer):
-    """
-    Serializer for Task status messages.
+    """Serializer for Task status messages.
 
     Independent of other serializers in order to decouple the task message schema from other
     interfaces.

--- a/pulpcore/app/serializers/user.py
+++ b/pulpcore/app/serializers/user.py
@@ -60,7 +60,7 @@ class PermissionField(serializers.RelatedField):
 
 
 class ContentObjectField(serializers.CharField):
-    """Content object field"""
+    """Content object field."""
 
     def to_representation(self, value):
         if value is None:
@@ -84,7 +84,7 @@ class ContentObjectField(serializers.CharField):
 
 
 class ContentObjectPRNField(serializers.CharField):
-    """Content object PRN field"""
+    """Content object PRN field."""
 
     def to_representation(self, value):
         if value is None:
@@ -259,10 +259,10 @@ class ValidateRoleMixin:
     CHECK_SAME_DOMAIN = False
 
     def _validate_role(self, role_type, data):
-        """
-        Checks if the role contains the right permissions for the object/domain
-        and checks if the user/group already has the role. Does not set any value
-        in data or return anything.
+        """Checks if the role contains the right permissions for the object/domain and checks if the
+        user/group already has the role.
+
+        Does not set any value in data or return anything.
         """
         if "content_object" not in data:
             raise serializers.ValidationError(
@@ -456,8 +456,7 @@ class GroupRoleSerializer(ValidateRoleMixin, ModelSerializer, NestedHyperlinkedM
 
 
 class NestedRoleSerializer(serializers.Serializer):
-    """
-    Serializer to add/remove object roles to/from users/groups.
+    """Serializer to add/remove object roles to/from users/groups.
 
     This is used in conjunction with ``pulpcore.app.viewsets.base.RolesMixin`` and requires the
     underlying object to be passed as ``content_object`` in the context.

--- a/pulpcore/app/settings.py
+++ b/pulpcore/app/settings.py
@@ -1,5 +1,4 @@
-"""
-Django settings for the Pulp Platform application
+"""Django settings for the Pulp Platform application.
 
 Never import this module directly, instead `from django.conf import settings`, see
 <https://docs.djangoproject.com/en/3.2/topics/settings/#using-settings-in-python-code>

--- a/pulpcore/app/tasks/analytics.py
+++ b/pulpcore/app/tasks/analytics.py
@@ -35,8 +35,7 @@ User = get_user_model()
 
 
 def get_analytics_posting_url():
-    """
-    Return either the dev or production analytics FQDN url.
+    """Return either the dev or production analytics FQDN url.
 
     Production version string examples:  ["3.21.1", "1.11.0"]
     Developer version string example: ["3.20.3.dev", "2.0.0a6"]

--- a/pulpcore/app/tasks/base.py
+++ b/pulpcore/app/tasks/base.py
@@ -9,8 +9,7 @@ from asgiref.sync import sync_to_async
 
 
 def general_create_from_temp_file(app_label, serializer_name, temp_file_pk, *args, **kwargs):
-    """
-    Create a model instance from contents stored in a temporary file.
+    """Create a model instance from contents stored in a temporary file.
 
     A task which executes this function takes the ownership of a temporary file and deletes it
     afterwards. This function calls the function general_create() to create a model instance.
@@ -23,12 +22,10 @@ def general_create_from_temp_file(app_label, serializer_name, temp_file_pk, *arg
 
 
 def general_create(app_label, serializer_name, *args, **kwargs):
-    """
-    Create a model instance.
+    """Create a model instance.
 
     Raises:
         ValidationError: If the serializer is not valid
-
     """
     data = kwargs.pop("data", None)
 
@@ -45,8 +42,7 @@ def general_create(app_label, serializer_name, *args, **kwargs):
 
 
 def general_update(instance_id, app_label, serializer_name, *args, **kwargs):
-    """
-    Update a model
+    """Update a model.
 
     The model instance is identified using the app_label, id, and serializer name. The serializer is
     used to perform validation.
@@ -82,8 +78,7 @@ def general_update(instance_id, app_label, serializer_name, *args, **kwargs):
 
 
 def general_delete(instance_id, app_label, serializer_name):
-    """
-    Delete a model
+    """Delete a model.
 
     The model instance is identified using the app_label, id, and serializer name.
 
@@ -104,8 +99,7 @@ def general_delete(instance_id, app_label, serializer_name):
 
 
 def general_multi_delete(instance_ids):
-    """
-    Delete a list of model instances in a transaction
+    """Delete a list of model instances in a transaction.
 
     The model instances are identified using the id, app_label, and serializer_name.
 
@@ -125,9 +119,7 @@ def general_multi_delete(instance_ids):
 
 
 async def ageneral_update(instance_id, app_label, serializer_name, *args, **kwargs):
-    """
-    Async version of [pulpcore.app.tasks.base.general_update][].
-    """
+    """Async version of [pulpcore.app.tasks.base.general_update][]."""
     data = kwargs.pop("data", None)
     partial = kwargs.pop("partial", False)
     serializer_class = get_plugin_config(app_label).named_serializers[serializer_name]
@@ -140,9 +132,7 @@ async def ageneral_update(instance_id, app_label, serializer_name, *args, **kwar
 
 
 async def ageneral_delete(instance_id, app_label, serializer_name):
-    """
-    Async version of [pulpcore.app.tasks.base.general_delete][].
-    """
+    """Async version of [pulpcore.app.tasks.base.general_delete][]."""
     serializer_class = get_plugin_config(app_label).named_serializers[serializer_name]
     instance = await serializer_class.Meta.model.objects.aget(pk=instance_id)
     if isinstance(instance, MasterModel):

--- a/pulpcore/app/tasks/export.py
+++ b/pulpcore/app/tasks/export.py
@@ -59,8 +59,7 @@ def _validate_fs_export(content_artifacts):
 
 
 def _export_to_file_system(path, relative_paths_to_artifacts, method=FS_EXPORT_METHODS.WRITE):
-    """
-    Export a set of artifacts to the filesystem.
+    """Export a set of artifacts to the filesystem.
 
     Args:
         path (str): A path to export the ContentArtifacts to
@@ -108,8 +107,7 @@ def _export_to_file_system(path, relative_paths_to_artifacts, method=FS_EXPORT_M
 def _export_publication_to_file_system(
     path, publication, start_repo_version=None, method=FS_EXPORT_METHODS.WRITE, allow_missing=False
 ):
-    """
-    Export a publication to the file system.
+    """Export a publication to the file system.
 
     Args:
         path (str): Path to place the exported data
@@ -166,8 +164,7 @@ def _export_publication_to_file_system(
 
 
 def _export_location_is_clean(path):
-    """
-    Returns whether the provided path is valid to use as an export location.
+    """Returns whether the provided path is valid to use as an export location.
 
     Args:
         path (str):
@@ -183,8 +180,7 @@ def _export_location_is_clean(path):
 
 
 def fs_publication_export(exporter_pk, publication_pk, start_repo_version_pk=None):
-    """
-    Export a publication to the file system using an exporter.
+    """Export a publication to the file system using an exporter.
 
     Args:
         exporter_pk (str): FilesystemExporter pk
@@ -227,8 +223,7 @@ def fs_publication_export(exporter_pk, publication_pk, start_repo_version_pk=Non
 
 
 def fs_repo_version_export(exporter_pk, repo_version_pk, start_repo_version_pk=None):
-    """
-    Export a repository version to the file system using an exporter.
+    """Export a repository version to the file system using an exporter.
 
     Args:
         exporter_pk (str): FilesystemExporter pk
@@ -284,11 +279,9 @@ def fs_repo_version_export(exporter_pk, repo_version_pk, start_repo_version_pk=N
 
 
 def _get_versions_to_export(the_exporter, the_export):
-    """
-    Return repo-versions to be exported.
+    """Return repo-versions to be exported.
 
-    versions is based on exporter-repositories and how the export-cmd was
-    invoked.
+    versions is based on exporter-repositories and how the export-cmd was invoked.
     """
     repositories = the_exporter.repositories.all()
     # Figure out which RepositoryVersions we're going to be exporting
@@ -316,9 +309,7 @@ def _get_starting_versions(do_incremental, the_exporter, the_export):
 
 
 def _get_versions_info(the_exporter):
-    """
-    Return plugin-version-info based on plugins are responsible for exporter-repositories.
-    """
+    """Return plugin-version-info based on plugins are responsible for exporter-repositories."""
     # extract plugin-version-info based on the repositories we're exporting from
     repositories = the_exporter.repositories.all()
     repo_types = {r.pulp_type for r in repositories}
@@ -329,14 +320,13 @@ def _get_versions_info(the_exporter):
 
 
 def _version_match(curr_versions, prev_versions):
-    """
-    Match list of repo-versions, to a prev-set, based on belonging to the same repository.
+    """Match list of repo-versions, to a prev-set, based on belonging to the same repository.
 
     We need this in order to be able to know how to 'diff' versions for incremental exports.
 
-    :param curr_versions ([model.RepositoryVersion]): versions we want to export
-    :param prev_versions ([model.RepositoryVersion]): last set of versions we exported (if any)
-    :return: { <a_curr_version>: <matching-prev-version>, or None if no match or no prev_versions }
+    :param curr_versions ([model.RepositoryVersion]): versions we want to export :param
+    prev_versions ([model.RepositoryVersion]): last set of versions we exported (if any) :return: {
+    <a_curr_version>: <matching-prev-version>, or None if no match or no prev_versions }
     """
     curr_to_repo = {v.repository: v for v in curr_versions}
     if prev_versions is None:
@@ -358,8 +348,7 @@ def _incremental_requested(the_export):
 
 
 def pulp_export(exporter_pk, params):
-    """
-    Create a PulpExport to export pulp_exporter.repositories.
+    """Create a PulpExport to export pulp_exporter.repositories.
 
     1) Spit out all Artifacts, ArtifactResource.json, and RepositoryResource.json
     2) Spit out all *resource JSONs in per-repo-version directories

--- a/pulpcore/app/tasks/importer.py
+++ b/pulpcore/app/tasks/importer.py
@@ -58,8 +58,7 @@ MAX_ATTEMPTS = 3
 
 
 class ChunkedFile(ExitStack):
-    """
-    Read a toc file and represent the reconstructed file as a fileobj.
+    """Read a toc file and represent the reconstructed file as a fileobj.
 
     This class implements just enough of the fileobj interface to let `tarfile` work on a bunch of
     file chunks.
@@ -139,8 +138,7 @@ class ChunkedFile(ExitStack):
         self.chunks[self.chunk].seek(self.offset)
 
     def validate_chunks(self):
-        """
-        Check validity of table-of-contents file.
+        """Check validity of table-of-contents file.
 
         table-of-contents must:
           * exist
@@ -189,9 +187,8 @@ class ChunkedFile(ExitStack):
 
 
 def _get_destination_repo_name(importer, source_repo_name):
-    """
-    Return the name of a destination repository considering the mapping or source repository name.
-    """
+    """Return the name of a destination repository considering the mapping or source repository
+    name."""
     if importer.repo_mapping and importer.repo_mapping.get(source_repo_name):
         dest_repo_name = importer.repo_mapping[source_repo_name]
     else:
@@ -200,12 +197,10 @@ def _get_destination_repo_name(importer, source_repo_name):
 
 
 def _impfile_iterator(fd):
-    """
-    Iterate over an import-file returning batches of rows as a json-array-string.
+    """Iterate over an import-file returning batches of rows as a json-array-string.
 
-    We use naya.json.stream_array() to get individual rows; once a batch is gathered,
-    we yield the result of json.dumps() for that batch. Repeat until all rows have been
-    called for.
+    We use naya.json.stream_array() to get individual rows; once a batch is gathered, we yield the
+    result of json.dumps() for that batch. Repeat until all rows have been called for.
     """
     data = json_stream.load(fd)
     batch = []
@@ -218,13 +213,12 @@ def _impfile_iterator(fd):
 
 
 def _import_file(fpath, resource_class, retry=False):
-    """
-    Import the specified resource-file in batches to limit memory-use.
+    """Import the specified resource-file in batches to limit memory-use.
 
-    We process resource-files one "batch" at a time. Because of the way django-import's
-    internals work, we have to feed it batches as StringIO-streams of json-formatted strings.
-    The file-to-json-to-string-to-import is overhead, but it lets us put an upper bound on the
-    number of entities in memory at any one time at import-time.
+    We process resource-files one "batch" at a time. Because of the way django-import's internals
+    work, we have to feed it batches as StringIO-streams of json-formatted strings. The file-to-
+    json-to-string-to-import is overhead, but it lets us put an upper bound on the number of
+    entities in memory at any one time at import-time.
     """
     try:
         log.info(f"Importing file {fpath}.")
@@ -278,11 +272,10 @@ def _import_file(fpath, resource_class, retry=False):
 
 
 def _check_versions(version_json):
-    """
-    Compare the export version_json to the installed components.
+    """Compare the export version_json to the installed components.
 
-    An upstream whose db-metadata doesn't match the downstream won't import successfully; check
-    for compatibility and raise a ValidationError if incompatible versions are found.
+    An upstream whose db-metadata doesn't match the downstream won't import successfully; check for
+    compatibility and raise a ValidationError if incompatible versions are found.
     """
     error_messages = []
     for component in version_json:
@@ -315,8 +308,7 @@ def _check_versions(version_json):
 def import_repository_version(
     importer_pk, src_repo_name, src_repo_type, dest_repo_name, dest_repo_pk, tar_path, toc_path=None
 ):
-    """
-    Import a repository version from a Pulp export.
+    """Import a repository version from a Pulp export.
 
     Args:
         importer_pk (str): Importer we are working with.
@@ -424,8 +416,7 @@ def import_repository_version(
 
 
 def pulp_import(importer_pk, path, toc, create_repositories):
-    """
-    Import a Pulp export into Pulp.
+    """Import a Pulp export into Pulp.
 
     Args:
         importer_pk (str): Primary key of PulpImporter to do the import

--- a/pulpcore/app/tasks/migrate.py
+++ b/pulpcore/app/tasks/migrate.py
@@ -11,8 +11,8 @@ _logger = logging.getLogger(__name__)
 
 
 def migrate_backend(data):
-    """
-    Copy the artifacts from the current storage backend to a new one. Then update backend settings.
+    """Copy the artifacts from the current storage backend to a new one. Then update backend
+    settings.
 
     Args:
         data (dict): validated data of the new storage backend settings

--- a/pulpcore/app/tasks/orphan.py
+++ b/pulpcore/app/tasks/orphan.py
@@ -19,8 +19,7 @@ log = getLogger(__name__)
 
 
 def queryset_iterator(qs, batchsize=2000, gc_collect=True):
-    """
-    Provide a batching functionality that returns individual querysets per batch.
+    """Provide a batching functionality that returns individual querysets per batch.
 
     Copied from here with minor changes:
     https://www.guguweb.com/2020/03/27/optimize-django-memory-usage/
@@ -40,14 +39,11 @@ def queryset_iterator(qs, batchsize=2000, gc_collect=True):
 
 
 def orphan_cleanup(content_pks=None, orphan_protection_time=settings.ORPHAN_PROTECTION_TIME):
-    """
-    Delete all orphan Content and Artifact records.
-    Go through orphan Content multiple times to remove content from subrepos.
-    This task removes Artifact files from the filesystem as well.
+    """Delete all orphan Content and Artifact records. Go through orphan Content multiple times to
+    remove content from subrepos. This task removes Artifact files from the filesystem as well.
 
     Kwargs:
         content_pks (list): A list of content pks. If specified, only remove these orphans.
-
     """
     content = Content.objects.orphaned(orphan_protection_time, content_pks).exclude(
         pulp_type=PublishedMetadata.get_pulp_type()

--- a/pulpcore/app/tasks/purge.py
+++ b/pulpcore/app/tasks/purge.py
@@ -26,8 +26,7 @@ TASK_KEY = "core.Task"
 
 
 def _details_reporting(current_reports, current_details, totals_pb):
-    """
-    Create and update progress-reports for each detail-key returned from a delete() call.
+    """Create and update progress-reports for each detail-key returned from a delete() call.
 
     We don't know how many entities will be deleted via cascade-delete until we're all done.
 
@@ -63,8 +62,8 @@ def _details_reporting(current_reports, current_details, totals_pb):
 # Versions of this task up until at least 3.74 may not know about the user_pk argument.
 # We need to handle them accordingly.
 def purge(finished_before=None, states=None, **kwargs):
-    """
-    This task purges from the database records of tasks which finished prior to the specified time.
+    """This task purges from the database records of tasks which finished prior to the specified
+    time.
 
     It will remove only tasks that are 'deletable' by the current-user (admin-users own All The
     Things, so admins can delete all tasks). It will only delete tasks within the domain this task
@@ -80,7 +79,6 @@ def purge(finished_before=None, states=None, **kwargs):
     Args:
         finished_before (Optional[DateTime]): Earliest finished-time to **NOT** purge.
         states (Optional[List[str]]): List of task-states we want to purge.
-
     """
     if finished_before is None:
         assert settings.TASK_PROTECTION_TIME > 0

--- a/pulpcore/app/tasks/reclaim_space.py
+++ b/pulpcore/app/tasks/reclaim_space.py
@@ -17,8 +17,7 @@ log = getLogger(__name__)
 
 
 def reclaim_space(repo_pks, keeplist_rv_pks=None, force=False):
-    """
-    This task frees-up disk space by removing Artifact files from the filesystem for Content
+    """This task frees-up disk space by removing Artifact files from the filesystem for Content
     exclusive to the list of provided repos.
 
     Note: content marked as `proctected` will be excluded from the reclaim disk space.
@@ -28,7 +27,6 @@ def reclaim_space(repo_pks, keeplist_rv_pks=None, force=False):
         keeplist_rv_pks (list): A list of repo version pks that will be excluded from the reclaim
         disk space.
         force (bool): If True, uploaded content will be taken into account.
-
     """
     reclaimed_repos = Repository.objects.filter(pk__in=repo_pks)
     for repo in reclaimed_repos:

--- a/pulpcore/app/tasks/replica.py
+++ b/pulpcore/app/tasks/replica.py
@@ -16,9 +16,7 @@ from pulp_glue.common.context import PluginRequirement
 
 
 def user_agent():
-    """
-    Produce a User-Agent string to identify Pulp and relevant system info.
-    """
+    """Produce a User-Agent string to identify Pulp and relevant system info."""
     pulp_version = PulpAppConfig.version
     python = "{} {}.{}.{}-{}{}".format(sys.implementation.name, *sys.version_info)
     uname = platform.uname()

--- a/pulpcore/app/tasks/repository.py
+++ b/pulpcore/app/tasks/repository.py
@@ -20,9 +20,8 @@ CHUNK_SIZE = 1024 * 1024  # 1 Mb
 
 
 def delete_version(pk):
-    """
-    Delete a repository version by squashing its changes with the next newer version. This ensures
-    that the content set for each version stays the same.
+    """Delete a repository version by squashing its changes with the next newer version. This
+    ensures that the content set for each version stays the same.
 
     There must be a newer version to squash into. If we deleted the latest version, the next content
     change would create a new one of the same number, which would violate the immutability
@@ -164,8 +163,7 @@ async def _repair_artifacts_for_content(subset=None, verify_checksums=True):
 
 
 def repair_version(repository_version_pk, verify_checksums):
-    """
-    Repair the artifacts associated with this repository version.
+    """Repair the artifacts associated with this repository version.
 
     Artifact files that have suffered from bit rot, were altered or have gone missing will be
     attempted to be refetched fron an associated upstream.
@@ -190,8 +188,7 @@ def repair_version(repository_version_pk, verify_checksums):
 
 
 def repair_all_artifacts(verify_checksums):
-    """
-    Repair all artifacts, globally.
+    """Repair all artifacts, globally.
 
     Artifact files that have suffered from bit rot, were altered or have gone missing will be
     attempted to be refetched fron an associated upstream.
@@ -206,8 +203,7 @@ def repair_all_artifacts(verify_checksums):
 
 
 def add_and_remove(repository_pk, add_content_units, remove_content_units, base_version_pk=None):
-    """
-    Create a new repository version by adding and then removing content units.
+    """Create a new repository version by adding and then removing content units.
 
     Args:
         repository_pk (uuid): The primary key for a Repository for which a new Repository Version

--- a/pulpcore/app/tasks/test.py
+++ b/pulpcore/app/tasks/test.py
@@ -26,7 +26,7 @@ def gooey_task(interval):
 
 
 def dummy_group_task(inbetween=3, intervals=None):
-    """A group task that dispatches 'interval' sleep tasks every 'inbetween' seconds.'"""
+    """A group task that dispatches 'interval' sleep tasks every 'inbetween' seconds.'."""
     intervals = intervals or range(5)
     task_group = TaskGroup.current()
     for interval in intervals:

--- a/pulpcore/app/tasks/upload.py
+++ b/pulpcore/app/tasks/upload.py
@@ -9,8 +9,7 @@ log = getLogger(__name__)
 
 
 def commit(upload_id, sha256):
-    """
-    Commit the upload and turn it into an artifact.
+    """Commit the upload and turn it into an artifact.
 
     Args:
         upload_id (int): The upload primary key

--- a/pulpcore/app/templatetags/pulp_urls.py
+++ b/pulpcore/app/templatetags/pulp_urls.py
@@ -6,8 +6,7 @@ from django.utils.safestring import SafeData, mark_safe
 @register.filter(needs_autoescape=True)
 @stringfilter
 def urlize(text, autoescape=True):
-    """
-    Converts hrefs and urls in the input in to clickable links.
+    """Converts hrefs and urls in the input in to clickable links.
 
     This filter overwrites the django default implementation to also handle pulp api hrefs.
     """

--- a/pulpcore/app/urls.py
+++ b/pulpcore/app/urls.py
@@ -1,4 +1,4 @@
-"""pulp URL Configuration"""
+"""Pulp URL Configuration."""
 
 from django.conf import settings
 from django.urls import path, include
@@ -39,8 +39,7 @@ else:
 
 
 class ViewSetNode:
-    """
-    Each node is a tree that can register nested ViewSets with DRF nested routers.
+    """Each node is a tree that can register nested ViewSets with DRF nested routers.
 
     The structure of the tree becomes the url heirarchy when the ViewSets are registered.
 
@@ -57,8 +56,7 @@ class ViewSetNode:
     """
 
     def __init__(self, viewset=None):
-        """
-        Create a new node.
+        """Create a new node.
 
         Args:
             viewset (pulpcore.app.viewsets.base.NamedModelViewSet): If provided, represent this
@@ -68,8 +66,8 @@ class ViewSetNode:
         self.children = []
 
     def add_decendent(self, node):
-        """
-        Add a VSNode to the tree. If node is not a direct child, attempt to add the to each child.
+        """Add a VSNode to the tree. If node is not a direct child, attempt to add the to each
+        child.
 
         Args:
             node (ViewSetNode): A node that represents a viewset and its decendents.
@@ -88,8 +86,7 @@ class ViewSetNode:
                 child.add_decendent(node)
 
     def register_with(self, router):
-        """
-        Register this tree with the specified router and create new routers as necessary.
+        """Register this tree with the specified router and create new routers as necessary.
 
         Args:
             router (routers.DefaultRouter): router to register the viewset with.

--- a/pulpcore/app/util.py
+++ b/pulpcore/app/util.py
@@ -35,8 +35,7 @@ STRIPPED_API_ROOT = settings.API_ROOT.strip("/")
 
 
 def reverse(viewname, args=None, kwargs=None, request=None, relative_url=True, **extra):
-    """
-    Customized reverse to handle Pulp specific parameters like domains and API_ROOT rewrite.
+    """Customized reverse to handle Pulp specific parameters like domains and API_ROOT rewrite.
 
     Calls DRF's reverse, but with request as None if relative_url is True (default) so that the
     returned url is always relative.
@@ -52,9 +51,8 @@ def reverse(viewname, args=None, kwargs=None, request=None, relative_url=True, *
 
 
 def get_url(model, domain=None, request=None):
-    """
-    Get a resource url for the specified model instance or class. This returns the path component of
-    the resource URI.
+    """Get a resource url for the specified model instance or class. This returns the path component
+    of the resource URI.
 
     Args:
         model (django.models.Model): A model instance or class.
@@ -84,11 +82,10 @@ def get_url(model, domain=None, request=None):
 
 
 def get_prn(instance=None, uri=None):
-    """
-    Get a Pulp Resource Name (PRN) for the specified model instance. It is similar to a HREF
-    url in that it uniquely identifies a resource, but it also has the guarantee that it will not
-    change regardless of API_ROOT or DOMAIN_ENABLED. This is used in our resource locking/
-    reservation code to identify resources.
+    """Get a Pulp Resource Name (PRN) for the specified model instance. It is similar to a HREF url
+    in that it uniquely identifies a resource, but it also has the guarantee that it will not change
+    regardless of API_ROOT or DOMAIN_ENABLED. This is used in our resource locking/ reservation code
+    to identify resources.
 
     The format for the PRN is as follows:
     ```
@@ -123,8 +120,7 @@ def get_prn(instance=None, uri=None):
 
 
 def resolve_prn(prn):
-    """
-    Resolve a PRN to its model and pk.
+    """Resolve a PRN to its model and pk.
 
     Args:
         prn (str): The PRN to resolve.
@@ -162,8 +158,7 @@ def resolve_prn(prn):
 
 
 def extract_pk(uri, only_prn=False):
-    """
-    Resolve a resource URI or PRN to a simple PK value.
+    """Resolve a resource URI or PRN to a simple PK value.
 
     Provides a means to resolve an href/prn passed in a POST body to a primary key.
     Doesn't assume anything about whether the resource corresponding to the URI/PRN
@@ -246,9 +241,7 @@ def raise_for_unknown_content_units(
 # depended on by viewsets. They're defined here because they're used here, and to avoid
 # odd import dependencies.
 def get_viewset_for_model(model_obj, ignore_error=False):
-    """
-    Given a Model instance or class, return the registered ViewSet for that Model
-    """
+    """Given a Model instance or class, return the registered ViewSet for that Model."""
     # model_obj can be an instance or class, force it to class
     model_class = model_obj._meta.model
     if model_class in _model_viewset_cache:
@@ -279,8 +272,7 @@ def get_viewset_for_model(model_obj, ignore_error=False):
 
 
 def get_view_name_for_model(model_obj, view_action):
-    """
-    Given a Model instance or class, return the correct view name for that ViewSet view.
+    """Given a Model instance or class, return the correct view name for that ViewSet view.
 
     This is the "glue" that generates view names dynamically based on a model object.
 
@@ -334,10 +326,8 @@ def batch_qs(qs, batch_size=1000):
 
 
 def get_view_urlpattern(view):
-    """
-    Get a full urlpattern for a view which includes a parent urlpattern if it exists.
-    E.g. for repository versions the urlpattern is just `versions` without its parent_viewset
-    urlpattern.
+    """Get a full urlpattern for a view which includes a parent urlpattern if it exists. E.g. for
+    repository versions the urlpattern is just `versions` without its parent_viewset urlpattern.
 
     Args:
         view(subclass rest_framework.viewsets.GenericViewSet): The view being requested.
@@ -351,8 +341,7 @@ def get_view_urlpattern(view):
 
 
 def get_request_without_query_params(context):
-    """
-    Remove query parameters from a request object.
+    """Remove query parameters from a request object.
 
     Removing query parameters should not influence the features provided by the library
     'djangorestframework-queryfields'. But, once a user selects which fields should be sent in the
@@ -383,8 +372,7 @@ def get_request_without_query_params(context):
 
 
 def gpg_verify(public_keys, signature, detached_data=None):
-    """
-    Check whether the provided gnupg signature is valid for one of the provided public keys.
+    """Check whether the provided gnupg signature is valid for one of the provided public keys.
 
     Args:
         public_keys (str): Ascii armored public key data
@@ -428,7 +416,7 @@ def compute_file_hash(filename, hasher=None, cumulative_hash=None, blocksize=819
 
 
 class Crc32Hasher:
-    """Wrapper to make the CRC32 implementation act like a standard hashlib hasher"""
+    """Wrapper to make the CRC32 implementation act like a standard hashlib hasher."""
 
     def __init__(self):
         self.hashval = 0
@@ -596,11 +584,10 @@ def get_domain():
 
 
 def get_domain_pk():
-    """
-    THIS CAN/WILL BE RAN IN MIGRATIONS. DO NOT USE ORM FOR IT MIGHT GENERATE INVALID SQL.
+    """THIS CAN/WILL BE RAN IN MIGRATIONS. DO NOT USE ORM FOR IT MIGHT GENERATE INVALID SQL.
 
-    This is ran in plugin migrations so we can not move this implemenation or change its
-    semantics, EVER!
+    This is ran in plugin migrations so we can not move this implemenation or change its semantics,
+    EVER!
     """
     if domain := current_domain.get():
         return domain.pk
@@ -637,8 +624,7 @@ def get_worker_name():
 
 
 class PGAdvisoryLock:
-    """
-    A context manager that will hold a postgres advisory lock non-blocking.
+    """A context manager that will hold a postgres advisory lock non-blocking.
 
     The locks can be chosen from a lock group to avoid collisions. They will never collide with the
     locks used for tasks.

--- a/pulpcore/app/views/importer.py
+++ b/pulpcore/app/views/importer.py
@@ -20,12 +20,11 @@ def _check_allowed_import_path(a_path):
 
 
 def _validate_file(in_param, data):
-    """
-    Returns a (is-valid, msgs[]) tuple describing all problems found with data[in_param]
+    """Returns a (is-valid, msgs[]) tuple describing all problems found with data[in_param]
 
     We check for a number of things, attempting to return all the errors we can find. We don't want
-    to give out information for files in arbitrary locations on the filesystem; if the check
-    for ALLOWED_IMPORT_PATHS fails, we report that and ignore any other problems.
+    to give out information for files in arbitrary locations on the filesystem; if the check for
+    ALLOWED_IMPORT_PATHS fails, we report that and ignore any other problems.
 
     If the directory containing the base-file doesn't exist, or isn't readable, or the specified
     file doesn't exist, report and return.
@@ -74,9 +73,7 @@ def _validate_file(in_param, data):
 
 
 class PulpImporterImportCheckView(APIView):
-    """
-    Returns validity of proposed parameters for a PulpImport call.
-    """
+    """Returns validity of proposed parameters for a PulpImport call."""
 
     @extend_schema(
         summary="Validate the parameters to be used for a PulpImport call",
@@ -85,8 +82,7 @@ class PulpImporterImportCheckView(APIView):
         responses={200: PulpImportCheckResponseSerializer},
     )
     def post(self, request, format=None):
-        """
-        Evaluates validity of proposed PulpImport parameters 'toc', 'path', and 'repo_mapping'.
+        """Evaluates validity of proposed PulpImport parameters 'toc', 'path', and 'repo_mapping'.
 
         * Checks that toc, path are in ALLOWED_IMPORT_PATHS
         * if ALLOWED:

--- a/pulpcore/app/views/orphans.py
+++ b/pulpcore/app/views/orphans.py
@@ -16,9 +16,7 @@ class OrphansView(APIView):
         responses={202: AsyncOperationResponseSerializer},
     )
     def delete(self, request, format=None):
-        """
-        Cleans up all the Content and Artifact orphans in the system
-        """
+        """Cleans up all the Content and Artifact orphans in the system."""
         exclusive_resources = [f"pdrn:{request.pulp_domain.pulp_id}:orphans"]
         task = dispatch(orphan_cleanup, exclusive_resources=exclusive_resources)
 

--- a/pulpcore/app/views/repair.py
+++ b/pulpcore/app/views/repair.py
@@ -18,9 +18,7 @@ class RepairView(APIView):
         responses={202: AsyncOperationResponseSerializer},
     )
     def post(self, request):
-        """
-        Repair artifacts.
-        """
+        """Repair artifacts."""
         serializer = RepairSerializer(data=request.data)
         serializer.is_valid(raise_exception=True)
 

--- a/pulpcore/app/views/status.py
+++ b/pulpcore/app/views/status.py
@@ -35,9 +35,7 @@ def _disk_usage():
 
 
 class StatusView(APIView):
-    """
-    Returns status information about the application
-    """
+    """Returns status information about the application."""
 
     # allow anyone to access the status api
     authentication_classes = []
@@ -49,8 +47,7 @@ class StatusView(APIView):
         responses={200: StatusSerializer},
     )
     def get(self, request):
-        """
-        Returns status and app information about Pulp.
+        """Returns status and app information about Pulp.
 
         Information includes:
          * version of pulpcore and loaded pulp plugins
@@ -106,8 +103,7 @@ class StatusView(APIView):
 
     @staticmethod
     def _get_db_conn_status():
-        """
-        Returns True if pulp is connected to the database
+        """Returns True if pulp is connected to the database.
 
         Returns:
             bool: True if there's a db connection. False otherwise.
@@ -122,8 +118,7 @@ class StatusView(APIView):
 
     @staticmethod
     def _get_redis_conn_status():
-        """
-        Returns True if pulp can connect to Redis
+        """Returns True if pulp can connect to Redis.
 
         Returns:
             bool: True if pulp can connect to Redis. False otherwise.
@@ -139,9 +134,7 @@ class StatusView(APIView):
 
 
 class LivezView(APIView):
-    """
-    Liveness Probe for the REST API.
-    """
+    """Liveness Probe for the REST API."""
 
     # allow anyone to access the liveness api
     authentication_classes = []
@@ -153,7 +146,5 @@ class LivezView(APIView):
         responses={200: None},
     )
     def get(self, request):
-        """
-        Returns 200 OK when API is alive.
-        """
+        """Returns 200 OK when API is alive."""
         return Response()

--- a/pulpcore/app/viewsets/access_policy.py
+++ b/pulpcore/app/viewsets/access_policy.py
@@ -14,9 +14,7 @@ from pulpcore.app.util import get_view_urlpattern
 class AccessPolicyViewSet(
     NamedModelViewSet, mixins.UpdateModelMixin, mixins.RetrieveModelMixin, mixins.ListModelMixin
 ):
-    """
-    ViewSet for AccessPolicy.
-    """
+    """ViewSet for AccessPolicy."""
 
     queryset = AccessPolicy.objects.all()
     serializer_class = AccessPolicySerializer
@@ -27,9 +25,7 @@ class AccessPolicyViewSet(
     @extend_schema(request=None)
     @action(detail=True, methods=["post"])
     def reset(self, request, pk=None):
-        """
-        Reset the access policy to its uncustomized default value.
-        """
+        """Reset the access policy to its uncustomized default value."""
 
         access_policy = self.get_object()
         for plugin_config in pulp_plugin_configs():

--- a/pulpcore/app/viewsets/acs.py
+++ b/pulpcore/app/viewsets/acs.py
@@ -27,9 +27,7 @@ class AlternateContentSourceViewSet(
     AsyncUpdateMixin,
     NamedModelViewSet,
 ):
-    """
-    A class for ACS viewset.
-    """
+    """A class for ACS viewset."""
 
     queryset = AlternateContentSource.objects.all()
     serializer_class = AlternateContentSourceSerializer

--- a/pulpcore/app/viewsets/base.py
+++ b/pulpcore/app/viewsets/base.py
@@ -53,16 +53,14 @@ NULLABLE_NUMERIC_FILTER_OPTIONS = ["exact", "ne", "lt", "lte", "gt", "gte", "ran
 
 
 class DefaultSchema(PulpAutoSchema):
-    """
-    Overrides _allows_filters method to include filter fields only for read actions.
+    """Overrides _allows_filters method to include filter fields only for read actions.
 
     Schema can be customised per view(set). Override this class and set it as a ``schema``
     attribute of a view(set) of interest.
     """
 
     def _allows_filters(self):
-        """
-        Include filter fields only for read actions, or GET requests.
+        """Include filter fields only for read actions, or GET requests.
 
         Returns:
             bool: True if filter fields should be included into the schema, False otherwise.
@@ -77,8 +75,7 @@ class DefaultSchema(PulpAutoSchema):
 
 
 class NamedModelViewSet(viewsets.GenericViewSet):
-    """
-    A customized named ModelViewSet that knows how to register itself with the Pulp API router.
+    """A customized named ModelViewSet that knows how to register itself with the Pulp API router.
 
     This viewset is discoverable by its name.
     "Normal" Django Models and Master/Detail models are supported by the ``register_with`` method.
@@ -105,15 +102,14 @@ class NamedModelViewSet(viewsets.GenericViewSet):
     schema = DefaultSchema()
 
     def get_serializer_class(self):
-        """
-        Fetch the serializer class to use for the request.
+        """Fetch the serializer class to use for the request.
 
-        The default behavior is to use the "serializer_class" attribute on the viewset.
-        We override that for the case where a "minimal_serializer_class" attribute is defined
-        and where the request contains a query parameter of "minimal=True".
+        The default behavior is to use the "serializer_class" attribute on the viewset. We override
+        that for the case where a "minimal_serializer_class" attribute is defined and where the
+        request contains a query parameter of "minimal=True".
 
-        The intention is that ViewSets can define a second, more minimal serializer with only
-        the most important fields.
+        The intention is that ViewSets can define a second, more minimal serializer with only the
+        most important fields.
         """
         assert self.serializer_class is not None, (
             "'{}' should either include a `serializer_class` attribute, or override the "
@@ -133,8 +129,7 @@ class NamedModelViewSet(viewsets.GenericViewSet):
 
     @staticmethod
     def get_resource_model(uri):
-        """
-        Resolve a resource URI to the model for the resource.
+        """Resolve a resource URI to the model for the resource.
 
         Provides a means to resolve an href passed in a POST body to an
         model for the resource.
@@ -157,8 +152,7 @@ class NamedModelViewSet(viewsets.GenericViewSet):
 
     @staticmethod
     def get_resource(uri, model=None):
-        """
-        Resolve a resource URI/PRN to an instance of the resource.
+        """Resolve a resource URI/PRN to an instance of the resource.
 
         Provides a means to resolve an href/prn passed in a POST body to an
         instance of the resource.
@@ -299,19 +293,17 @@ class NamedModelViewSet(viewsets.GenericViewSet):
             return pieces
 
     def initial(self, request, *args, **kwargs):
-        """
-        Runs anything that needs to occur prior to calling the method handler.
+        """Runs anything that needs to occur prior to calling the method handler.
 
-        For nested ViewSets, it checks that the parent object exists, otherwise return 404.
-        For non-nested Viewsets, this does nothing.
+        For nested ViewSets, it checks that the parent object exists, otherwise return 404. For non-
+        nested Viewsets, this does nothing.
         """
         if self.parent_lookup_kwargs:
             self.get_parent_field_and_object()
         super().initial(request, *args, **kwargs)
 
     def get_queryset(self):
-        """
-        Gets a QuerySet based on the current request.
+        """Gets a QuerySet based on the current request.
 
         For nested ViewSets, this adds parent filters to the result returned by the superclass. For
         non-nested ViewSets, this returns the original QuerySet unchanged.
@@ -346,8 +338,7 @@ class NamedModelViewSet(viewsets.GenericViewSet):
         return qs
 
     def scope_queryset(self, qs):
-        """
-        A default queryset scoping method implementation for all NamedModelViewSets.
+        """A default queryset scoping method implementation for all NamedModelViewSets.
 
         If the ViewSet is not a Master ViewSet, then it'll perform scoping based on the ViewSet's
         `queryset_filtering_required_permission` attribute if present.
@@ -382,8 +373,7 @@ class NamedModelViewSet(viewsets.GenericViewSet):
         return max([len(v.split("__")) for k, v in cls.parent_lookup_kwargs.items()])
 
     def get_parent_field_and_object(self):
-        """
-        For nested ViewSets, retrieve the nested parent implied by the url.
+        """For nested ViewSets, retrieve the nested parent implied by the url.
 
         Returns:
             tuple: (parent field name, parent)
@@ -401,8 +391,7 @@ class NamedModelViewSet(viewsets.GenericViewSet):
             return parent_field, get_object_or_404(self.parent_viewset.queryset, **filters)
 
     def get_parent_object(self):
-        """
-        For nested ViewSets, retrieve the nested parent implied by the url.
+        """For nested ViewSets, retrieve the nested parent implied by the url.
 
         Returns:
             pulpcore.app.models.Model: parent model object
@@ -414,15 +403,13 @@ class NamedModelViewSet(viewsets.GenericViewSet):
 
 
 class AsyncReservedObjectMixin:
-    """
-    Mixin class providing the default method to compute the resources to reserve in the task.
+    """Mixin class providing the default method to compute the resources to reserve in the task.
 
     By default, lock the object instance we are working on.
     """
 
     def async_reserved_resources(self, instance):
-        """
-        Return the resources to reserve for the task created by the Async...Mixins.
+        """Return the resources to reserve for the task created by the Async...Mixins.
 
         This default implementation locks the instance being worked on.
 
@@ -441,7 +428,6 @@ class AsyncReservedObjectMixin:
 
         Raises:
             AssertionError if instance is None (which happens for creation)
-
         """
         assert instance is not None, (
             "'{}' must not use the default `async_reserved_resources` method " "when using create."
@@ -450,18 +436,14 @@ class AsyncReservedObjectMixin:
 
 
 class AsyncCreateMixin:
-    """
-    Provides a create method that dispatches a task with reservation.
-    """
+    """Provides a create method that dispatches a task with reservation."""
 
     @extend_schema(
         description="Trigger an asynchronous create task",
         responses={202: AsyncOperationResponseSerializer},
     )
     def create(self, request, *args, **kwargs):
-        """
-        Dispatches a task with reservation for creating an instance.
-        """
+        """Dispatches a task with reservation for creating an instance."""
         serializer = self.get_serializer(data=request.data)
         serializer.is_valid(raise_exception=True)
         app_label = self.queryset.model._meta.app_label
@@ -475,9 +457,7 @@ class AsyncCreateMixin:
 
 
 class AsyncUpdateMixin(AsyncReservedObjectMixin):
-    """
-    Provides an update method that dispatches a task with reservation
-    """
+    """Provides an update method that dispatches a task with reservation."""
 
     ALLOW_NON_BLOCKING_UPDATE = True
 
@@ -510,9 +490,7 @@ class AsyncUpdateMixin(AsyncReservedObjectMixin):
 
 
 class AsyncRemoveMixin(AsyncReservedObjectMixin):
-    """
-    Provides a delete method that dispatches a task with reservation
-    """
+    """Provides a delete method that dispatches a task with reservation."""
 
     ALLOW_NON_BLOCKING_DELETE = True
 
@@ -521,9 +499,7 @@ class AsyncRemoveMixin(AsyncReservedObjectMixin):
         responses={202: AsyncOperationResponseSerializer},
     )
     def destroy(self, request, pk, **kwargs):
-        """
-        Delete a model instance
-        """
+        """Delete a model instance."""
         instance = self.get_object()
         serializer = self.get_serializer(instance)
         app_label = instance._meta.app_label

--- a/pulpcore/app/viewsets/content.py
+++ b/pulpcore/app/viewsets/content.py
@@ -90,9 +90,7 @@ class ArtifactViewSet(
     # However, for compatibility reasons, it is still possible to execute the DELETE
     # request by overriding the DEFAULT_ACCESS_POLICY.
     def destroy(self, request, pk):
-        """
-        Remove Artifact only if it is not associated with any Content.
-        """
+        """Remove Artifact only if it is not associated with any Content."""
         msg = _(
             "destroy is deprecated. Deleting artifacts is a dangerous operation, "
             "use orphan cleanup instead."
@@ -142,8 +140,7 @@ class ContentFilter(BaseFilterSet):
 
 
 class BaseContentViewSet(NamedModelViewSet):
-    """
-    A base class for any content viewset.
+    """A base class for any content viewset.
 
     It ensures that 'content/' is a part of endpoint, sets a default filter class and provides
     a default `scope_queryset` method.
@@ -213,23 +210,17 @@ class ContentViewSet(
     mixins.ListModelMixin,
     LabelsMixin,
 ):
-    """
-    Content viewset that supports POST and GET by default.
-    """
+    """Content viewset that supports POST and GET by default."""
 
 
 class ReadOnlyContentViewSet(
     BaseContentViewSet, mixins.RetrieveModelMixin, mixins.ListModelMixin, LabelsMixin
 ):
-    """
-    Content viewset that supports only GET by default.
-    """
+    """Content viewset that supports only GET by default."""
 
 
 class SigningServiceViewSet(NamedModelViewSet, mixins.RetrieveModelMixin, mixins.ListModelMixin):
-    """
-    A ViewSet that supports browsing of existing signing services.
-    """
+    """A ViewSet that supports browsing of existing signing services."""
 
     endpoint_name = "signing-services"
     queryset = SigningService.objects.all()

--- a/pulpcore/app/viewsets/custom_filters.py
+++ b/pulpcore/app/viewsets/custom_filters.py
@@ -1,6 +1,4 @@
-"""
-This module contains custom filters that might be used by more than one ViewSet.
-"""
+"""This module contains custom filters that might be used by more than one ViewSet."""
 
 import re
 
@@ -30,9 +28,7 @@ OLD_RESOURCE_HREFS = {
 
 
 class ReservedResourcesFilter(Filter):
-    """
-    Enables a user to filter tasks by a reserved resource href.
-    """
+    """Enables a user to filter tasks by a reserved resource href."""
 
     def __init__(self, *args, exclusive=True, shared=True, **kwargs):
         self.exclusive = exclusive
@@ -43,8 +39,7 @@ class ReservedResourcesFilter(Filter):
         super().__init__(*args, **kwargs)
 
     def filter(self, qs, value):
-        """
-        Callback to filter the query set based on the provided filter value.
+        """Callback to filter the query set based on the provided filter value.
 
         Args:
             qs (django.db.models.query.QuerySet): The Queryset to filter
@@ -83,17 +78,13 @@ class ReservedResourcesFilter(Filter):
 
 
 class ReservedResourcesInFilter(BaseInFilter, ReservedResourcesFilter):
-    """
-    Enables a user to filter tasks by a list of reserved resource hrefs.
-    """
+    """Enables a user to filter tasks by a list of reserved resource hrefs."""
 
 
 class CreatedResourcesFilter(Filter):
-    """
-    Filter used to get tasks by created resources.
+    """Filter used to get tasks by created resources.
 
-    Created resources contain a reference to newly created repository
-    versions, distributions, etc.
+    Created resources contain a reference to newly created repository versions, distributions, etc.
     """
 
     def filter(self, qs, value):
@@ -115,9 +106,7 @@ class CreatedResourcesFilter(Filter):
 
 
 class RepoVersionHrefPrnFilter(Filter):
-    """
-    Filter Content by a Repository Version.
-    """
+    """Filter Content by a Repository Version."""
 
     def __init__(self, *args, **kwargs):
         kwargs.setdefault("help_text", _("Repository Version referenced by HREF/PRN"))
@@ -125,8 +114,7 @@ class RepoVersionHrefPrnFilter(Filter):
 
     @staticmethod
     def get_repository_version(value):
-        """
-        Get the repository version from the HREF/PRN value provided by the user.
+        """Get the repository version from the HREF/PRN value provided by the user.
 
         Args:
             value (string): The RepositoryVersion href/prn to filter by
@@ -148,9 +136,7 @@ class RepoVersionHrefPrnFilter(Filter):
 
 
 class RepositoryVersionFilter(RepoVersionHrefPrnFilter):
-    """
-    Filter by RepositoryVersion href/prn.
-    """
+    """Filter by RepositoryVersion href/prn."""
 
     def filter(self, qs, value):
         """
@@ -171,9 +157,7 @@ class RepositoryVersionFilter(RepoVersionHrefPrnFilter):
 
 
 class ArtifactRepositoryVersionFilter(RepoVersionHrefPrnFilter):
-    """
-    Filter used to get the artifacts in a repository version.
-    """
+    """Filter used to get the artifacts in a repository version."""
 
     def filter(self, qs, value):
         """
@@ -195,9 +179,7 @@ class ArtifactRepositoryVersionFilter(RepoVersionHrefPrnFilter):
 
 
 class ContentRepositoryVersionFilter(RepoVersionHrefPrnFilter):
-    """
-    Filter used to get the content of this type found in a repository version.
-    """
+    """Filter used to get the content of this type found in a repository version."""
 
     def filter(self, qs, value):
         """
@@ -217,9 +199,7 @@ class ContentRepositoryVersionFilter(RepoVersionHrefPrnFilter):
 
 
 class ContentAddedRepositoryVersionFilter(RepoVersionHrefPrnFilter):
-    """
-    Filter used to get the content of this type found in a repository version.
-    """
+    """Filter used to get the content of this type found in a repository version."""
 
     def filter(self, qs, value):
         """
@@ -239,9 +219,7 @@ class ContentAddedRepositoryVersionFilter(RepoVersionHrefPrnFilter):
 
 
 class ContentRemovedRepositoryVersionFilter(RepoVersionHrefPrnFilter):
-    """
-    Filter used to get the content of this type found in a repository version.
-    """
+    """Filter used to get the content of this type found in a repository version."""
 
     def filter(self, qs, value):
         """

--- a/pulpcore/app/viewsets/domain.py
+++ b/pulpcore/app/viewsets/domain.py
@@ -39,8 +39,7 @@ class DomainViewSet(
     AsyncRemoveMixin,
     LabelsMixin,
 ):
-    """
-    ViewSet for Domain.
+    """ViewSet for Domain.
 
     NOTE: This API endpoint is in "tech preview" and subject to change
     """
@@ -138,8 +137,7 @@ class DomainViewSet(
     )
     @action(detail=False, methods=["post"])
     def migrate(self, request, **kwargs):
-        """
-        Migrate the domain's storage backend to a new one.
+        """Migrate the domain's storage backend to a new one.
 
         Launches a background task to copy the domain's artifacts over to the supplied storage
         backend. Then updates the domain's storage settings to the new storage backend. This task
@@ -147,8 +145,8 @@ class DomainViewSet(
 
         **IMPORTANT** This task will block all other tasks within the domain until the migration is
         completed, essentially putting the domain into a read only state. Content will still be
-        served from the old storage backend until the migration has completed, so don't remove
-        the old backend until then. Note, this endpoint is not allowed on the default domain.
+        served from the old storage backend until the migration has completed, so don't remove the
+        old backend until then. Note, this endpoint is not allowed on the default domain.
 
         This feature is in Tech Preview and is subject to future change and thus not guaranteed to
         be backwards compatible.

--- a/pulpcore/app/viewsets/exporter.py
+++ b/pulpcore/app/viewsets/exporter.py
@@ -45,9 +45,7 @@ class ExporterViewSet(
     mixins.ListModelMixin,
     AsyncRemoveMixin,
 ):
-    """
-    ViewSet for viewing exporters.
-    """
+    """ViewSet for viewing exporters."""
 
     # Too many cascaded deletes to block the gunicorn worker.
     ALLOW_NON_BLOCKING_DELETE = False
@@ -62,9 +60,7 @@ class ExporterViewSet(
 
 
 class PulpExporterViewSet(ExporterViewSet):
-    """
-    ViewSet for viewing PulpExporters.
-    """
+    """ViewSet for viewing PulpExporters."""
 
     endpoint_name = "pulp"
     serializer_class = PulpExporterSerializer
@@ -72,9 +68,7 @@ class PulpExporterViewSet(ExporterViewSet):
 
 
 class FilesystemExporterViewSet(ExporterViewSet):
-    """
-    Endpoint for managing FilesystemExporters.
-    """
+    """Endpoint for managing FilesystemExporters."""
 
     endpoint_name = "filesystem"
     serializer_class = FilesystemExporterSerializer
@@ -88,9 +82,7 @@ class ExportViewSet(
     mixins.ListModelMixin,
     mixins.DestroyModelMixin,
 ):
-    """
-    ViewSet for viewing exports from an Exporter.
-    """
+    """ViewSet for viewing exports from an Exporter."""
 
     endpoint_name = "exports"
     nest_prefix = "exporters"
@@ -103,9 +95,7 @@ class ExportViewSet(
 
 
 class PulpExportViewSet(ExportViewSet):
-    """
-    ViewSet for viewing exports from a PulpExporter.
-    """
+    """ViewSet for viewing exports from a PulpExporter."""
 
     parent_viewset = PulpExporterViewSet
     serializer_class = PulpExportSerializer
@@ -117,9 +107,8 @@ class PulpExportViewSet(ExportViewSet):
         responses={202: AsyncOperationResponseSerializer},
     )
     def create(self, request, exporter_pk):
-        """
-        Generates a Task to export the set of repositories assigned to a specific PulpExporter.
-        """
+        """Generates a Task to export the set of repositories assigned to a specific
+        PulpExporter."""
         if settings.DOMAIN_ENABLED:
             raise exceptions.ValidationError(_("Export not supported with Domains enabled."))
         # Validate Exporter
@@ -142,9 +131,7 @@ class PulpExportViewSet(ExportViewSet):
 
 
 class FilesystemExportViewSet(ExportViewSet):
-    """
-    Endpoint for managing FilesystemExports.
-    """
+    """Endpoint for managing FilesystemExports."""
 
     parent_viewset = FilesystemExporterViewSet
     serializer_class = FilesystemExportSerializer
@@ -156,9 +143,7 @@ class FilesystemExportViewSet(ExportViewSet):
         responses={202: AsyncOperationResponseSerializer},
     )
     def create(self, request, exporter_pk):
-        """
-        Generates a Task to export files to the filesystem.
-        """
+        """Generates a Task to export files to the filesystem."""
         if settings.DOMAIN_ENABLED:
             raise exceptions.ValidationError(_("Export not supported with Domains enabled."))
         # Validate Exporter

--- a/pulpcore/app/viewsets/orphans.py
+++ b/pulpcore/app/viewsets/orphans.py
@@ -16,9 +16,7 @@ class OrphansCleanupViewset(ViewSet):
         responses={202: AsyncOperationResponseSerializer},
     )
     def cleanup(self, request):
-        """
-        Triggers an asynchronous orphan cleanup operation.
-        """
+        """Triggers an asynchronous orphan cleanup operation."""
         serializer = OrphansCleanupSerializer(data=request.data)
         serializer.is_valid(raise_exception=True)
 

--- a/pulpcore/app/viewsets/publication.py
+++ b/pulpcore/app/viewsets/publication.py
@@ -75,9 +75,7 @@ class PublicationFilter(BaseFilterSet):
 
 
 class BasePublicationViewSet(NamedModelViewSet):
-    """
-    A base class for any publication viewset.
-    """
+    """A base class for any publication viewset."""
 
     endpoint_name = "publications"
     queryset = Publication.objects.filter(complete=True)
@@ -133,8 +131,9 @@ class PublicationViewSet(
     mixins.ListModelMixin,
     mixins.DestroyModelMixin,
 ):
-    """
-    Provides read, list and destroy methods for publications. Plugins should inherit from this.
+    """Provides read, list and destroy methods for publications.
+
+    Plugins should inherit from this.
     """
 
 
@@ -184,14 +183,12 @@ class ContentGuardViewSet(
     mixins.RetrieveModelMixin,
     mixins.ListModelMixin,
 ):
-    """
-    A viewset for contentguards.
-    """
+    """A viewset for contentguards."""
 
 
 class RBACContentGuardViewSet(ContentGuardViewSet, RolesMixin):
-    """
-    Viewset for creating contentguards that use RBAC to protect content.
+    """Viewset for creating contentguards that use RBAC to protect content.
+
     Has add and remove actions for managing permission for users and groups to download content
     protected by this guard.
     """
@@ -269,9 +266,7 @@ class RBACContentGuardViewSet(ContentGuardViewSet, RolesMixin):
 
 
 class ContentRedirectContentGuardViewSet(ContentGuardViewSet, RolesMixin):
-    """
-    Content guard to protect preauthenticated redirects to the content app.
-    """
+    """Content guard to protect preauthenticated redirects to the content app."""
 
     endpoint_name = "content_redirect"
     queryset = ContentRedirectContentGuard.objects.all()
@@ -344,9 +339,7 @@ class ContentRedirectContentGuardViewSet(ContentGuardViewSet, RolesMixin):
 
 
 class HeaderContentGuardViewSet(ContentGuardViewSet, RolesMixin):
-    """
-    Content guard to protect the content app using a specific header.
-    """
+    """Content guard to protect the content app using a specific header."""
 
     endpoint_name = "header"
     queryset = HeaderContentGuard.objects.all()
@@ -414,9 +407,7 @@ class HeaderContentGuardViewSet(ContentGuardViewSet, RolesMixin):
 
 
 class CompositeContentGuardViewSet(ContentGuardViewSet, RolesMixin):
-    """
-    Content guard that queries a list-of content-guards for access permissions.
-    """
+    """Content guard that queries a list-of content-guards for access permissions."""
 
     endpoint_name = "composite"
     queryset = CompositeContentGuard.objects.all()
@@ -503,9 +494,7 @@ class DistributionFilter(BaseFilterSet):
 
 
 class BaseDistributionViewSet(NamedModelViewSet):
-    """
-    Provides base viewset for Distributions.
-    """
+    """Provides base viewset for Distributions."""
 
     endpoint_name = "distributions"
     queryset = Distribution.objects.all()
@@ -554,9 +543,7 @@ class ReadOnlyDistributionViewSet(
     mixins.RetrieveModelMixin,
     mixins.ListModelMixin,
 ):
-    """
-    Provides read and list methods for Distributions.
-    """
+    """Provides read and list methods for Distributions."""
 
 
 class DistributionViewSet(
@@ -566,17 +553,13 @@ class DistributionViewSet(
     AsyncUpdateMixin,
     LabelsMixin,
 ):
-    """
-    Provides read and list methods and also provides asynchronous CUD methods to dispatch tasks
+    """Provides read and list methods and also provides asynchronous CUD methods to dispatch tasks
     with reservation that lock all Distributions preventing race conditions during base_path
-    checking.
-    """
+    checking."""
 
 
 class ArtifactDistributionViewSet(ReadOnlyDistributionViewSet):
-    """
-    ViewSet for ArtifactDistribution.
-    """
+    """ViewSet for ArtifactDistribution."""
 
     endpoint_name = "artifacts"
     queryset = ArtifactDistribution.objects.all()

--- a/pulpcore/app/viewsets/reclaim.py
+++ b/pulpcore/app/viewsets/reclaim.py
@@ -8,9 +8,7 @@ from pulpcore.tasking.tasks import dispatch
 
 
 class ReclaimSpaceViewSet(ViewSet):
-    """
-    Viewset for reclaim disk space endpoint.
-    """
+    """Viewset for reclaim disk space endpoint."""
 
     serializer_class = ReclaimSpaceSerializer
 
@@ -19,9 +17,7 @@ class ReclaimSpaceViewSet(ViewSet):
         responses={202: AsyncOperationResponseSerializer},
     )
     def reclaim(self, request):
-        """
-        Triggers an asynchronous space reclaim operation.
-        """
+        """Triggers an asynchronous space reclaim operation."""
         serializer = ReclaimSpaceSerializer(data=request.data)
         serializer.is_valid(raise_exception=True)
 

--- a/pulpcore/app/viewsets/replica.py
+++ b/pulpcore/app/viewsets/replica.py
@@ -1,6 +1,4 @@
-"""
-ViewSet for replicating repositories and distributions from an upstream Pulp
-"""
+"""ViewSet for replicating repositories and distributions from an upstream Pulp."""
 
 from drf_spectacular.utils import extend_schema
 from rest_framework import mixins
@@ -24,7 +22,10 @@ class UpstreamPulpViewSet(
     mixins.UpdateModelMixin,
     RolesMixin,
 ):
-    """API for configuring an upstream Pulp to replicate. This API is provided as a tech preview."""
+    """API for configuring an upstream Pulp to replicate.
+
+    This API is provided as a tech preview.
+    """
 
     queryset = UpstreamPulp.objects.all()
     endpoint_name = "upstream-pulps"
@@ -123,9 +124,7 @@ class UpstreamPulpViewSet(
     )
     @action(detail=True, methods=["post"])
     def replicate(self, request, pk):
-        """
-        Triggers an asynchronous repository replication operation.
-        """
+        """Triggers an asynchronous repository replication operation."""
         server = UpstreamPulp.objects.get(pk=pk)
         task_group = TaskGroup.objects.create(description=f"Replication of {server.name}")
 

--- a/pulpcore/app/viewsets/repository.py
+++ b/pulpcore/app/viewsets/repository.py
@@ -47,9 +47,7 @@ from pulpcore.app.util import resolve_prn
 
 
 class RepositoryContentFilter(Filter):
-    """
-    Filter used to filter repositories which have a piece of content
-    """
+    """Filter used to filter repositories which have a piece of content."""
 
     def __init__(self, *args, **kwargs):
         kwargs.setdefault("help_text", _("Content Unit referenced by HREF/PRN"))
@@ -101,9 +99,7 @@ class RepositoryFilter(BaseFilterSet):
 
 
 class BaseRepositoryViewSet(NamedModelViewSet):
-    """
-    A base class for any repository viewset.
-    """
+    """A base class for any repository viewset."""
 
     queryset = Repository.objects.exclude(user_hidden=True).order_by("name")
     serializer_class = RepositorySerializer
@@ -151,9 +147,7 @@ class ReadOnlyRepositoryViewSet(
     mixins.ListModelMixin,
     mixins.RetrieveModelMixin,
 ):
-    """
-    A readonly repository which allows only GET method.
-    """
+    """A readonly repository which allows only GET method."""
 
     queryset = Repository.objects.all().order_by("name")
     serializer_class = RepositorySerializer
@@ -169,16 +163,12 @@ class ImmutableRepositoryViewSet(
 ):
     # Too many cascaded deletes to block the gunicorn worker.
     ALLOW_NON_BLOCKING_DELETE = False
-
-    """
-    An immutable repository ViewSet that does not allow the usage of the methods PATCH and PUT.
-    """
+    """An immutable repository ViewSet that does not allow the usage of the methods PATCH and
+    PUT."""
 
 
 class RepositoryViewSet(ImmutableRepositoryViewSet, AsyncUpdateMixin, LabelsMixin):
-    """
-    A ViewSet for an ordinary repository.
-    """
+    """A ViewSet for an ordinary repository."""
 
 
 class RepositoryVersionFilter(BaseFilterSet):
@@ -273,9 +263,7 @@ class RepositoryVersionViewSet(
         responses={202: AsyncOperationResponseSerializer},
     )
     def destroy(self, request, repository_pk, number):
-        """
-        Queues a task to handle deletion of a RepositoryVersion
-        """
+        """Queues a task to handle deletion of a RepositoryVersion."""
         version = self.get_object()
 
         if version in version.repository.protected_versions():
@@ -294,9 +282,7 @@ class RepositoryVersionViewSet(
     )
     @action(detail=True, methods=["post"], serializer_class=RepairSerializer)
     def repair(self, request, repository_pk, number):
-        """
-        Queues a task to repair corrupted artifacts corresponding to a RepositoryVersion
-        """
+        """Queues a task to repair corrupted artifacts corresponding to a RepositoryVersion."""
         version = self.get_object()
         serializer = RepairSerializer(data=request.data)
         serializer.is_valid(raise_exception=True)

--- a/pulpcore/app/viewsets/task.py
+++ b/pulpcore/app/viewsets/task.py
@@ -253,9 +253,7 @@ class TaskViewSet(
     )
     @action(detail=False, methods=["post"])
     def purge(self, request):
-        """
-        Purge task-records for tasks in 'final' states.
-        """
+        """Purge task-records for tasks in 'final' states."""
         serializer = PurgeSerializer(data=request.data)
         serializer.is_valid(raise_exception=True)
         current_user = get_current_user()
@@ -275,9 +273,7 @@ class TaskViewSet(
     )
     @action(detail=True)
     def profile_artifacts(self, request, pk):
-        """
-        Return pre-signed URLs used for downloading raw profile artifacts.
-        """
+        """Return pre-signed URLs used for downloading raw profile artifacts."""
         task = self.get_object()
         data = {}
 
@@ -392,9 +388,7 @@ class TaskScheduleViewSet(
     mixins.ListModelMixin,
     RolesMixin,
 ):
-    """
-    ViewSet to monitor task schedules.
-    """
+    """ViewSet to monitor task schedules."""
 
     queryset = TaskSchedule.objects.all()
     endpoint_name = "task-schedules"

--- a/pulpcore/app/viewsets/upload.py
+++ b/pulpcore/app/viewsets/upload.py
@@ -127,9 +127,7 @@ class UploadViewSet(
         responses={200: UploadSerializer},
     )
     def update(self, request, pk=None):
-        """
-        Upload a chunk for an upload.
-        """
+        """Upload a chunk for an upload."""
         serializer = self.get_serializer(data=request.data)
         serializer.is_valid(raise_exception=True)
 
@@ -150,9 +148,8 @@ class UploadViewSet(
     )
     @action(detail=True, methods=["post"])
     def commit(self, request, pk):
-        """
-        Queues a Task that creates an Artifact, and the Upload gets deleted and cannot be re-used.
-        """
+        """Queues a Task that creates an Artifact, and the Upload gets deleted and cannot be re-
+        used."""
         serializer = self.get_serializer(data=request.data)
         serializer.is_valid(raise_exception=True)
 

--- a/pulpcore/app/viewsets/user.py
+++ b/pulpcore/app/viewsets/user.py
@@ -42,9 +42,7 @@ class UserViewSet(
     mixins.ListModelMixin,
     mixins.DestroyModelMixin,
 ):
-    """
-    ViewSet for User.
-    """
+    """ViewSet for User."""
 
     endpoint_name = "users"
     router_lookup = "user"
@@ -70,9 +68,7 @@ class GroupViewSet(
     mixins.DestroyModelMixin,
     RolesMixin,
 ):
-    """
-    ViewSet for Group.
-    """
+    """ViewSet for Group."""
 
     endpoint_name = "groups"
     router_lookup = "group"
@@ -149,9 +145,7 @@ class GroupViewSet(
 
 
 class GroupUserViewSet(NamedModelViewSet):
-    """
-    ViewSet for Users that belong to a Group.
-    """
+    """ViewSet for Users that belong to a Group."""
 
     endpoint_name = "users"
     router_lookup = "user"
@@ -185,9 +179,7 @@ class GroupUserViewSet(NamedModelViewSet):
     }
 
     def list(self, request, group_pk):
-        """
-        List group users.
-        """
+        """List group users."""
         group = Group.objects.get(pk=group_pk)
         queryset = group.user_set.all()
 
@@ -200,9 +192,7 @@ class GroupUserViewSet(NamedModelViewSet):
         return Response(serializer.data)
 
     def create(self, request, group_pk):
-        """
-        Add a user to a group.
-        """
+        """Add a user to a group."""
         group = Group.objects.get(pk=group_pk)
         if not request.data:
             raise ValidationError(
@@ -220,9 +210,7 @@ class GroupUserViewSet(NamedModelViewSet):
         return Response(serializer.data, status=status.HTTP_201_CREATED)
 
     def destroy(self, request, group_pk, pk):
-        """
-        Remove a user from a group.
-        """
+        """Remove a user from a group."""
         group = Group.objects.get(pk=group_pk)
         user = get_object_or_404(User, pk=pk)
         group.user_set.remove(user)
@@ -231,9 +219,7 @@ class GroupUserViewSet(NamedModelViewSet):
 
 
 class RoleFilter(BaseFilterSet):
-    """
-    FilterSet for Role.
-    """
+    """FilterSet for Role."""
 
     for_object_type = filters.CharFilter(
         field_name="for_object_type", method="filter_for_object_type"
@@ -309,9 +295,7 @@ class RoleViewSet(
     mixins.ListModelMixin,
     mixins.DestroyModelMixin,
 ):
-    """
-    ViewSet for Role.
-    """
+    """ViewSet for Role."""
 
     endpoint_name = "roles"
     router_lookup = "role"
@@ -332,9 +316,7 @@ class _CharInFilter(filters.BaseInFilter, filters.CharFilter):
 
 
 class NestedRoleFilter(BaseFilterSet):
-    """
-    FilterSet for Roles nested under users / groups.
-    """
+    """FilterSet for Roles nested under users / groups."""
 
     # For some reason the generated Filters don't work here
     role = filters.CharFilter(field_name="role__name")
@@ -365,9 +347,7 @@ class NestedRoleFilter(BaseFilterSet):
 
 
 class UserRoleFilter(NestedRoleFilter):
-    """
-    FilterSet for UserRole.
-    """
+    """FilterSet for UserRole."""
 
     class Meta:
         model = UserRole
@@ -381,9 +361,7 @@ class UserRoleViewSet(
     mixins.ListModelMixin,
     mixins.DestroyModelMixin,
 ):
-    """
-    ViewSet for UserRole.
-    """
+    """ViewSet for UserRole."""
 
     endpoint_name = "roles"
     router_lookup = "user"
@@ -396,9 +374,7 @@ class UserRoleViewSet(
 
 
 class GroupRoleFilter(NestedRoleFilter):
-    """
-    FilterSet for GroupRole.
-    """
+    """FilterSet for GroupRole."""
 
     class Meta:
         model = GroupRole
@@ -412,9 +388,7 @@ class GroupRoleViewSet(
     mixins.ListModelMixin,
     mixins.DestroyModelMixin,
 ):
-    """
-    ViewSet for GroupRole.
-    """
+    """ViewSet for GroupRole."""
 
     endpoint_name = "roles"
     router_lookup = "group"

--- a/pulpcore/app/wsgi.py
+++ b/pulpcore/app/wsgi.py
@@ -1,5 +1,4 @@
-"""
-WSGI config for pulp project.
+"""WSGI config for pulp project.
 
 It exposes the WSGI callable as a module-level variable named ``application``.
 

--- a/pulpcore/cache/cache.py
+++ b/pulpcore/cache/cache.py
@@ -65,18 +65,18 @@ def aconnection_error_wrapper(func):
 
 
 class Cache:
-    """Base class for Pulp's cache"""
+    """Base class for Pulp's cache."""
 
     default_base_key = "PULP_CACHE"
     default_expires_ttl = DEFAULT_EXPIRES_TTL
 
     def __init__(self):
-        """Creates synchronous cache instance"""
+        """Creates synchronous cache instance."""
         self.redis = get_redis_connection()
 
     @connection_error_wrapper
     def get(self, key, base_key=None):
-        """Gets cached entry of key"""
+        """Gets cached entry of key."""
         base_key = base_key or self.default_base_key
         if key is None:
             return self.redis.hgetall(base_key)
@@ -84,7 +84,7 @@ class Cache:
 
     @connection_error_wrapper
     def set(self, key, value, expires=None, base_key=None):
-        """Sets the cached entry at key"""
+        """Sets the cached entry at key."""
         base_key = base_key or self.default_base_key
         ret = self.redis.hset(base_key, key, value)
         if expires:
@@ -93,7 +93,7 @@ class Cache:
 
     @connection_error_wrapper
     def exists(self, key=None, base_key=None):
-        """Checks if cached entries exist"""
+        """Checks if cached entries exist."""
         if not base_key and base_key is not None:
             return False  # Failsafe for passing empty list/str
         base_key = base_key or self.default_base_key
@@ -132,8 +132,7 @@ class SyncContentCache(Cache):
     }
 
     def __init__(self, base_key=None, expires_ttl=None, keys=None, auth=None):
-        """
-        Initiates a cache instance to be used for dealing with a django server.
+        """Initiates a cache instance to be used for dealing with a django server.
 
         Args:
             base_key: a string to group entries under, defaults to DEFAULT_BASE_KEY,
@@ -176,13 +175,13 @@ class SyncContentCache(Cache):
         return cached_function
 
     def get_request_from_args(self, args):
-        """Finds the request object from list of args"""
+        """Finds the request object from list of args."""
         for arg in args:
             if isinstance(arg, ApiRequest):
                 return arg
 
     def make_response(self, key, base_key):
-        """Tries to find the cached entry and turn it into a proper response"""
+        """Tries to find the cached entry and turn it into a proper response."""
         entry = self.get(key, base_key)
         if not entry:
             return None
@@ -202,7 +201,7 @@ class SyncContentCache(Cache):
         return response
 
     def make_entry(self, key, base_key, handler, args, kwargs, expires=DEFAULT_EXPIRES_TTL):
-        """Gets the response for the request and try to turn it into a cacheable entry"""
+        """Gets the response for the request and try to turn it into a cacheable entry."""
         response = handler(*args, **kwargs)
         entry = {"headers": dict(response.headers), "status": response.status_code}
         if expires is not None:
@@ -230,7 +229,7 @@ class SyncContentCache(Cache):
         return response
 
     def make_key(self, request):
-        """Makes the key based off the request"""
+        """Makes the key based off the request."""
         all_keys = {
             CacheKeys.path: request.path,
             CacheKeys.method: request.method,
@@ -243,18 +242,18 @@ class SyncContentCache(Cache):
 
 
 class AsyncCache:
-    """Base class for asynchronous Pulp Cache"""
+    """Base class for asynchronous Pulp Cache."""
 
     default_base_key = "PULP_CACHE"
     default_expires_ttl = DEFAULT_EXPIRES_TTL
 
     def __init__(self):
-        """Creates asynchronous cache instance"""
+        """Creates asynchronous cache instance."""
         self.redis = get_async_redis_connection()
 
     @aconnection_error_wrapper
     async def get(self, key, base_key=None):
-        """Gets cached entry of key"""
+        """Gets cached entry of key."""
         base_key = base_key or self.default_base_key
         if key is None:
             return await self.redis.hgetall(base_key)
@@ -262,7 +261,7 @@ class AsyncCache:
 
     @aconnection_error_wrapper
     async def set(self, key, value, expires=None, base_key=None):
-        """Sets the cached entry at key"""
+        """Sets the cached entry at key."""
         base_key = base_key or self.default_base_key
         ret = await self.redis.hset(base_key, key, value)
         if expires:
@@ -271,7 +270,7 @@ class AsyncCache:
 
     @aconnection_error_wrapper
     async def exists(self, key=None, base_key=None):
-        """Checks if cached entries exist"""
+        """Checks if cached entries exist."""
         if not base_key and base_key is not None:
             return False  # Failsafe for passing empty list/str
         base_key = base_key or self.default_base_key
@@ -301,7 +300,7 @@ class AsyncCache:
 
 
 class AsyncContentCache(AsyncCache):
-    """Cache object meant to be used for the content app"""
+    """Cache object meant to be used for the content app."""
 
     RESPONSE_TYPES = {
         "FileResponse": FileResponse,
@@ -313,8 +312,7 @@ class AsyncContentCache(AsyncCache):
     ADD_TRAILING_SLASH = True
 
     def __init__(self, base_key=None, expires_ttl=None, keys=None, auth=None):
-        """
-        Initiates a cache instance to be used for dealing with an aiohttp server
+        """Initiates a cache instance to be used for dealing with an aiohttp server.
 
         Args:
             base_key: a string to group entries under, defaults to DEFAULT_BASE_KEY,
@@ -335,7 +333,7 @@ class AsyncContentCache(AsyncCache):
         self.auth = auth
 
     def __call__(self, func):
-        """Decorator magic call to make the handler cached"""
+        """Decorator magic call to make the handler cached."""
         if not settings.CACHE_ENABLED:
             return func
 
@@ -362,13 +360,13 @@ class AsyncContentCache(AsyncCache):
         return cached_function
 
     def get_request_from_args(self, args):
-        """Finds the request object from list of args"""
+        """Finds the request object from list of args."""
         for arg in args:
             if isinstance(arg, Request):
                 return arg
 
     async def make_response(self, key, base_key):
-        """Tries to find the cached entry and turn it into a proper response"""
+        """Tries to find the cached entry and turn it into a proper response."""
         entry = await self.get(key, base_key)
         if not entry:
             return None
@@ -395,7 +393,7 @@ class AsyncContentCache(AsyncCache):
         return response
 
     async def make_entry(self, key, base_key, handler, args, kwargs, expires=DEFAULT_EXPIRES_TTL):
-        """Gets the response for the request and try to turn it into a cacheable entry"""
+        """Gets the response for the request and try to turn it into a cacheable entry."""
         try:
             response = await handler(*args, **kwargs)
         except (HTTPSuccessful, HTTPFound) as e:
@@ -440,7 +438,7 @@ class AsyncContentCache(AsyncCache):
         return original_response
 
     def make_key(self, request):
-        """Makes the key based off the request"""
+        """Makes the key based off the request."""
         # Might potentially have to make this async if keys require async data from request
         all_keys = {
             CacheKeys.path: request.path,

--- a/pulpcore/content/authentication.py
+++ b/pulpcore/content/authentication.py
@@ -29,7 +29,7 @@ async def guid(request, handler):
 
 @middleware
 async def authenticate(request, handler):
-    """Authenticates the request to the content app using the DRF authentication classes"""
+    """Authenticates the request to the content app using the DRF authentication classes."""
     django_request = convert_request(request)
     fake_view = APIView()
 
@@ -59,8 +59,7 @@ async def authenticate(request, handler):
 
 
 def convert_request(request):
-    """
-    Converts an aiohttp Request to a Django HttpRequest
+    """Converts an aiohttp Request to a Django HttpRequest.
 
     This does not convert the async body to a sync body for POST requests
     """
@@ -84,9 +83,7 @@ def convert_request(request):
 
 
 def validate_domain(request):
-    """
-    Ensures the request is inside a proper Domain.
-    """
+    """Ensures the request is inside a proper Domain."""
     domain_name = request.match_info.get("pulp_domain", "default")
     try:
         domain = Domain.objects.get(name=domain_name)

--- a/pulpcore/content/handler.py
+++ b/pulpcore/content/handler.py
@@ -71,11 +71,10 @@ log = logging.getLogger(__name__)
 
 
 class PathNotResolved(HTTPNotFound):
-    """
-    The path could not be resolved to a published file.
+    """The path could not be resolved to a published file.
 
-    This could be caused by either the distribution, the publication,
-    or the published file could not be found.
+    This could be caused by either the distribution, the publication, or the published file could
+    not be found.
     """
 
     def __init__(self, path, *args, **kwargs):
@@ -85,8 +84,7 @@ class PathNotResolved(HTTPNotFound):
 
 
 class DistroListings(HTTPOk):
-    """
-    Response for browsing through the distributions and their potential multi-layered base-paths.
+    """Response for browsing through the distributions and their potential multi-layered base-paths.
 
     This is returned when visiting the base path of the content app (/pulp/content/) or a partial
     base path of a distribution, e.g. /pulp/content/foo/ for distros /foo/bar/ & /foo/baz/
@@ -119,8 +117,7 @@ class DistroListings(HTTPOk):
 
 
 class CheckpointListings(HTTPOk):
-    """
-    Response for browsing through the checkpoints of a specific checkpoint distro.
+    """Response for browsing through the checkpoints of a specific checkpoint distro.
 
     This is returned when visiting the base path of a checkpoint distro.
     """
@@ -141,16 +138,13 @@ class CheckpointListings(HTTPOk):
 
 
 class ArtifactNotFound(Exception):
-    """
-    The artifact associated with a published-artifact does not exist.
-    """
+    """The artifact associated with a published-artifact does not exist."""
 
     pass
 
 
 class Handler:
-    """
-    A default Handler for the Content App that also can be subclassed to create custom handlers.
+    """A default Handler for the Content App that also can be subclassed to create custom handlers.
 
     This Handler will perform the following:
 
@@ -171,7 +165,6 @@ class Handler:
     5. If the Distribution has a `remote`, find an associated `RemoteArtifact` that matches by
        `relative_path`. Fetch and stream the corresponding `RemoteArtifact` to the client,
        optionally saving the `Artifact` depending on the `policy` attribute.
-
     """
 
     hop_by_hop_headers = [
@@ -189,14 +182,12 @@ class Handler:
 
     @staticmethod
     def _reset_db_connection():
-        """
-        Reset database connection if it's unusable or obselete to avoid "connection already closed".
-        """
+        """Reset database connection if it's unusable or obselete to avoid "connection already
+        closed"."""
         connection.close_if_unusable_or_obsolete()
 
     async def list_distributions(self, request):
-        """
-        The handler for an HTML listing all distributions
+        """The handler for an HTML listing all distributions.
 
         Args:
             request (aiohttp.web.request) The request from the client.
@@ -220,8 +211,7 @@ class Handler:
 
     @classmethod
     async def find_base_path_cached(cls, request, cached):
-        """
-        Finds the base-path to use for the base-key in the cache
+        """Finds the base-path to use for the base-key in the cache.
 
         Args:
             request (aiohttp.web.request) The request from the client.
@@ -247,8 +237,7 @@ class Handler:
 
     @classmethod
     async def auth_cached(cls, request, cached, base_key):
-        """
-        Authentication check for the cached stream_content handler
+        """Authentication check for the cached stream_content handler.
 
         Args:
             request (aiohttp.web.request) The request from the client.
@@ -276,8 +265,7 @@ class Handler:
         auth=lambda req, cac, bk: Handler.auth_cached(req, cac, bk),
     )
     async def stream_content(self, request):
-        """
-        The request handler for the Content app.
+        """The request handler for the Content app.
 
         Args:
             request (aiohttp.web.request) The request from the client.
@@ -291,15 +279,13 @@ class Handler:
 
     @staticmethod
     def _base_paths(path):
-        """
-        Get a list of base paths used to match a distribution.
+        """Get a list of base paths used to match a distribution.
 
         Args:
             path (str): The path component of the URL.
 
         Returns:
             list: Of base paths.
-
         """
         tree = []
         while True:
@@ -312,8 +298,7 @@ class Handler:
 
     @classmethod
     def _match_distribution(cls, path, add_trailing_slash=True):
-        """
-        Match a distribution using a list of base paths and return its detail object.
+        """Match a distribution using a list of base paths and return its detail object.
 
         Args:
             path (str): The path component of the URL.
@@ -371,8 +356,7 @@ class Handler:
 
     @classmethod
     def _select_checkpoint_publication(cls, distro, path):
-        """
-        Finds the checkpoint publication to serve based on the checkpoint distribution and path.
+        """Finds the checkpoint publication to serve based on the checkpoint distribution and path.
 
         Args:
             distro (Distribution): The checkpoint distribution.
@@ -416,8 +400,7 @@ class Handler:
 
     @staticmethod
     def _parse_checkpoint_path(path):
-        """
-        Validate the path and extract the timestamp and rel_path from it.
+        """Validate the path and extract the timestamp and rel_path from it.
 
         Args:
             path (str): The checkpoint path component of the URL (e.g. 20250212T194653Z/dists/).
@@ -451,8 +434,7 @@ class Handler:
 
     @staticmethod
     def _format_checkpoint_timestamp(timestamp):
-        """
-        Format a timestamp to the checkpoint format.
+        """Format a timestamp to the checkpoint format.
 
         Args:
             timestamp (datetime): The timestamp to format.
@@ -464,8 +446,7 @@ class Handler:
 
     @staticmethod
     def _redirect_sub_path(path):
-        """
-        Redirect to the correct path based on whether domain is enabled.
+        """Redirect to the correct path based on whether domain is enabled.
 
         Args:
             path (str): The path component after the path prefix.
@@ -480,8 +461,7 @@ class Handler:
 
     @staticmethod
     def _permit(request, distribution):
-        """
-        Permit the request.
+        """Permit the request.
 
         Authorization is delegated to the optional content-guard associated with the distribution.
 
@@ -508,8 +488,7 @@ class Handler:
 
     @staticmethod
     def response_headers(path, distribution=None):
-        """
-        Get the Content-Type and Encoding-Type headers for the requested `path`.
+        """Get the Content-Type and Encoding-Type headers for the requested `path`.
 
         Args:
             path (str): The relative path that was requested.
@@ -534,8 +513,7 @@ class Handler:
 
     @staticmethod
     def render_html(directory_list, path="", dates=None, sizes=None):
-        """
-        Render a list of strings as an HTML list of links.
+        """Render a list of strings as an HTML list of links.
 
         Args:
             directory_list (iterable): an iterable of strings representing file and directory names
@@ -585,8 +563,7 @@ class Handler:
         )
 
     async def list_directory(self, repo_version, publication, path):
-        """
-        Generate a set with directory listing of the path.
+        """Generate a set with directory listing of the path.
 
         This method expects either a repo_version or a publication in addition to a path. This
         method generates a set of strings representing the list of a path inside the repository
@@ -665,8 +642,7 @@ class Handler:
         return await sync_to_async(list_directory_blocking)()
 
     async def _match_and_stream(self, path, request):
-        """
-        Match the path and stream results either from the filesystem or by downloading new data.
+        """Match the path and stream results either from the filesystem or by downloading new data.
 
         After deciding the client can access the distribution at ``path``, this function calls
         :meth:`Distribution.content_handler`. If that function returns a not-None result, it is
@@ -942,8 +918,8 @@ class Handler:
         raise PathNotResolved(path, reason=reason)
 
     async def _stream_content_artifact(self, request, response, content_artifact):
-        """
-        Stream and optionally save a ContentArtifact by requesting it using the associated remote.
+        """Stream and optionally save a ContentArtifact by requesting it using the associated
+        remote.
 
         If a fatal download failure occurs while downloading and there are additional
         [pulpcore.plugin.models.RemoteArtifact][] objects associated with the
@@ -992,8 +968,7 @@ class Handler:
         raise HTTPNotFound()
 
     def _save_artifact(self, download_result, remote_artifact, request=None):
-        """
-        Create/Get an Artifact and associate it to a RemoteArtifact and/or ContentArtifact.
+        """Create/Get an Artifact and associate it to a RemoteArtifact and/or ContentArtifact.
 
         Create (or get if already existing) an [pulpcore.plugin.models.Artifact][]
         based on the `download_result` and associate it to the `content_artifact` of the given
@@ -1139,8 +1114,7 @@ class Handler:
             raise NotImplementedError()
 
     async def _serve_content_artifact(self, content_artifact, headers, request):
-        """
-        Handle response for a Content Artifact with the file present.
+        """Handle response for a Content Artifact with the file present.
 
         Depending on where the file storage (e.g. filesystem, S3, etc) this could be responding with
         the file (filesystem) or a redirect (S3).
@@ -1185,8 +1159,7 @@ class Handler:
     async def _stream_remote_artifact(
         self, request, response, remote_artifact, save_artifact=True, repository=None
     ):
-        """
-        Stream and save a RemoteArtifact.
+        """Stream and save a RemoteArtifact.
 
         Args:
             request(aiohttp.web.Request) The request to prepare a response for.
@@ -1202,7 +1175,6 @@ class Handler:
                 [pulpcore.plugin.models.RemoteArtifact][] objects associated with the
                 [pulpcore.plugin.models.ContentArtifact][] returned the binary data needed for
                 the client.
-
         """
 
         remote = await remote_artifact.remote.acast()

--- a/pulpcore/download/base.py
+++ b/pulpcore/download/base.py
@@ -36,8 +36,8 @@ Args:
 
 
 class BaseDownloader:
-    """
-    The base class of all downloaders, providing digest calculation, validation, and file handling.
+    """The base class of all downloaders, providing digest calculation, validation, and file
+    handling.
 
     This is an abstract class and is meant to be subclassed. Subclasses are required to implement
     the :meth:`~pulpcore.plugin.download.BaseDownloader.run` method and do two things:
@@ -78,8 +78,7 @@ class BaseDownloader:
         *args,
         **kwargs,
     ):
-        """
-        Create a BaseDownloader object. This is expected to be called by all subclasses.
+        """Create a BaseDownloader object. This is expected to be called by all subclasses.
 
         Args:
             url (str): The url to download.
@@ -112,11 +111,10 @@ class BaseDownloader:
                 )
 
     def _ensure_writer_has_open_file(self):
-        """
-        Create a temporary file on demand.
+        """Create a temporary file on demand.
 
-        Create a temporary file when it's actually used,
-        allowing plugin writers to instantiate many downloaders in memory.
+        Create a temporary file when it's actually used, allowing plugin writers to instantiate many
+        downloaders in memory.
         """
         if not self._writer:
             filename = urlsplit(self.url).path.split("/")[-1]
@@ -141,8 +139,7 @@ class BaseDownloader:
             self._size = 0
 
     async def handle_data(self, data):
-        """
-        A coroutine that writes data to the file object and compute its digests.
+        """A coroutine that writes data to the file object and compute its digests.
 
         All subclassed downloaders are expected to pass all data downloaded to this method. Similar
         to the hashlib docstring, repeated calls are equivalent to a single call with
@@ -157,8 +154,7 @@ class BaseDownloader:
         self._record_size_and_digests_for_data(data)
 
     async def finalize(self):
-        """
-        A coroutine to flush downloaded data, close the file writer, and validate the data.
+        """A coroutine to flush downloaded data, close the file writer, and validate the data.
 
         All subclasses are required to call this method after all data has been passed to
         :meth:`~pulpcore.plugin.download.BaseDownloader.handle_data`.
@@ -181,8 +177,7 @@ class BaseDownloader:
         log.debug(f"Downloaded file from {self.url}")
 
     def fetch(self, extra_data=None):
-        """
-        Run the download synchronously and return the `DownloadResult`.
+        """Run the download synchronously and return the `DownloadResult`.
 
         Returns:
             [pulpcore.plugin.download.DownloadResult][]
@@ -194,8 +189,7 @@ class BaseDownloader:
         return result
 
     def _record_size_and_digests_for_data(self, data):
-        """
-        Record the size and digest for an available chunk of data.
+        """Record the size and digest for an available chunk of data.
 
         Args:
             data (bytes): The data to have its size and digest values recorded.
@@ -206,9 +200,9 @@ class BaseDownloader:
 
     @property
     def artifact_attributes(self):
-        """
-        A property that returns a dictionary with size and digest information. The keys of this
-        dictionary correspond with [pulpcore.plugin.models.Artifact][] fields.
+        """A property that returns a dictionary with size and digest information.
+
+        The keys of this dictionary correspond with [pulpcore.plugin.models.Artifact][] fields.
         """
         attributes = {"size": self._size}
         for algorithm in self._digests:
@@ -216,8 +210,7 @@ class BaseDownloader:
         return attributes
 
     def validate_digests(self):
-        """
-        Validate all digests validate if ``expected_digests`` is set
+        """Validate all digests validate if ``expected_digests`` is set.
 
         Raises:
             [pulpcore.exceptions.DigestValidationError][]: When any of the ``expected_digest``
@@ -231,8 +224,7 @@ class BaseDownloader:
                     raise DigestValidationError(actual_digest, expected_digest, url=self.url)
 
     def validate_size(self):
-        """
-        Validate the size if ``expected_size`` is set
+        """Validate the size if ``expected_size`` is set.
 
         Raises:
             [pulpcore.exceptions.SizeValidationError][]: When the ``expected_size`` value
@@ -246,8 +238,7 @@ class BaseDownloader:
                 raise SizeValidationError(actual_size, expected_size, url=self.url)
 
     async def run(self, extra_data=None):
-        """
-        Run the downloader with concurrency restriction.
+        """Run the downloader with concurrency restriction.
 
         This method acquires `self.semaphore` before calling the actual download implementation
         contained in `_run()`. This ensures that the semaphore stays acquired even as the `backoff`
@@ -258,7 +249,6 @@ class BaseDownloader:
 
         Returns:
             [pulpcore.plugin.download.DownloadResult][] from `_run()`.
-
         """
         async with self.semaphore:
             try:
@@ -267,8 +257,7 @@ class BaseDownloader:
                 raise TimeoutException(self.url)
 
     async def _run(self, extra_data=None):
-        """
-        Run the downloader.
+        """Run the downloader.
 
         This is a coroutine that asyncio can schedule to complete downloading. Subclasses are
         required to implement this method and do two things:

--- a/pulpcore/download/factory.py
+++ b/pulpcore/download/factory.py
@@ -25,8 +25,7 @@ PROTOCOL_MAP = {
 
 
 class DownloaderFactory:
-    """
-    A factory for creating downloader objects that are configured from with remote settings.
+    """A factory for creating downloader objects that are configured from with remote settings.
 
     The DownloadFactory correctly handles SSL settings, basic auth settings, proxy settings, and
     connection limit settings.
@@ -77,9 +76,7 @@ class DownloaderFactory:
 
     @staticmethod
     def user_agent():
-        """
-        Produce a User-Agent string to identify Pulp and relevant system info.
-        """
+        """Produce a User-Agent string to identify Pulp and relevant system info."""
         pulp_version = PulpAppConfig.version
         python = "{} {}.{}.{}-{}{}".format(sys.implementation.name, *sys.version_info)
         uname = platform.uname()
@@ -90,8 +87,7 @@ class DownloaderFactory:
         asyncio.get_event_loop().run_until_complete(self._session.close())
 
     def _make_aiohttp_session_from_remote(self):
-        """
-        Build a [aiohttp.ClientSession][] from the remote's settings and timing settings.
+        """Build a [aiohttp.ClientSession][] from the remote's settings and timing settings.
 
         This method is what provides the force_close of the TCP connection with each request.
 
@@ -151,8 +147,7 @@ class DownloaderFactory:
         )
 
     def build(self, url, **kwargs):
-        """
-        Build a downloader which can optionally verify integrity using either digest or size.
+        """Build a downloader which can optionally verify integrity using either digest or size.
 
         The built downloader also provides concurrency restriction if specified by the remote.
 
@@ -214,8 +209,7 @@ class DownloaderFactory:
         return download_class(url, **options, **kwargs)
 
     def _generic(self, download_class, url, **kwargs):
-        """
-        Build a generic downloader based on the url.
+        """Build a generic downloader based on the url.
 
         Args:
             download_class (pulpcore.plugin.download.BaseDownloader) The download

--- a/pulpcore/download/file.py
+++ b/pulpcore/download/file.py
@@ -8,15 +8,13 @@ from .base import BaseDownloader, DownloadResult
 
 
 class FileDownloader(BaseDownloader):
-    """
-    A downloader for downloading files from the filesystem.
+    """A downloader for downloading files from the filesystem.
 
     It provides digest and size validation along with computation of the digests needed to save the
     file as an Artifact. It writes a new file to the disk and the return path is included in the
     [pulpcore.plugin.download.DownloadResult][].
 
-    This downloader has all of the attributes of
-    [pulpcore.plugin.download.BaseDownloader][]
+    This downloader has all of the attributes of [pulpcore.plugin.download.BaseDownloader][]
     """
 
     def __init__(self, url, *args, **kwargs):
@@ -40,8 +38,7 @@ class FileDownloader(BaseDownloader):
         super().__init__(url, *args, **kwargs)
 
     async def _run(self, extra_data=None):
-        """
-        Read, validate, and compute digests on the `url`. This is a coroutine.
+        """Read, validate, and compute digests on the `url`. This is a coroutine.
 
         This method provides the same return object type and documented in
         :meth:`~pulpcore.plugin.download.BaseDownloader._run`.

--- a/pulpcore/download/http.py
+++ b/pulpcore/download/http.py
@@ -19,8 +19,7 @@ logging.getLogger("backoff").addHandler(logging.StreamHandler())
 
 
 def http_giveup_handler(exc):
-    """
-    Inspect a raised exception and determine if we should give up.
+    """Inspect a raised exception and determine if we should give up.
 
     Do not give up when the error is one of the following:
 
@@ -50,8 +49,7 @@ def http_giveup_handler(exc):
 
 
 class HttpDownloader(BaseDownloader):
-    """
-    An HTTP/HTTPS Downloader built on `aiohttp`.
+    """An HTTP/HTTPS Downloader built on `aiohttp`.
 
     This downloader downloads data from one `url` and is not reused.
 
@@ -175,8 +173,7 @@ class HttpDownloader(BaseDownloader):
         super().__init__(url, **kwargs)
 
     def raise_for_status(self, response):
-        """
-        Raise error if aiohttp response status is >= 400 and not silenced.
+        """Raise error if aiohttp response status is >= 400 and not silenced.
 
         Args:
             response (aiohttp.ClientResponse): The response to handle.
@@ -187,8 +184,7 @@ class HttpDownloader(BaseDownloader):
         response.raise_for_status()
 
     async def _handle_response(self, response):
-        """
-        Handle the aiohttp response by writing it to disk and calculating digests
+        """Handle the aiohttp response by writing it to disk and calculating digests.
 
         Args:
             response (aiohttp.ClientResponse): The response to handle.
@@ -213,8 +209,7 @@ class HttpDownloader(BaseDownloader):
         )
 
     async def run(self, extra_data=None):
-        """
-        Run the downloader with concurrency restriction and optional retry logic.
+        """Run the downloader with concurrency restriction and optional retry logic.
 
         This method acquires `self.semaphore` before calling the actual download implementation
         contained in `_run()`. This ensures that the semaphore stays acquired even as the `backoff`
@@ -226,7 +221,6 @@ class HttpDownloader(BaseDownloader):
 
         Returns:
             [pulpcore.plugin.download.DownloadResult][] from `_run()`.
-
         """
         disable_retry_list = [] if not extra_data else extra_data.get("disable_retry_list", [])
         default_retryable_errors = (
@@ -274,8 +268,7 @@ class HttpDownloader(BaseDownloader):
             return await download_wrapper()
 
     async def _run(self, extra_data=None):
-        """
-        Download, validate, and compute digests on the `url`. This is a coroutine.
+        """Download, validate, and compute digests on the `url`. This is a coroutine.
 
         This method is externally wrapped with backoff-and-retry behavior for some errors.
         It retries with exponential backoff some number of times before allowing a final

--- a/pulpcore/exceptions/base.py
+++ b/pulpcore/exceptions/base.py
@@ -3,9 +3,7 @@ from gettext import gettext as _
 
 
 class PulpException(Exception):
-    """
-    Base exception class for Pulp.
-    """
+    """Base exception class for Pulp."""
 
     http_status_code = http.client.INTERNAL_SERVER_ERROR
 
@@ -19,8 +17,7 @@ class PulpException(Exception):
         self.error_code = error_code
 
     def __str__(self):
-        """
-        Returns the string representation of the exception.
+        """Returns the string representation of the exception.
 
         Each concrete class that inherits from [pulpcore.server.exception.PulpException][] is
         expected to implement it's own __str__() method. The return value is used by Pulp when
@@ -30,24 +27,18 @@ class PulpException(Exception):
 
 
 def exception_to_dict(exc, traceback=None):
-    """
-    Return a dictionary representation of an Exception.
+    """Return a dictionary representation of an Exception.
 
-    :param exc: Exception that is being serialized
-    :type exc: Exception
-    :param traceback: String representation of a traceback generated when the exception occurred.
-    :type traceback: str
+    :param exc: Exception that is being serialized :type exc: Exception :param traceback: String
+    representation of a traceback generated when the exception occurred. :type traceback: str
 
-    :return: dictionary representing the Exception
-    :rtype: dict
+    :return: dictionary representing the Exception :rtype: dict
     """
     return {"description": str(exc), "traceback": traceback}
 
 
 class ResourceImmutableError(PulpException):
-    """
-    Exceptions that are raised due to trying to update an immutable resource
-    """
+    """Exceptions that are raised due to trying to update an immutable resource."""
 
     def __init__(self, model):
         """
@@ -69,9 +60,7 @@ class AdvisoryLockError(Exception):
 
 
 class TimeoutException(PulpException):
-    """
-    Exception to signal timeout error.
-    """
+    """Exception to signal timeout error."""
 
     def __init__(self, url):
         """
@@ -88,10 +77,8 @@ class TimeoutException(PulpException):
 
 
 class DomainProtectedError(PulpException):
-    """
-    Exception to signal that a domain the user is trying to delete still contains
-    repositories with content.
-    """
+    """Exception to signal that a domain the user is trying to delete still contains repositories
+    with content."""
 
     def __init__(self):
         super().__init__("PLP0007")

--- a/pulpcore/exceptions/plugin.py
+++ b/pulpcore/exceptions/plugin.py
@@ -4,8 +4,7 @@ from .base import PulpException
 
 
 class MissingPlugin(PulpException):
-    """
-    Missing plugin exception.
+    """Missing plugin exception.
 
     Exception that is raised when a requested plugin is not installed.
     """

--- a/pulpcore/exceptions/validation.py
+++ b/pulpcore/exceptions/validation.py
@@ -4,17 +4,13 @@ from pulpcore.exceptions import PulpException
 
 
 class ValidationError(PulpException):
-    """
-    A base class for all Validation Errors.
-    """
+    """A base class for all Validation Errors."""
 
     pass
 
 
 class DigestValidationError(ValidationError):
-    """
-    Raised when a file fails to validate a digest checksum.
-    """
+    """Raised when a file fails to validate a digest checksum."""
 
     def __init__(self, actual, expected, *args, url=None, **kwargs):
         super().__init__("PLP0003")
@@ -37,9 +33,7 @@ class DigestValidationError(ValidationError):
 
 
 class SizeValidationError(ValidationError):
-    """
-    Raised when a file fails to validate a size checksum.
-    """
+    """Raised when a file fails to validate a size checksum."""
 
     def __init__(self, actual, expected, *args, url=None, **kwargs):
         super().__init__("PLP0004")
@@ -62,25 +56,19 @@ class SizeValidationError(ValidationError):
 
 
 class MissingDigestValidationError(Exception):
-    """
-    Raised when attempting to save() an Artifact with an incomplete set of checksums.
-    """
+    """Raised when attempting to save() an Artifact with an incomplete set of checksums."""
 
     pass
 
 
 class UnsupportedDigestValidationError(Exception):
-    """
-    Raised when an attempt is made to use a checksum-type that is not enabled/available.
-    """
+    """Raised when an attempt is made to use a checksum-type that is not enabled/available."""
 
     pass
 
 
 class InvalidSignatureError(RuntimeError):
-    """
-    Raised when a signature could not be verified by the GnuPG utility.
-    """
+    """Raised when a signature could not be verified by the GnuPG utility."""
 
     def __init__(self, *args, **kwargs):
         self.verified = kwargs.pop("verified", None)

--- a/pulpcore/filters.py
+++ b/pulpcore/filters.py
@@ -26,9 +26,8 @@ UPMatch = namedtuple("UPMatch", ("model", "pk"))
 
 
 class StableOrderingFilter(filters.OrderingFilter):
-    """
-    Ordering filter with a stabilized order by either creation date, if available or primary key.
-    """
+    """Ordering filter with a stabilized order by either creation date, if available or primary
+    key."""
 
     def filter(self, qs, value):
         try:
@@ -42,8 +41,7 @@ class StableOrderingFilter(filters.OrderingFilter):
 
 
 class HyperlinkRelatedFilter(filters.Filter):
-    """
-    Enables a user to filter by a foreign key using that FK's href/prn.
+    """Enables a user to filter by a foreign key using that FK's href/prn.
 
     Foreign key filter can be specified to an object type by specifying the base URI of that type.
     e.g. Filter by file remotes: ?remote=/pulp/api/v3/remotes/file/file/
@@ -284,15 +282,13 @@ class ExpressionFilter(filters.CharFilter):
 
 
 class BaseFilterSet(filterset.FilterSet):
-    """
-    Class to override django_filter's FilterSet and provide a way to set help text
+    """Class to override django_filter's FilterSet and provide a way to set help text.
 
     By default, this class will use predefined text and the field name to create help text for the
     filter. However, this can be overriden by setting a help_text dict with the field name
     mapped to some help text:
 
         help_text = {'name__in': 'Lorem ipsum dolor', 'pulp_last_updated__lt': 'blah blah'}
-
     """
 
     help_text = {}
@@ -365,8 +361,7 @@ class BaseFilterSet(filterset.FilterSet):
 
     @classmethod
     def filter_for_field(cls, field, name, lookup_expr):
-        """
-        Looks up and initializes a filter and returns it. Also, sets the help text on the filter.
+        """Looks up and initializes a filter and returns it. Also, sets the help text on the filter.
 
         Args:
             field: The field class for the filter

--- a/pulpcore/metrics.py
+++ b/pulpcore/metrics.py
@@ -20,8 +20,7 @@ def init_otel_meter(service_name, exporter=None, reader=None, provider=None):
 
 
 class MetricsEmitter:
-    """
-    A builder class that initializes an emitter.
+    """A builder class that initializes an emitter.
 
     If Open Telemetry is enabled, the builder configures a real emitter capable of sending data to
     the collector. Otherwise, a no-op emitter is initialized. The real emitter may utilize the

--- a/pulpcore/middleware.py
+++ b/pulpcore/middleware.py
@@ -15,8 +15,7 @@ from pulpcore.app.util import (
 
 
 class DomainMiddleware:
-    """
-    A middleware class to add in the domain name to the request context.
+    """A middleware class to add in the domain name to the request context.
 
     Removes the domain name from the view kwargs if present in the url. If no domain is specified
     "default" is used.
@@ -52,8 +51,7 @@ class DomainMiddleware:
 
 
 class APIRootRewriteMiddleware:
-    """
-    A middleware class to support API_ROOT_REWRITE_HEADER setting.
+    """A middleware class to support API_ROOT_REWRITE_HEADER setting.
 
     When API_ROOT_REWRITE_HEADER is set, this middleware will check for the existence of the header
     on the request and if set it will add the new API_ROOT to the request context and remove the

--- a/pulpcore/openapi/__init__.py
+++ b/pulpcore/openapi/__init__.py
@@ -61,8 +61,7 @@ class PulpAutoSchema(AutoSchema):
     V3_API = API_ROOT_NO_FRONT_SLASH.replace("{pulp_domain}/", "")
 
     def _tokenize_path(self):
-        """
-        Tokenize path.
+        """Tokenize path.
 
         drf_spectacular uses this to tokenize the path:
             "/my/path/to/{variable}/api" => ["my", "path", "to", "api"]
@@ -71,7 +70,6 @@ class PulpAutoSchema(AutoSchema):
             "/pulp/api/v3/artifacts/{pulp_id}" == "{artifact_href}"
 
         This method extends _tokenize_path to handle pulp cases.
-
         """
         tokenized_path = []
 
@@ -92,8 +90,7 @@ class PulpAutoSchema(AutoSchema):
         return tokenized_path
 
     def get_tags(self):
-        """
-        Generate tags.
+        """Generate tags.
 
         For bindings, tags are used to group operation ids into same class.
         Example:
@@ -106,7 +103,6 @@ class PulpAutoSchema(AutoSchema):
         Example:
             class MyViewSet(ViewSet):
                 pulp_tag_name = "Pulp: Customized Tag"
-
         """
         pulp_tag_name = getattr(self.view, "pulp_tag_name", False)
         if pulp_tag_name:
@@ -126,8 +122,7 @@ class PulpAutoSchema(AutoSchema):
         return tags
 
     def get_operation_id_action(self):
-        """
-        Get action from operation_id.
+        """Get action from operation_id.
 
         - For default actions: maps methods to action
             "patch" => "partial_update"
@@ -144,8 +139,7 @@ class PulpAutoSchema(AutoSchema):
         return self.method_mapping[self.method.lower()]
 
     def get_operation_id(self):
-        """
-        Get operation id.
+        """Get operation id.
 
         Combines tokenized_path with action.
         Example:
@@ -153,7 +147,6 @@ class PulpAutoSchema(AutoSchema):
             method = "patch"
 
             Return "my_path_to_api_partial_update"
-
         """
         tokenized_path = self._tokenize_path()
         tokenized_path = [t.replace("-", "_").replace("/", "_").lower() for t in tokenized_path]
@@ -161,8 +154,8 @@ class PulpAutoSchema(AutoSchema):
         return "_".join(tokenized_path + [self.get_operation_id_action()])
 
     def get_summary(self):
-        """
-        Returns summary of operation.
+        """Returns summary of operation.
+
         This is the value that is displayed in the ReDoc document as the short name for the API
         operation.
         """
@@ -189,9 +182,7 @@ class PulpAutoSchema(AutoSchema):
             return f"Partially update {article} {resource}"
 
     def _get_serializer_name(self, serializer, direction, bypass_extensions=False):
-        """
-        Get serializer name.
-        """
+        """Get serializer name."""
         name = super()._get_serializer_name(
             serializer, direction, bypass_extensions=bypass_extensions
         )
@@ -202,8 +193,7 @@ class PulpAutoSchema(AutoSchema):
         return name
 
     def map_parsers(self):
-        """
-        Get request parsers.
+        """Get request parsers.
 
         Handling cases with `FileField`.
         """
@@ -222,9 +212,7 @@ class PulpAutoSchema(AutoSchema):
         return request_body
 
     def _get_response_bodies(self):
-        """
-        Handle response status code.
-        """
+        """Handle response status code."""
         response = super()._get_response_bodies()
         if (
             self.method == "POST"
@@ -275,6 +263,7 @@ class PulpSchemaGenerator(SchemaGenerator):
 
     def convert_endpoint_path_params(self, path, view, schema):
         """Replaces all 'pulp_id' path parameters with a specific name for the primary key.
+
         This method is used to ensure that the primary key name is consistent between nested
         endpoints. get_endpoints() returns paths that use 'pulp_id' for the top level path and a
         specific name for the nested paths. e.g.: repository_pk.

--- a/pulpcore/plugin/access_policy.py
+++ b/pulpcore/plugin/access_policy.py
@@ -10,9 +10,7 @@ from pulpcore.app.loggers import deprecation_logger
 
 
 class AccessPolicyFromDB(AccessPolicy):
-    """
-    An AccessPolicy that loads statements from an `AccessPolicy` model instance.
-    """
+    """An AccessPolicy that loads statements from an `AccessPolicy` model instance."""
 
     def __init_subclass__(self, *args, **kwargs):
         deprecation_logger.warning(
@@ -24,8 +22,7 @@ class AccessPolicyFromDB(AccessPolicy):
 
     @staticmethod
     def get_access_policy(view):
-        """
-        Retrieves the AccessPolicy from the DB or None if it doesn't exist.
+        """Retrieves the AccessPolicy from the DB or None if it doesn't exist.
 
         Args:
             view (subclass of rest_framework.view.APIView): The view or viewset to receive the
@@ -47,13 +44,11 @@ class AccessPolicyFromDB(AccessPolicy):
 
     @classmethod
     def handle_creation_hooks(cls, obj):
-        """
-        Handle the creation hooks defined in this policy for the passed in `obj`.
+        """Handle the creation hooks defined in this policy for the passed in `obj`.
 
         Args:
             cls: The class this method belongs to.
             obj: The model instance to have its creation hooks handled for.
-
         """
         viewset = get_viewset_for_model(obj)
         access_policy = cls.get_access_policy(viewset)
@@ -71,9 +66,7 @@ class AccessPolicyFromDB(AccessPolicy):
                 function(**kwargs)
 
     def scope_queryset(self, view, qs):
-        """
-        Scope the queryset based on the access policy `scope_queryset` method if present.
-        """
+        """Scope the queryset based on the access policy `scope_queryset` method if present."""
         if access_policy := self.get_access_policy(view):
             if access_policy.queryset_scoping:
                 scope = access_policy.queryset_scoping["function"]
@@ -86,8 +79,7 @@ class AccessPolicyFromDB(AccessPolicy):
         return qs
 
     def get_policy_statements(self, request, view):
-        """
-        Return the policy statements from an AccessPolicy instance matching the viewset name.
+        """Return the policy statements from an AccessPolicy instance matching the viewset name.
 
         This is an implementation of a method that will be called by
         `rest_access_policy.AccessPolicy`. See the drf-access-policy docs for more info:

--- a/pulpcore/plugin/actions.py
+++ b/pulpcore/plugin/actions.py
@@ -22,9 +22,8 @@ class ModifyRepositoryActionMixin:
     )
     @action(detail=True, methods=["post"], serializer_class=RepositoryAddRemoveContentSerializer)
     def modify(self, request, pk):
-        """
-        Queues a task that creates a new RepositoryVersion by adding and removing content units
-        """
+        """Queues a task that creates a new RepositoryVersion by adding and removing content
+        units."""
         repository = self.get_object()
         serializer = self.get_serializer(data=request.data)
         serializer.is_valid(raise_exception=True)

--- a/pulpcore/plugin/importexport.py
+++ b/pulpcore/plugin/importexport.py
@@ -3,8 +3,7 @@ from pulpcore.app.util import get_domain_pk
 
 
 class QueryModelResource(resources.ModelResource):
-    """
-    A ModelResource that knows the RepositoryVersion to use to filter its query
+    """A ModelResource that knows the RepositoryVersion to use to filter its query.
 
     QueryModelResource has-a repository-version that can be used to limit its export, and a
     queryset that is derived from that repository-version.
@@ -21,8 +20,8 @@ class QueryModelResource(resources.ModelResource):
     """
 
     def before_import_row(self, row, **kwargs):
-        """
-        Sets pulp_domain/_pulp_domain to the current-domain on import.
+        """Sets pulp_domain/_pulp_domain to the current-domain on import.
+
         Args:
             row (tablib.Dataset row): incoming import-row representing a single Variant.
             kwargs: args passed along from the import() call.
@@ -51,8 +50,7 @@ class QueryModelResource(resources.ModelResource):
 
 
 class BaseContentResource(QueryModelResource):
-    """
-    A QueryModelResource that knows how to fill in the 'upstream_id' export-field
+    """A QueryModelResource that knows how to fill in the 'upstream_id' export-field.
 
     BaseContentResource knows to de/hydrate upstream_id with the content-being-exported's pulp_id.
 

--- a/pulpcore/plugin/publication_utils.py
+++ b/pulpcore/plugin/publication_utils.py
@@ -5,8 +5,7 @@ from pulpcore.app.files import validate_file_paths
 
 
 def validate_publication_paths(publication):
-    """
-    Validate artifact relative paths for dupes or overlap (e.g. a/b and a/b/c).
+    """Validate artifact relative paths for dupes or overlap (e.g. a/b and a/b/c).
 
     Raises:
         ValueError: If two artifact relative paths are dupes or overlap

--- a/pulpcore/plugin/pulp_hashlib.py
+++ b/pulpcore/plugin/pulp_hashlib.py
@@ -1,3 +1,3 @@
-"""A wrapper around `hashlib` providing only hashers named in settings.ALLOWED_CONTENT_CHECKSUMS"""
+"""A wrapper around `hashlib` providing only hashers named in settings.ALLOWED_CONTENT_CHECKSUMS."""
 
 from pulpcore.app.pulp_hashlib import new  # noqa: F401

--- a/pulpcore/plugin/repo_version_utils.py
+++ b/pulpcore/plugin/repo_version_utils.py
@@ -14,8 +14,8 @@ __all__ = ["remove_duplicates"]
 
 
 def remove_duplicates(repository_version):
-    """
-    Inspect content additions in the `RepositoryVersion` and remove existing repository duplicates.
+    """Inspect content additions in the `RepositoryVersion` and remove existing repository
+    duplicates.
 
     This function will inspect the content being added to a repo version and remove any existing
     content which would collide with the content being added to the repository version. It does not
@@ -72,8 +72,7 @@ def remove_duplicates(repository_version):
 
 
 def validate_duplicate_content(version):
-    """
-    Validate that a repository version doesn't contain duplicate content.
+    """Validate that a repository version doesn't contain duplicate content.
 
     Uses repo_key_fields to determine if content is duplicated.
 
@@ -110,8 +109,7 @@ def validate_duplicate_content(version):
 
 
 def validate_version_paths(version):
-    """
-    Validate artifact relative paths for dupes or overlap (e.g. a/b and a/b/c).
+    """Validate artifact relative paths for dupes or overlap (e.g. a/b and a/b/c).
 
     Raises:
         ValueError: If two artifact relative paths overlap
@@ -126,8 +124,7 @@ def validate_version_paths(version):
 
 
 def validate_repo_version(version):
-    """
-    Validate a repo version.
+    """Validate a repo version.
 
     Checks for duplicate content, duplicate relative paths, etc.
 

--- a/pulpcore/plugin/serializers/content.py
+++ b/pulpcore/plugin/serializers/content.py
@@ -59,8 +59,7 @@ class UploadSerializerFieldsMixin(Serializer):
         return url_parse._replace(netloc=url_parse.netloc.split("@")[-1]).geturl()
 
     def download(self, url, expected_digests=None, expected_size=None):
-        """
-        Downloads & returns the file from the url.
+        """Downloads & returns the file from the url.
 
         Plugins can overwrite this method on their content serializers to get specific download
         behavior for their content types.
@@ -106,8 +105,7 @@ class UploadSerializerFieldsMixin(Serializer):
         return data
 
     def deferred_validate(self, data):
-        """
-        Validate the content unit by deeply analyzing the specified Artifact.
+        """Validate the content unit by deeply analyzing the specified Artifact.
 
         This is only called when validating without a request context to prevent stalling
         an ongoing http request.
@@ -168,12 +166,11 @@ class NoArtifactContentUploadSerializer(UploadSerializerFieldsMixin, NoArtifactC
 class SingleArtifactContentUploadSerializer(
     UploadSerializerFieldsMixin, SingleArtifactContentSerializer
 ):
-    """
-    A serializer for content_types with a single Artifact.
+    """A serializer for content_types with a single Artifact.
 
-    The Artifact can either be specified via it's url or an uncommitted upload, or a new file can
-    be uploaded in the POST data.
-    Additionally a repository can be specified, to which the content unit will be added.
+    The Artifact can either be specified via it's url or an uncommitted upload, or a new file can be
+    uploaded in the POST data. Additionally a repository can be specified, to which the content unit
+    will be added.
 
     When using this serializer, the creation of the real content must be wrapped in a task that
     touches the Artifact and locks the Upload and Repository when specified.
@@ -196,8 +193,7 @@ class SingleArtifactContentUploadSerializer(
             self.fields["artifact"].required = False
 
     def deferred_validate(self, data):
-        """
-        Validate the content unit by deeply analyzing the specified Artifact.
+        """Validate the content unit by deeply analyzing the specified Artifact.
 
         This is only called when validating without a request context to prevent stalling
         an ongoing http request.

--- a/pulpcore/plugin/stages/api.py
+++ b/pulpcore/plugin/stages/api.py
@@ -9,8 +9,7 @@ log = logging.getLogger(__name__)
 
 
 class Stage:
-    """
-    The base class for all Stages API stages.
+    """The base class for all Stages API stages.
 
     To make a stage, inherit from this class and implement :meth:`run` on the subclass.
     """
@@ -21,8 +20,7 @@ class Stage:
         self.domain = get_domain()
 
     def _connect(self, in_q, out_q):
-        """
-        Connect to queues within a pipeline.
+        """Connect to queues within a pipeline.
 
         Args:
             in_q (asyncio.Queue): The stage input queue.
@@ -32,8 +30,7 @@ class Stage:
         self._out_q = out_q
 
     async def __call__(self):
-        """
-        This coroutine makes the stage callable.
+        """This coroutine makes the stage callable.
 
         It calls :meth:`run` and signals the next stage that its work is finished.
         """
@@ -43,18 +40,15 @@ class Stage:
         log.debug(_("%(name)s - put end-marker."), {"name": self})
 
     async def run(self):
-        """
-        The coroutine that is run as part of this stage.
+        """The coroutine that is run as part of this stage.
 
         Returns:
             The coroutine that runs this stage.
-
         """
         raise NotImplementedError(_("A plugin writer must implement this method"))
 
     async def items(self):
-        """
-        Asynchronous iterator yielding items of [DeclarativeContent][] from `self._in_q`.
+        """Asynchronous iterator yielding items of [DeclarativeContent][] from `self._in_q`.
 
         The iterator will get instances of [DeclarativeContent][] one by one as they get
         available.
@@ -70,7 +64,6 @@ class Stage:
                         async for d_content in self.items():
                             # process declarative content
                             await self.put(d_content)
-
         """
         while True:
             content = await self._in_q.get()
@@ -80,8 +73,7 @@ class Stage:
             yield content
 
     async def batches(self, minsize=500):
-        """
-        Asynchronous iterator yielding batches of [DeclarativeContent][] from `self._in_q`.
+        """Asynchronous iterator yielding batches of [DeclarativeContent][] from `self._in_q`.
 
         The iterator will try to get as many instances of
         [DeclarativeContent][] as possible without blocking, but
@@ -102,7 +94,6 @@ class Stage:
                             for d_content in batch:
                                 # process declarative content
                                 await self.put(d_content)
-
         """
         batch = []
         shutdown = False
@@ -159,8 +150,7 @@ class Stage:
         get_listener.cancel()
 
     async def put(self, item):
-        """
-        Coroutine to pass items to the next stage.
+        """Coroutine to pass items to the next stage.
 
         Args:
             item: A handled instance of [pulpcore.plugin.stages.DeclarativeContent][]
@@ -178,8 +168,7 @@ class Stage:
 
 
 async def create_pipeline(stages, maxsize=1):
-    """
-    A coroutine that builds a Stages API linear pipeline from the list `stages` and runs it.
+    """A coroutine that builds a Stages API linear pipeline from the list `stages` and runs it.
 
     Each stage is an instance of a class derived from [pulpcore.plugin.stages.Stage][] that
     implements the :meth:`run` coroutine. This coroutine reads asynchronously either from the
@@ -232,8 +221,7 @@ async def create_pipeline(stages, maxsize=1):
 
 
 class EndStage(Stage):
-    """
-    A Stages API stage that drains incoming items and does nothing with the items. This is
+    """A Stages API stage that drains incoming items and does nothing with the items. This is
     required at the end of all pipelines.
 
     Without this stage, the `maxsize` of the last stage's `_out_q` could fill up and block the
@@ -241,8 +229,7 @@ class EndStage(Stage):
     """
 
     async def __call__(self):
-        """
-        This method drains items from the last queue and drops them.
+        """This method drains items from the last queue and drops them.
 
         Importantly it does not try to put items into the nonexistent next queue.
         """

--- a/pulpcore/plugin/stages/artifact_stages.py
+++ b/pulpcore/plugin/stages/artifact_stages.py
@@ -25,8 +25,8 @@ log = logging.getLogger(__name__)
 def _check_for_forbidden_checksum_type(artifact):
     """Check if content doesn't have forbidden checksum type.
 
-    If contains forbidden checksum type it will raise ValueError,
-    otherwise it passes without returning anything.
+    If contains forbidden checksum type it will raise ValueError, otherwise it passes without
+    returning anything.
     """
     for digest_type in Artifact.FORBIDDEN_DIGESTS:
         digest_value = getattr(artifact, digest_type)
@@ -41,9 +41,8 @@ def _check_for_forbidden_checksum_type(artifact):
 
 
 class QueryExistingArtifacts(Stage):
-    """
-    A Stages API stage that replaces :attr:`DeclarativeContent.content` objects with already-saved
-    [pulpcore.plugin.models.Artifact][] objects.
+    """A Stages API stage that replaces :attr:`DeclarativeContent.content` objects with already-
+    saved [pulpcore.plugin.models.Artifact][] objects.
 
     This stage expects [pulpcore.plugin.stages.DeclarativeContent][] units from `self._in_q`
     and inspects their associated [pulpcore.plugin.stages.DeclarativeArtifact][] objects. Each
@@ -64,8 +63,7 @@ class QueryExistingArtifacts(Stage):
     """
 
     async def run(self):
-        """
-        The coroutine for this stage.
+        """The coroutine for this stage.
 
         Returns:
             The coroutine for this stage.
@@ -114,8 +112,7 @@ class QueryExistingArtifacts(Stage):
 
 
 class GenericDownloader(Stage):
-    """
-    A base Stages API stage to download files.
+    """A base Stages API stage to download files.
 
     This stage creates a ProgressReport named `PROGRESS_REPORTING_MESSAGE` that counts the number of
     downloads completed. Since it's a stream the total count isn't known until it's finished.
@@ -144,8 +141,7 @@ class GenericDownloader(Stage):
         self.max_concurrent_content = max_concurrent_content
 
     async def run(self):
-        """
-        The coroutine for this stage.
+        """The coroutine for this stage.
 
         Returns:
             The coroutine for this stage.
@@ -207,9 +203,8 @@ class GenericDownloader(Stage):
 
 
 class ArtifactDownloader(GenericDownloader):
-    """
-    A Stages API stage to download [pulpcore.plugin.models.Artifact][] files, but don't save
-    the [pulpcore.plugin.models.Artifact][] in the db.
+    """A Stages API stage to download [pulpcore.plugin.models.Artifact][] files, but don't save the
+    [pulpcore.plugin.models.Artifact][] in the db.
 
     This stage downloads the file for any [pulpcore.plugin.models.Artifact][] objects missing
     files and creates a new [pulpcore.plugin.models.Artifact][] object from the downloaded
@@ -244,8 +239,7 @@ class ArtifactDownloader(GenericDownloader):
 
 
 class ArtifactSaver(Stage):
-    """
-    A Stages API stage that saves any unsaved :attr:`DeclarativeArtifact.artifact` objects.
+    """A Stages API stage that saves any unsaved :attr:`DeclarativeArtifact.artifact` objects.
 
     This stage expects [pulpcore.plugin.stages.DeclarativeContent][] units from `self._in_q`
     and inspects their associated [pulpcore.plugin.stages.DeclarativeArtifact][] objects. Each
@@ -261,8 +255,7 @@ class ArtifactSaver(Stage):
     """
 
     async def run(self):
-        """
-        The coroutine for this stage.
+        """The coroutine for this stage.
 
         Returns:
             The coroutine for this stage.
@@ -295,8 +288,7 @@ class ArtifactSaver(Stage):
 
 
 class RemoteArtifactSaver(Stage):
-    """
-    A Stage that saves [pulpcore.plugin.models.RemoteArtifact][] objects
+    """A Stage that saves [pulpcore.plugin.models.RemoteArtifact][] objects.
 
     An [pulpcore.plugin.models.RemoteArtifact][] object is saved for each
     [pulpcore.plugin.stages.DeclarativeArtifact][].
@@ -307,8 +299,7 @@ class RemoteArtifactSaver(Stage):
         self.fix_mismatched_remote_artifacts = fix_mismatched_remote_artifacts
 
     async def run(self):
-        """
-        The coroutine for this stage.
+        """The coroutine for this stage.
 
         Returns:
             The coroutine for this stage.
@@ -319,9 +310,8 @@ class RemoteArtifactSaver(Stage):
                 await self.put(d_content)
 
     async def _handle_remote_artifacts(self, batch):
-        """
-        Build a list of only [pulpcore.plugin.models.RemoteArtifact][] that need
-        to be created for the batch.
+        """Build a list of only [pulpcore.plugin.models.RemoteArtifact][] that need to be created
+        for the batch.
 
         Args:
             batch (list): List of [pulpcore.plugin.stages.DeclarativeContent][].
@@ -465,10 +455,8 @@ class RemoteArtifactSaver(Stage):
 
 
 class ACSArtifactHandler(Stage):
-    """
-    API stage to download [pulpcore.plugin.models.Artifact][] files from Alternate
-    Content Source if available.
-    """
+    """API stage to download [pulpcore.plugin.models.Artifact][] files from Alternate Content Source
+    if available."""
 
     def __init__(self, *args, **kwargs):
         self.remote_cache = {}

--- a/pulpcore/plugin/stages/content_stages.py
+++ b/pulpcore/plugin/stages/content_stages.py
@@ -13,9 +13,8 @@ from .api import Stage
 
 
 class QueryExistingContents(Stage):
-    """
-    A Stages API stage that saves :attr:`DeclarativeContent.content` objects and saves its related
-    [pulpcore.plugin.models.ContentArtifact][] objects too.
+    """A Stages API stage that saves :attr:`DeclarativeContent.content` objects and saves its
+    related [pulpcore.plugin.models.ContentArtifact][] objects too.
 
     This stage expects [pulpcore.plugin.stages.DeclarativeContent][] units from `self._in_q`
     and inspects their associated [pulpcore.plugin.stages.DeclarativeArtifact][] objects. Each
@@ -34,8 +33,7 @@ class QueryExistingContents(Stage):
     """
 
     async def run(self):
-        """
-        The coroutine for this stage.
+        """The coroutine for this stage.
 
         Returns:
             The coroutine for this stage.
@@ -70,9 +68,8 @@ class QueryExistingContents(Stage):
 
 
 class ContentSaver(Stage):
-    """
-    A Stages API stage that saves :attr:`DeclarativeContent.content` objects and saves its related
-    [pulpcore.plugin.models.ContentArtifact][] objects too.
+    """A Stages API stage that saves :attr:`DeclarativeContent.content` objects and saves its
+    related [pulpcore.plugin.models.ContentArtifact][] objects too.
 
     This stage expects [pulpcore.plugin.stages.DeclarativeContent][] units from `self._in_q`
     and inspects their associated [pulpcore.plugin.stages.DeclarativeArtifact][] objects. Each
@@ -89,8 +86,7 @@ class ContentSaver(Stage):
     """
 
     async def run(self):
-        """
-        The coroutine for this stage.
+        """The coroutine for this stage.
 
         Returns:
             The coroutine for this stage.
@@ -200,35 +196,30 @@ class ContentSaver(Stage):
                 await self.put(declarative_content)
 
     def _pre_save(self, batch):
-        """
-        A hook plugin-writers can override to save related objects prior to content unit saving.
+        """A hook plugin-writers can override to save related objects prior to content unit saving.
 
         This is run within the same transaction as the content unit saving.
 
         Args:
             batch (list of [pulpcore.plugin.stages.DeclarativeContent][]): The batch of
                 [pulpcore.plugin.stages.DeclarativeContent][] objects to be saved.
-
         """
         pass
 
     def _post_save(self, batch):
-        """
-        A hook plugin-writers can override to save related objects after content unit saving.
+        """A hook plugin-writers can override to save related objects after content unit saving.
 
         This is run within the same transaction as the content unit saving.
 
         Args:
             batch (list of [pulpcore.plugin.stages.DeclarativeContent][]): The batch of
                 [pulpcore.plugin.stages.DeclarativeContent][] objects to be saved.
-
         """
         pass
 
 
 class ResolveContentFutures(Stage):
-    """
-    This stage resolves the futures in [pulpcore.plugin.stages.DeclarativeContent][].
+    """This stage resolves the futures in [pulpcore.plugin.stages.DeclarativeContent][].
 
     Futures results are set to the found/created [pulpcore.plugin.models.Content][].
 
@@ -258,8 +249,7 @@ class ResolveContentFutures(Stage):
     """
 
     async def run(self):
-        """
-        The coroutine for this stage.
+        """The coroutine for this stage.
 
         Returns:
             The coroutine for this stage.
@@ -270,8 +260,7 @@ class ResolveContentFutures(Stage):
 
 
 class ContentAssociation(Stage):
-    """
-    A Stages API stage that associates content units with `new_version`.
+    """A Stages API stage that associates content units with `new_version`.
 
     This stage stores all content unit primary keys in memory before running. This is done to
     compute the units already associated but not received from `self._in_q`. These units are passed
@@ -299,8 +288,7 @@ class ContentAssociation(Stage):
         self.allow_delete = mirror
 
     async def run(self):
-        """
-        The coroutine for this stage.
+        """The coroutine for this stage.
 
         Returns:
             The coroutine for this stage.

--- a/pulpcore/plugin/stages/declarative_version.py
+++ b/pulpcore/plugin/stages/declarative_version.py
@@ -21,9 +21,8 @@ from pulpcore.plugin.util import get_domain_pk
 
 class DeclarativeVersion:
     def __init__(self, first_stage, repository, mirror=False, acs=False):
-        """
-        A pipeline that creates a new [pulpcore.plugin.models.RepositoryVersion][] from a
-        stream of [pulpcore.plugin.stages.DeclarativeContent][] objects.
+        """A pipeline that creates a new [pulpcore.plugin.models.RepositoryVersion][] from a stream
+        of [pulpcore.plugin.stages.DeclarativeContent][] objects.
 
         The plugin writer needs to specify a first_stage that will create a
         [pulpcore.plugin.stages.DeclarativeContent][] object for each Content unit that should
@@ -106,7 +105,6 @@ class DeclarativeVersion:
                 'False' is the default.
             acs (bool): When set to 'True' a new stage is added to look for
                 Alternate Content Sources.
-
         """
         self.first_stage = first_stage
         self.repository = repository
@@ -114,8 +112,7 @@ class DeclarativeVersion:
         self.acs = acs
 
     def pipeline_stages(self, new_version):
-        """
-        Build the list of pipeline stages feeding into the ContentAssociation stage.
+        """Build the list of pipeline stages feeding into the ContentAssociation stage.
 
         Plugin-writers may override this method to build a custom pipeline. This
         can be achieved by returning a list with different stages or by extending
@@ -127,7 +124,6 @@ class DeclarativeVersion:
 
         Returns:
             list: List of [pulpcore.plugin.stages.Stage][] instances
-
         """
         pipeline = [
             self.first_stage,
@@ -148,8 +144,7 @@ class DeclarativeVersion:
         return pipeline
 
     def create(self):
-        """
-        Perform the work. This is the long-blocking call where all syncing occurs.
+        """Perform the work. This is the long-blocking call where all syncing occurs.
 
         Returns: The created RepositoryVersion or None if it represents no change from the latest.
         """

--- a/pulpcore/plugin/stages/models.py
+++ b/pulpcore/plugin/stages/models.py
@@ -7,9 +7,8 @@ from pulpcore.plugin.models import Artifact
 
 
 class DeclarativeArtifact:
-    """
-    Relates an [pulpcore.plugin.models.Artifact][], how to download it, and its
-    `relative_path` used later during publishing.
+    """Relates an [pulpcore.plugin.models.Artifact][], how to download it, and its `relative_path`
+    used later during publishing.
 
     This is used by the Stages API stages to determine if an
     [pulpcore.plugin.models.Artifact][] is already present and ensure Pulp can download it in
@@ -83,8 +82,7 @@ class DeclarativeArtifact:
         return self.urls[0]
 
     async def download(self):
-        """
-        Download content and update the associated Artifact.
+        """Download content and update the associated Artifact.
 
         Returns:
             Returns the [pulpcore.plugin.download.DownloadResult][] of the Artifact.
@@ -124,8 +122,7 @@ class DeclarativeArtifact:
 
 
 class DeclarativeContent:
-    """
-    Relates a Content unit and zero or more [pulpcore.plugin.stages.DeclarativeArtifact][]
+    """Relates a Content unit and zero or more [pulpcore.plugin.stages.DeclarativeArtifact][]
     objects.
 
     This is used by the Stages API stages to determine if a Content unit is already present and
@@ -166,13 +163,16 @@ class DeclarativeContent:
     @property
     def does_batch(self):
         """Whether this content is being awaited on and must therefore not wait forever in batches.
+
         When overwritten in subclasses, a `True` value must never be turned into `False`.
         """
         return self._resolved or self._future is None
 
     async def resolution(self):
         """Coroutine that waits for the content to be saved to database.
-        Returns the content unit."""
+
+        Returns the content unit.
+        """
         if self._resolved:
             # Already resolved ~> shortcut
             return self.content

--- a/pulpcore/plugin/sync.py
+++ b/pulpcore/plugin/sync.py
@@ -15,8 +15,7 @@ def next_async(it):
 
 
 def sync_to_async_iterable(sync_iterable):
-    """
-    Creates an async iterable.
+    """Creates an async iterable.
 
     The returned iterator is able to be reused and iterated through multiple times.
 

--- a/pulpcore/plugin/viewsets/content.py
+++ b/pulpcore/plugin/viewsets/content.py
@@ -20,11 +20,10 @@ class DefaultDeferredContextMixin:
     """A mixin that provides a method for retrieving the default deferred context."""
 
     def get_deferred_context(self, request):
-        """
-        Supply context for deferred validation.
+        """Supply context for deferred validation.
 
-        When overwriting this method, it must return a dict, that is JSON serializable by
-        and does _not_ contain 'request' as a key.
+        When overwriting this method, it must return a dict, that is JSON serializable by and does
+        _not_ contain 'request' as a key.
         """
         return {}
 

--- a/pulpcore/pytest_plugin.py
+++ b/pulpcore/pytest_plugin.py
@@ -138,8 +138,7 @@ def _patch_cid_user_agent(_api_client_set, cid, monkeypatch):
 
 @pytest.fixture(scope="session")
 def pulpcore_bindings(_api_client_set, bindings_cfg):
-    """
-    A namespace providing preconfigured pulpcore api clients.
+    """A namespace providing preconfigured pulpcore api clients.
 
     e.g. `pulpcore_bindings.WorkersApi.list()`.
     """
@@ -671,8 +670,7 @@ def delete_orphans_pre(request, pulpcore_bindings, monitor_task):
 
 @pytest.fixture(scope="session")
 def monitor_task(pulpcore_bindings, pulp_domain_enabled):
-    """
-    Wait for a task to reach a final state.
+    """Wait for a task to reach a final state.
 
     Returns the task in "completed" state, or throws a `PulpTaskTimeoutError` in case the timeout
     in seconds (defaulting to 30*60) exceeded or a `PulpTaskError` in case it reached any other
@@ -706,8 +704,7 @@ def monitor_task(pulpcore_bindings, pulp_domain_enabled):
 
 @pytest.fixture(scope="session")
 def monitor_task_group(pulpcore_bindings):
-    """
-    Wait for a task group to reach a final state.
+    """Wait for a task group to reach a final state.
 
     Returns the task group in "completed" state, or throws a `PulpTaskTimeoutError` in case the
     timeout in seconds (defaulting to 30*60) exceeded or a `PulpTaskGroupError` in case it reached
@@ -823,7 +820,7 @@ def pulp_versions(pulp_status):
 
 @pytest.fixture
 def needs_pulp_plugin(pulp_versions):
-    """Skip test if a component is not available in the specified version range"""
+    """Skip test if a component is not available in the specified version range."""
 
     def _needs_pulp_plugin(plugin, min=None, max=None):
         if plugin not in pulp_versions:
@@ -1091,9 +1088,7 @@ def signing_gpg_homedir_path(tmp_path_factory):
 
 @pytest.fixture
 def sign_with_ascii_armored_detached_signing_service(signing_script_path, signing_gpg_metadata):
-    """
-    Runs the test signing script manually, locally, and returns the signature file produced.
-    """
+    """Runs the test signing script manually, locally, and returns the signature file produced."""
 
     def _sign_with_ascii_armored_detached_signing_service(filename):
         env = {"PULP_SIGNING_KEY_FINGERPRINT": signing_gpg_metadata[1]}

--- a/pulpcore/tasking/_util.py
+++ b/pulpcore/tasking/_util.py
@@ -40,8 +40,7 @@ def startup_hook():
 
 
 def delete_incomplete_resources(task):
-    """
-    Delete all incomplete created-resources on a canceled task.
+    """Delete all incomplete created-resources on a canceled task.
 
     Args:
         task (Task): A task.
@@ -90,7 +89,9 @@ def child_signal_handler(sig, frame):
 
 def perform_task(task_pk, task_working_dir_rel_path):
     """Setup the environment to handle a task and execute it.
-    This must be called as a subprocess, while the parent holds the advisory lock of the task."""
+
+    This must be called as a subprocess, while the parent holds the advisory lock of the task.
+    """
     signal.signal(signal.SIGINT, child_signal_handler)
     signal.signal(signal.SIGTERM, child_signal_handler)
     signal.signal(signal.SIGHUP, child_signal_handler)

--- a/pulpcore/tasking/storage.py
+++ b/pulpcore/tasking/storage.py
@@ -5,8 +5,7 @@ from django.conf import settings
 
 
 class _WorkingDir:
-    """
-    A base class for temporary working directories.
+    """A base class for temporary working directories.
 
     TODO: This is very similar to functionality already in the stdlib, why keep our own?
 
@@ -25,8 +24,7 @@ class _WorkingDir:
 
     @property
     def path(self):
-        """
-        The absolute path to the directory.
+        """The absolute path to the directory.
 
         Returns:
             str: The absolute directory path.
@@ -34,14 +32,11 @@ class _WorkingDir:
         return self._path
 
     def create(self):
-        """
-        Create the directory.
-        """
+        """Create the directory."""
         os.makedirs(self.path, mode=self.MODE)
 
     def delete(self):
-        """
-        Delete the directory.
+        """Delete the directory.
 
         On permission denied - an attempt is made to fix the
         permissions on the tree and the delete is retried.
@@ -53,18 +48,14 @@ class _WorkingDir:
             self._delete()
 
     def _delete(self):
-        """
-        Helper method for delete
-        """
+        """Helper method for delete."""
         try:
             shutil.rmtree(self.path, ignore_errors=True)
         except FileNotFoundError:
             pass
 
     def _set_permissions(self):
-        """
-        Set appropriate permissions on the directory tree.
-        """
+        """Set appropriate permissions on the directory tree."""
         for path in os.walk(self.path):
             os.chmod(path[0], mode=self.MODE)
 
@@ -72,8 +63,7 @@ class _WorkingDir:
         return self.path
 
     def __enter__(self):
-        """
-        Create the directory and set the CWD to the path.
+        """Create the directory and set the CWD to the path.
 
         Returns: self
 
@@ -86,16 +76,13 @@ class _WorkingDir:
         return self
 
     def __exit__(self, *unused):
-        """
-        Delete the directory (tree) and restore the original CWD.
-        """
+        """Delete the directory (tree) and restore the original CWD."""
         os.chdir(self._prev_dir)
         self.delete()
 
 
 def get_worker_path(hostname):
-    """
-    Get the root directory path for a worker by hostname.
+    """Get the root directory path for a worker by hostname.
 
     Format: <root>/<worker-hostname>
 
@@ -109,8 +96,7 @@ def get_worker_path(hostname):
 
 
 class WorkerDirectory(_WorkingDir):
-    """
-    The directory associated with a pulpcore-worker.
+    """The directory associated with a pulpcore-worker.
 
     Path format: <root>/<worker-hostname>
     """
@@ -123,11 +109,10 @@ class WorkerDirectory(_WorkingDir):
         self._path = get_worker_path(hostname)
 
     def create(self):
-        """
-        Create the directory.
+        """Create the directory.
 
-        The directory is deleted and recreated when already exists.
-        Only one of these should ever be held at a time for any individual worker.
+        The directory is deleted and recreated when already exists. Only one of these should ever be
+        held at a time for any individual worker.
         """
         try:
             super().create()

--- a/pulpcore/tasking/tasks.py
+++ b/pulpcore/tasking/tasks.py
@@ -161,8 +161,7 @@ def dispatch(
     deferred=True,
     versions=None,
 ):
-    """
-    Enqueue a message to Pulp workers with a reservation.
+    """Enqueue a message to Pulp workers with a reservation.
 
     This method provides normal enqueue functionality, while also requesting necessary locks for
     serialized urls. No two tasks that claim the same resource can execute concurrently. It
@@ -310,8 +309,7 @@ def dispatch(
 
 
 def cancel_task(task_id):
-    """
-    Cancel the task that is represented by the given task_id.
+    """Cancel the task that is represented by the given task_id.
 
     This method cancels only the task with given task_id, not the spawned tasks. This also updates
     task's state to 'canceling'.
@@ -346,8 +344,7 @@ def cancel_task(task_id):
 
 
 def cancel_task_group(task_group_id):
-    """
-    Cancel the task group that is represented by the given task_group_id.
+    """Cancel the task group that is represented by the given task_group_id.
 
     This method attempts to cancel all tasks in the task group.
 

--- a/pulpcore/tasking/worker.py
+++ b/pulpcore/tasking/worker.py
@@ -132,12 +132,10 @@ class PulpcoreWorker:
                 self.cancel_task = True
 
     def handle_worker_heartbeat(self):
-        """
-        Create or update worker heartbeat records.
+        """Create or update worker heartbeat records.
 
         Existing Worker objects are searched for one to update. If an existing one is found, it is
         updated. Otherwise a new Worker entry is created. Logging at the info level is also done.
-
         """
         worker, created = Worker.objects.get_or_create(
             name=self.name, defaults={"versions": self.versions}
@@ -380,7 +378,8 @@ class PulpcoreWorker:
     def supervise_task(self, task):
         """Call and supervise the task process while heart beating.
 
-        This function must only be called while holding the lock for that task."""
+        This function must only be called while holding the lock for that task.
+        """
 
         self.cancel_task = False
         self.task = task
@@ -477,9 +476,9 @@ class PulpcoreWorker:
     def handle_available_tasks(self):
         """Pick and supervise tasks until there are no more available tasks.
 
-        Failing to detect new available tasks can lead to a stuck state, as the workers
-        would go to sleep and wouldn't be able to know about the unhandled task until
-        an external wakeup event occurs (e.g., new worker startup or new task gets in).
+        Failing to detect new available tasks can lead to a stuck state, as the workers would go to
+        sleep and wouldn't be able to know about the unhandled task until an external wakeup event
+        occurs (e.g., new worker startup or new task gets in).
         """
         keep_looping = True
         while keep_looping and not self.shutdown_requested:

--- a/pulpcore/tests/functional/api/test_access_policy.py
+++ b/pulpcore/tests/functional/api/test_access_policy.py
@@ -23,7 +23,7 @@ def test_access_policy_default_policies(pulpcore_bindings):
 
 
 def test_statements_attr_can_be_modified(pulpcore_bindings):
-    """Test that `AccessPolicy.statements` can be modified"""
+    """Test that `AccessPolicy.statements` can be modified."""
     tasks_response = pulpcore_bindings.AccessPoliciesApi.list(viewset_name="tasks")
     tasks_href = tasks_response.results[0].pulp_href
     task_access_policy = pulpcore_bindings.AccessPoliciesApi.read(tasks_href)
@@ -44,7 +44,7 @@ def test_statements_attr_can_be_modified(pulpcore_bindings):
 
 
 def test_creation_hooks_attr_can_be_modified(pulpcore_bindings):
-    """Test that `AccessPolicy.creation_hooks` can be modified"""
+    """Test that `AccessPolicy.creation_hooks` can be modified."""
     groups_response = pulpcore_bindings.AccessPoliciesApi.list(viewset_name="groups")
     groups_href = groups_response.results[0].pulp_href
     groups_access_policy = pulpcore_bindings.AccessPoliciesApi.read(groups_href)
@@ -66,7 +66,7 @@ def test_creation_hooks_attr_can_be_modified(pulpcore_bindings):
 
 @pytest.mark.parallel
 def test_customized_is_read_only(pulpcore_bindings):
-    """Test that the `AccessPolicy.customized` attribute is read only"""
+    """Test that the `AccessPolicy.customized` attribute is read only."""
     tasks_response = pulpcore_bindings.AccessPoliciesApi.list(viewset_name="tasks")
     tasks_href = tasks_response.results[0].pulp_href
     task_access_policy = pulpcore_bindings.AccessPoliciesApi.read(tasks_href)
@@ -79,7 +79,7 @@ def test_customized_is_read_only(pulpcore_bindings):
 
 @pytest.mark.parallel
 def test_viewset_name_is_read_only(pulpcore_bindings):
-    """Test that the `AccessPolicy.viewset_name` attribute is read only"""
+    """Test that the `AccessPolicy.viewset_name` attribute is read only."""
     tasks_response = pulpcore_bindings.AccessPoliciesApi.list(viewset_name="tasks")
     tasks_href = tasks_response.results[0].pulp_href
     task_access_policy = pulpcore_bindings.AccessPoliciesApi.read(tasks_href)

--- a/pulpcore/tests/functional/api/test_api_root_rewrite.py
+++ b/pulpcore/tests/functional/api/test_api_root_rewrite.py
@@ -2,7 +2,6 @@ import pytest
 import uuid
 import json
 
-
 """
 To run these tests:
 1. Copy ../assets/api_root_rewrite.conf to /etc/nginx/pulp in your Pulp container

--- a/pulpcore/tests/functional/api/test_login.py
+++ b/pulpcore/tests/functional/api/test_login.py
@@ -6,8 +6,8 @@ pytestmark = [pytest.mark.parallel]
 
 @pytest.fixture(autouse=True)
 def _fix_response_headers(monkeypatch, pulpcore_bindings):
-    """
-    Fix bindings incorrectly translating HTTPHeaderDict to dict.
+    """Fix bindings incorrectly translating HTTPHeaderDict to dict.
+
     Ideally they wouldn't even make it a dict, but keep it whatever case insensitive multivalued
     mapping the underlying http adapter provides. Alternatively translate everything into the
     mutidict.CIMultiDict type.

--- a/pulpcore/tests/functional/api/test_status.py
+++ b/pulpcore/tests/functional/api/test_status.py
@@ -156,8 +156,6 @@ def test_livez_unauthenticated(
     pulpcore_bindings,
     anonymous_user,
 ):
-    """
-    Assert that GET requests to Livez API return 200 without a response body.
-    """
+    """Assert that GET requests to Livez API return 200 without a response body."""
     with anonymous_user:
         assert pulpcore_bindings.LivezApi.livez_read() is None

--- a/pulpcore/tests/functional/api/test_task_purge.py
+++ b/pulpcore/tests/functional/api/test_task_purge.py
@@ -1,6 +1,4 @@
-"""
-Tests task-purge functionality.
-"""
+"""Tests task-purge functionality."""
 
 from datetime import datetime, timedelta, timezone
 

--- a/pulpcore/tests/functional/api/test_tasking.py
+++ b/pulpcore/tests/functional/api/test_tasking.py
@@ -250,9 +250,7 @@ def test_search_task_by_name(task, pulpcore_bindings):
 
 @pytest.mark.parallel
 def test_search_task_using_an_invalid_name(pulpcore_bindings):
-    """Expect to return an empty results array when searching using an invalid
-    task name.
-    """
+    """Expect to return an empty results array when searching using an invalid task name."""
 
     search_results = pulpcore_bindings.TasksApi.list(name=str(uuid4()))
 
@@ -457,12 +455,8 @@ class TestImmediateTaskWithNoResource:
 
     @pytest.mark.parallel
     def test_succeeds_on_api_worker(self, pulpcore_bindings, dispatch_task):
-        """
-        GIVEN a task with no resource requirements
-        AND the task IS an async function
-        WHEN dispatching a task as immediate
-        THEN the task completes with no associated worker
-        """
+        """GIVEN a task with no resource requirements AND the task IS an async function WHEN
+        dispatching a task as immediate THEN the task completes with no associated worker."""
         task_href = dispatch_task(
             "pulpcore.app.tasks.test.asleep", args=(LT_TIMEOUT,), immediate=True
         )
@@ -472,12 +466,8 @@ class TestImmediateTaskWithNoResource:
 
     @pytest.mark.parallel
     def test_executes_on_api_worker_when_no_async(self, pulpcore_bindings, dispatch_task, capsys):
-        """
-        GIVEN a task with no resource requirements
-        AND the task IS NOT an async function
-        WHEN dispatching a task as immediate
-        THEN the task completes with no associated worker
-        """
+        """GIVEN a task with no resource requirements AND the task IS NOT an async function WHEN
+        dispatching a task as immediate THEN the task completes with no associated worker."""
         # TODO: on 3.85 this should throw an error
         task_href = dispatch_task(
             "pulpcore.app.tasks.test.sleep", args=(LT_TIMEOUT,), immediate=True
@@ -490,13 +480,9 @@ class TestImmediateTaskWithNoResource:
 
     @pytest.mark.parallel
     def test_timeouts_on_api_worker(self, pulpcore_bindings, dispatch_task):
-        """
-        GIVEN a task with no resource requirements
-        AND the task is an async function
-        WHEN dispatching a task as immediate
-        AND it takes longer than timeout
-        THEN the task fails with a timeout error message
-        """
+        """GIVEN a task with no resource requirements AND the task is an async function WHEN
+        dispatching a task as immediate AND it takes longer than timeout THEN the task fails with a
+        timeout error message."""
         task_href = dispatch_task(
             "pulpcore.app.tasks.test.asleep", args=(GT_TIMEOUT,), immediate=True
         )
@@ -534,11 +520,8 @@ class TestImmediateTaskWithBlockedResource:
     def test_executes_in_task_worker(
         self, resource_blocker, dispatch_task, monitor_task, pulpcore_bindings
     ):
-        """
-        GIVEN an async task requiring busy resources
-        WHEN dispatching a task as immediate
-        THEN the task completes with a worker
-        """
+        """GIVEN an async task requiring busy resources WHEN dispatching a task as immediate THEN
+        the task completes with a worker."""
         COMMON_RESOURCE = str(uuid4())
         with resource_blocker(exclusive_resources=[COMMON_RESOURCE]):
             task_href = dispatch_task(
@@ -555,11 +538,8 @@ class TestImmediateTaskWithBlockedResource:
     def test_throws_when_non_deferrable(
         self, resource_blocker, pulpcore_bindings, dispatch_task, monitor_task
     ):
-        """
-        GIVEN an async task requiring busy resources
-        WHEN dispatching as immediate and not deferrable
-        THEN an error is raised
-        """
+        """GIVEN an async task requiring busy resources WHEN dispatching as immediate and not
+        deferrable THEN an error is raised."""
         COMMON_RESOURCE = str(uuid4())
         with resource_blocker(exclusive_resources=[COMMON_RESOURCE]):
             task_href = dispatch_task(
@@ -578,12 +558,8 @@ class TestImmediateTaskWithBlockedResource:
     def test_times_out_on_task_worker(
         self, resource_blocker, pulpcore_bindings, dispatch_task, monitor_task
     ):
-        """
-        GIVEN an async task requiring busy resources
-        WHEN dispatching a task as immediate
-        AND it takes longer than timeout
-        THEN an error is raised
-        """
+        """GIVEN an async task requiring busy resources WHEN dispatching a task as immediate AND it
+        takes longer than timeout THEN an error is raised."""
         COMMON_RESOURCE = str(uuid4())
         with pytest.raises(PulpTaskError) as ctx:
             with resource_blocker(exclusive_resources=[COMMON_RESOURCE]):

--- a/pulpcore/tests/functional/api/test_upload.py
+++ b/pulpcore/tests/functional/api/test_upload.py
@@ -50,9 +50,8 @@ def pulpcore_upload_chunks(
     artifacts = []
 
     def _upload_chunks(size, chunks, sha256, include_chunk_sha256=False):
-        """
-        Chunks is a list of tuples in the form of (chunk_filename, "bytes-ranges", optional_sha256).
-        """
+        """Chunks is a list of tuples in the form of (chunk_filename, "bytes-ranges",
+        optional_sha256)."""
         upload = gen_object_with_cleanup(pulpcore_bindings.UploadsApi, {"size": size})
 
         for data in chunks:

--- a/pulpcore/tests/functional/api/using_plugin/test_content_cache.py
+++ b/pulpcore/tests/functional/api/using_plugin/test_content_cache.py
@@ -29,7 +29,7 @@ def test_full_workflow(
         pytest.xfail("Could not connect to the Redis server")
 
     def _check_cache(url):
-        """Helper to check if cache miss or hit"""
+        """Helper to check if cache miss or hit."""
         r = get_from_url(url)
         if r.history:
             r = r.history[0]

--- a/pulpcore/tests/functional/api/using_plugin/test_content_delivery.py
+++ b/pulpcore/tests/functional/api/using_plugin/test_content_delivery.py
@@ -119,16 +119,14 @@ def test_remote_content_changed_with_on_demand(
     file_distribution_factory,
     tmp_path,
 ):
-    """
-    GIVEN a remote synced on demand with fileA (e.g, digest=123),
-    AND the remote server, fileA changed its content (e.g, digest=456),
+    """GIVEN a remote synced on demand with fileA (e.g, digest=123), AND the remote server, fileA
+    changed its content (e.g, digest=456),
 
-    WHEN the client first requests that content
-    THEN the content app will start a response but close the connection before finishing
-    AND no file will be present in the filesystem
+    WHEN the client first requests that content THEN the content app will start a response but close
+    the connection before finishing AND no file will be present in the filesystem
 
-    WHEN the client requests that content again (within the RA cooldown interval)
-    THEN the content app will return a 404
+    WHEN the client requests that content again (within the RA cooldown interval) THEN the content
+    app will return a 404
     """
     # GIVEN
     basic_manifest_path = write_3_iso_file_fixture_data_factory("basic")
@@ -176,15 +174,12 @@ def test_handling_remote_artifact_on_demand_streaming_failure(
     gen_object_with_cleanup,
     generate_server_and_remote,
 ):
-    """
-    GIVEN A content synced with on-demand which has 2 RemoteArtifacts (Remote + ACS).
-    AND Only the ACS RemoteArtifact (that has priority on the content-app) is corrupted
+    """GIVEN A content synced with on-demand which has 2 RemoteArtifacts (Remote + ACS). AND Only
+    the ACS RemoteArtifact (that has priority on the content-app) is corrupted.
 
-    WHEN a client requests the content for the first time
-    THEN the client doesnt get any content
+    WHEN a client requests the content for the first time THEN the client doesnt get any content
 
-    WHEN a client requests the content for the second time
-    THEN the client gets the right content
+    WHEN a client requests the content for the second time THEN the client gets the right content
     """
 
     # Plumbing

--- a/pulpcore/tests/functional/api/using_plugin/test_filesystemexport.py
+++ b/pulpcore/tests/functional/api/using_plugin/test_filesystemexport.py
@@ -1,5 +1,4 @@
-"""
-Tests FilesystemExporter and FilesystemExport functionality
+"""Tests FilesystemExporter and FilesystemExport functionality.
 
 NOTE: assumes ALLOWED_EXPORT_PATHS setting contains "/tmp" - all tests will fail if this is not
 the case.

--- a/pulpcore/tests/functional/api/using_plugin/test_prn.py
+++ b/pulpcore/tests/functional/api/using_plugin/test_prn.py
@@ -48,7 +48,7 @@ def test_create_and_filter_with_prn(
     file_distribution_factory,
     monitor_task,
 ):
-    """Test that we can use PRNs to refer to any object"""
+    """Test that we can use PRNs to refer to any object."""
     # Creation tests
     remote = file_remote_factory(basic_manifest_path)
     task = file_bindings.RepositoriesFileApi.sync(file_repo.pulp_href, {"remote": remote.prn}).task

--- a/pulpcore/tests/functional/api/using_plugin/test_proxy.py
+++ b/pulpcore/tests/functional/api/using_plugin/test_proxy.py
@@ -26,9 +26,7 @@ def test_sync_http_through_http_proxy(
     basic_manifest_path,
     monitor_task,
 ):
-    """
-    Test syncing http through a http proxy.
-    """
+    """Test syncing http through a http proxy."""
     remote_on_demand = file_remote_factory(
         manifest_path=basic_manifest_path, policy="on_demand", proxy_url=http_proxy.proxy_url
     )
@@ -45,9 +43,7 @@ def test_sync_https_through_http_proxy(
     basic_manifest_path,
     monitor_task,
 ):
-    """
-    Test syncing https through a http proxy.
-    """
+    """Test syncing https through a http proxy."""
     remote_on_demand = file_remote_ssl_factory(
         manifest_path=basic_manifest_path, policy="on_demand", proxy_url=http_proxy.proxy_url
     )
@@ -64,9 +60,7 @@ def test_sync_https_through_http_proxy_with_auth(
     basic_manifest_path,
     monitor_task,
 ):
-    """
-    Test syncing https through a http proxy that requires auth.
-    """
+    """Test syncing https through a http proxy that requires auth."""
     remote_on_demand = file_remote_ssl_factory(
         manifest_path=basic_manifest_path,
         policy="on_demand",
@@ -88,9 +82,7 @@ def test_sync_https_through_http_proxy_with_auth_but_auth_not_configured(
     basic_manifest_path,
     monitor_task,
 ):
-    """
-    Test syncing https through a http proxy that requires auth, but auth is not configured.
-    """
+    """Test syncing https through a http proxy that requires auth, but auth is not configured."""
     remote_on_demand = file_remote_ssl_factory(
         manifest_path=basic_manifest_path,
         policy="on_demand",
@@ -113,9 +105,7 @@ def test_sync_http_through_https_proxy(
     basic_manifest_path,
     monitor_task,
 ):
-    """
-    Test syncing http through an https proxy.
-    """
+    """Test syncing http through an https proxy."""
     remote_on_demand = file_remote_factory(
         manifest_path=basic_manifest_path,
         policy="on_demand",
@@ -135,9 +125,7 @@ def test_sync_https_through_https_proxy(
     basic_manifest_path,
     monitor_task,
 ):
-    """
-    Test syncing http through an https proxy.
-    """
+    """Test syncing http through an https proxy."""
     if not (sys.version_info.major >= 3 and sys.version_info.minor >= 11):
         pytest.skip("HTTPS proxy only supported on python3.11+")
     remote_on_demand = file_remote_ssl_factory(

--- a/pulpcore/tests/functional/api/using_plugin/test_pulpimport.py
+++ b/pulpcore/tests/functional/api/using_plugin/test_pulpimport.py
@@ -1,5 +1,4 @@
-"""
-Tests PulpImporter and PulpImport functionality
+"""Tests PulpImporter and PulpImport functionality.
 
 NOTE: assumes ALLOWED_EXPORT_PATHS and ALLOWED_IMPORT_PATHS settings contain "/tmp" - all tests
 will fail if this is not the case.
@@ -74,7 +73,7 @@ def exporter(pulpcore_bindings, tmpdir, gen_object_with_cleanup, import_export_r
 
 @pytest.fixture
 def import_check_directory(tmp_path):
-    """Creates a directory/file structure for testing import-check"""
+    """Creates a directory/file structure for testing import-check."""
     os.makedirs(f"{tmp_path}/noreaddir")
     os.makedirs(f"{tmp_path}/nowritedir")
     os.makedirs(f"{tmp_path}/nowritedir/notafile")

--- a/pulpcore/tests/functional/api/using_plugin/test_reclaim_disk_space.py
+++ b/pulpcore/tests/functional/api/using_plugin/test_reclaim_disk_space.py
@@ -18,10 +18,8 @@ def test_reclaim_immediate_content(
     basic_manifest_path,
     monitor_task,
 ):
-    """
-    Test whether immediate repository content can be reclaimed
-    and then re-populated back after sync.
-    """
+    """Test whether immediate repository content can be reclaimed and then re-populated back after
+    sync."""
     remote = file_remote_ssl_factory(manifest_path=basic_manifest_path, policy="immediate")
 
     # sync the repository with immediate policy
@@ -88,10 +86,8 @@ def test_reclaim_on_demand_content(
     sync_repository_distribution,
     monitor_task,
 ):
-    """
-    Test whether on_demand repository content can be reclaimed
-    and then re-populated back after client request.
-    """
+    """Test whether on_demand repository content can be reclaimed and then re-populated back after
+    client request."""
     repo, remote, distribution = sync_repository_distribution(policy="on_demand")
 
     distribution_base_url = distribution_base_url(distribution.base_url)

--- a/pulpcore/tests/functional/api/using_plugin/test_repo_versions.py
+++ b/pulpcore/tests/functional/api/using_plugin/test_repo_versions.py
@@ -66,11 +66,10 @@ def test_add_remove_content(
 ):
     """Add and remove content to a repository. Verify side-effects.
 
-    A new repository version is automatically created each time content is
-    added to or removed from a repository. Furthermore, it's possible to
-    inspect any repository version and discover which content is present, which
-    content was removed, and which content was added. This test case explores
-    these features.
+    A new repository version is automatically created each time content is added to or removed from
+    a repository. Furthermore, it's possible to inspect any repository version and discover which
+    content is present, which content was removed, and which content was added. This test case
+    explores these features.
     """
     file_repo = file_repository_factory()
     repo_versions = file_bindings.RepositoriesFileVersionsApi.list(file_repo.pulp_href)

--- a/pulpcore/tests/functional/api/using_plugin/test_unlinking_repo.py
+++ b/pulpcore/tests/functional/api/using_plugin/test_unlinking_repo.py
@@ -1,4 +1,4 @@
-"""Tests that perform action over remotes"""
+"""Tests that perform action over remotes."""
 
 import pytest
 

--- a/pulpcore/tests/functional/utils.py
+++ b/pulpcore/tests/functional/utils.py
@@ -134,8 +134,8 @@ def generate_manifest(name, file_list):
 
 
 def get_files_in_manifest(url):
-    """
-    Download a File Repository manifest and return content as a list of tuples.
+    """Download a File Repository manifest and return content as a list of tuples.
+
     [(name,sha256,size),]
     """
     files = set()
@@ -146,9 +146,7 @@ def get_files_in_manifest(url):
 
 
 def get_from_url(url, auth=None, headers=None):
-    """
-    Performs a GET request on a URL and returns an aiohttp.Response object.
-    """
+    """Performs a GET request on a URL and returns an aiohttp.Response object."""
     return asyncio.run(_get_from_url(url, auth=auth, headers=headers))
 
 

--- a/pulpcore/tests/performance/test_performance.py
+++ b/pulpcore/tests/performance/test_performance.py
@@ -62,7 +62,6 @@ def test_performance(
     data = []
 
     auth = (bindings_cfg.username, bindings_cfg.password)
-
     """Measure time of synchronization."""
 
     for r in args.repositories:
@@ -91,7 +90,6 @@ def test_performance(
 
     results = [monitor_task(response.task) for response in responses]
     report_tasks_stats("Sync tasks", results)
-
     """Measure time of resynchronization."""
     responses = []
     for r in data:
@@ -101,7 +99,6 @@ def test_performance(
 
     results = [monitor_task(response.task) for response in responses]
     report_tasks_stats("Resync tasks", results)
-
     """Measure time of repository publishing."""
     responses = []
     for r in data:
@@ -151,7 +148,6 @@ def test_performance(
 
     after = datetime.datetime.utcnow()
     print_fmt_experiment_time("Repository download", before, after)
-
     """Measure time of inspecting the repository content."""
     before = datetime.datetime.utcnow()
 
@@ -171,7 +167,6 @@ def test_performance(
             pool.starmap(measureit, params)
     after = datetime.datetime.utcnow()
     print_fmt_experiment_time("Content inspection", before, after)
-
     """Measure time of repository cloning."""
     for r in data:
         r["repository_clone1_name"] = str(uuid4())
@@ -237,5 +232,5 @@ def get_results(url, params=None, auth=None):
 
 
 def list_units_in_repo_ver(content_url, repo_ver, auth=None):
-    """List the file content with all the fields"""
+    """List the file content with all the fields."""
     return get_results(content_url, params={"repository_version": repo_ver}, auth=auth)

--- a/pulpcore/tests/unit/content/test_handler.py
+++ b/pulpcore/tests/unit/content/test_handler.py
@@ -266,7 +266,10 @@ async def test_pull_through_new_remote_artifacts(request123, monkeypatch):
 @pytest.mark.asyncio
 @pytest.mark.django_db
 async def test_pull_through_metadata_file(request123, monkeypatch):
-    """Requested path is for a metadata file. Don't save response."""
+    """Requested path is for a metadata file.
+
+    Don't save response.
+    """
     handler = Handler()
     handler._stream_remote_artifact = AsyncMock()
 

--- a/pulpcore/tests/unit/content/test_heartbeat.py
+++ b/pulpcore/tests/unit/content/test_heartbeat.py
@@ -14,10 +14,8 @@ class MockException(Exception):
 
 @pytest.mark.asyncio
 async def test_db_connection_interface_error(monkeypatch, settings):
-    """
-    Test that if an InterfaceError or OperationalError is raised,
-    Handler._reset_db_connection() is called
-    """
+    """Test that if an InterfaceError or OperationalError is raised, Handler._reset_db_connection()
+    is called."""
 
     mock_aget_or_create = AsyncMock()
     mock_aget_or_create.side_effect = [InterfaceError(), OperationalError(), MockException()]

--- a/pulpcore/tests/unit/models/test_repository.py
+++ b/pulpcore/tests/unit/models/test_repository.py
@@ -44,8 +44,7 @@ def remove_content(content_pks):
 @pytest.fixture
 def verify_content_sets(content_pks):
     def _verify_content_sets(version, current, added, removed, base_version=None):
-        """
-        Verify the content, added, and removed sets for a repository version.
+        """Verify the content, added, and removed sets for a repository version.
 
         Args:
             version (pulpcore.app.models.RepositoryVersion): the version instance to verify
@@ -56,7 +55,6 @@ def verify_content_sets(content_pks):
             remove (list): "presence list" for removed content
             base_version (pulpcore.app.models.RepositoryVersion): optional base version to
                 verify the difference to
-
         """
         current_pks = set(version.content.values_list("pk", flat=True))
         added_pks = set(version.added(base_version).values_list("pk", flat=True))
@@ -125,8 +123,8 @@ def test_remove_add(repository, add_content, remove_content, verify_content_sets
 def test_multiple_adds_and_removes(repository, add_content, remove_content, verify_content_sets):
     """Verify that adding/removing content multiple times is handled properly.
 
-    Additionally, verify that other content (untouched, simple add, simple
-    remove) is not influenced and behaves as expected.
+    Additionally, verify that other content (untouched, simple add, simple remove) is not influenced
+    and behaves as expected.
     """
     # v1 == content id 0, 2, and 4
     with repository.new_version() as version1:

--- a/pulpcore/tests/unit/serializers/test_base.py
+++ b/pulpcore/tests/unit/serializers/test_base.py
@@ -12,9 +12,7 @@ from pulpcore.app.util import get_domain
 
 
 def test_unknown_field():
-    """
-    Test disjoint sets of `initial_data` with a single field and `defined_fields`.
-    """
+    """Test disjoint sets of `initial_data` with a single field and `defined_fields`."""
     initial_data = {"unknown1": "unknown"}
     defined_fields = {"field1": 1, "field2": 2}
 
@@ -24,9 +22,7 @@ def test_unknown_field():
 
 
 def test_unknown_fields():
-    """
-    Test disjoint sets of `initial_data` with multiple fields and `defined_fields`.
-    """
+    """Test disjoint sets of `initial_data` with multiple fields and `defined_fields`."""
     initial_data = {"unknown1": "unknown", "unknown2": "unknown", "unknown3": "unknown"}
     defined_fields = {"field1": 1, "field2": 2}
 
@@ -36,9 +32,7 @@ def test_unknown_fields():
 
 
 def test_mixed_initial_data():
-    """
-    Test where `defined_fields` is a proper subset of the `initial_data`.
-    """
+    """Test where `defined_fields` is a proper subset of the `initial_data`."""
     initial_data = {
         "field1": 1,
         "field2": 2,
@@ -53,9 +47,7 @@ def test_mixed_initial_data():
 
 
 def test_mixed_incomplete_initial_data():
-    """
-    Test where `initial_data` and `defined_fields` are intersecting sets.
-    """
+    """Test where `initial_data` and `defined_fields` are intersecting sets."""
     initial_data = {
         "field2": 2,
         "unknown1": "unknown",
@@ -69,9 +61,7 @@ def test_mixed_incomplete_initial_data():
 
 
 def test_empty_defined_fields():
-    """
-    Test an empty `defined_fields`.
-    """
+    """Test an empty `defined_fields`."""
     initial_data = {
         "field2": 2,
         "unknown1": "unknown",
@@ -85,19 +75,15 @@ def test_empty_defined_fields():
 
 
 def test_validate_no_unknown_fields():
-    """
-    Test where the `initial_data` is equal to `defined_fields`.
-    """
+    """Test where the `initial_data` is equal to `defined_fields`."""
     initial_data = {"field1": 1, "field2": 2}
     defined_fields = {"field1": 1, "field2": 2}
     validate_unknown_fields(initial_data, defined_fields)
 
 
 def test_validate_no_unknown_fields_no_side_effects():
-    """
-    Test validation success where the `initial_data` is equal to `defined_fields`
-    and that `initial_data` and `defined_fields` are not mutated.
-    """
+    """Test validation success where the `initial_data` is equal to `defined_fields` and that
+    `initial_data` and `defined_fields` are not mutated."""
     initial_data = {"field1": 1, "field2": 2}
     defined_fields = {"field1": 1, "field2": 2}
     validate_unknown_fields(initial_data, defined_fields)
@@ -107,9 +93,7 @@ def test_validate_no_unknown_fields_no_side_effects():
 
 
 def test_ignored_fields_no_side_effects():
-    """
-    Test ignored fields in initial data don't cause side effects
-    """
+    """Test ignored fields in initial data don't cause side effects."""
     # there's just the `csrfmiddlewaretoken` in the ignored_fields
     initial_data = {"field1": 1, "csrfmiddlewaretoken": 2}
     defined_fields = {"field1": 1}
@@ -133,7 +117,7 @@ def test_mixin_get(guard_fixture):
 
 
 def test_mixin_create(guard_fixture):
-    """Test GetOrCreateSerializerMixin's create functionality.'"""
+    """Test GetOrCreateSerializerMixin's create functionality.'."""
     natural_key = {"name": "test2", "pulp_domain": get_domain()}
     default_data = {"description": "hello"}
     guard = GuardSerializer.get_or_create(natural_key, default_data)

--- a/pulpcore/tests/unit/serializers/test_fields.py
+++ b/pulpcore/tests/unit/serializers/test_fields.py
@@ -13,10 +13,8 @@ from pulpcore.app.serializers import fields
 )
 @pytest.mark.parametrize("binary_arg", [True, False])
 def test_custom_json_dict_field(field_and_data, binary_arg):
-    """
-    On the happy overlap case,
-    pulpcore JSONDictField and JSONListField should be compatible with drf JSONField.
-    """
+    """On the happy overlap case, pulpcore JSONDictField and JSONListField should be compatible with
+    drf JSONField."""
     custom_field, data = field_and_data
     drf_json_field = serializers.JSONField(binary=binary_arg)
     custom_field = custom_field(binary=binary_arg)
@@ -38,10 +36,8 @@ def test_custom_json_dict_field(field_and_data, binary_arg):
 )
 @pytest.mark.parametrize("binary_arg", [True, False])
 def test_custom_json_dict_field_raises(field_and_data, binary_arg):
-    """
-    On the invalid data case,
-    pulpcore JSONDictField and JSONListField should raise appropriately.
-    """
+    """On the invalid data case, pulpcore JSONDictField and JSONListField should raise
+    appropriately."""
     custom_field, data = field_and_data
     custom_field = custom_field(binary=binary_arg)
     error_msg = "Invalid type"

--- a/pulpcore/tests/unit/serializers/test_orphans_cleanup.py
+++ b/pulpcore/tests/unit/serializers/test_orphans_cleanup.py
@@ -7,11 +7,9 @@ from pulpcore.app.serializers import OrphansCleanupSerializer
 
 @pytest.mark.parametrize("value", [-1, 4294967296])
 def test_orphan_protection_time(value):
-    """
-    Test that OrphansCleanupSerializer is not valid if the "orphan_protection_time"
-    value is not in the range defined by ORPHAN_PROTECTION_TIME_LOWER_BOUND
-    and ORPHAN_PROTECTION_TIME_UPPER_BOUND.
-    """
+    """Test that OrphansCleanupSerializer is not valid if the "orphan_protection_time" value is not
+    in the range defined by ORPHAN_PROTECTION_TIME_LOWER_BOUND and
+    ORPHAN_PROTECTION_TIME_UPPER_BOUND."""
     serializer = OrphansCleanupSerializer(data={"orphan_protection_time": value})
 
     with pytest.raises(serializers.ValidationError):

--- a/pulpcore/tests/unit/serializers/test_repository.py
+++ b/pulpcore/tests/unit/serializers/test_repository.py
@@ -157,9 +157,8 @@ def test_validate_checkpoint_and_repository():
 
 
 def test_validate_repo_remote_sync(monkeypatch):
-    """
-    Test that the synchronization of repository and remote fails if they are from different plugins.
-    """
+    """Test that the synchronization of repository and remote fails if they are from different
+    plugins."""
     mock_remote = Mock(spec=models.Remote)
     data = {"remote": mock_remote}
 
@@ -179,10 +178,8 @@ def test_validate_repo_remote_sync(monkeypatch):
 
 @pytest.mark.parametrize("tested_serializer", [PublicationSerializer, DistributionSerializer])
 def test_validate_repo_remote_via_repository(monkeypatch, tested_serializer):
-    """
-    Test that the publication/distribution fails if
-    "repository" has a remote of an incompatible type.
-    """
+    """Test that the publication/distribution fails if "repository" has a remote of an incompatible
+    type."""
     monkeypatch.setattr(tested_serializer, "check_cross_domains", lambda self, data: None)
 
     mock_repository = Mock(spec=models.Repository)
@@ -199,10 +196,8 @@ def test_validate_repo_remote_via_repository(monkeypatch, tested_serializer):
 
 @pytest.mark.parametrize("tested_serializer", [PublicationSerializer, DistributionSerializer])
 def test_validate_repo_remote_via_repository_version(monkeypatch, tested_serializer):
-    """
-    Test that the publication/distribution fails if repository within
-    "repository_version" has a remote of an incompatible type.
-    """
+    """Test that the publication/distribution fails if repository within "repository_version" has a
+    remote of an incompatible type."""
     monkeypatch.setattr(tested_serializer, "check_cross_domains", lambda self, data: None)
 
     mock_repository = Mock(spec=models.Repository)
@@ -222,11 +217,9 @@ def test_validate_repo_remote_via_repository_version(monkeypatch, tested_seriali
 
 @pytest.mark.parametrize("field", ["repository", "repository_version"])
 def test_validate_repo_remote_via_publication(monkeypatch, field):
-    """
-    Test that the distribution fails if "publication.repository" has a remote
-    of an incompatible type or if repository within "publication.repository_version"
-    has a remote of an incompatible type.
-    """
+    """Test that the distribution fails if "publication.repository" has a remote of an incompatible
+    type or if repository within "publication.repository_version" has a remote of an incompatible
+    type."""
     monkeypatch.setattr(DistributionSerializer, "check_cross_domains", lambda self, data: None)
 
     mock_repository = Mock(spec=models.Repository)

--- a/pulpcore/tests/unit/stages/test_artifactdownloader.py
+++ b/pulpcore/tests/unit/stages/test_artifactdownloader.py
@@ -14,9 +14,7 @@ pytestmark = pytest.mark.usefixtures("fake_domain")
 
 
 class MockException(Exception):
-    """
-    A tracer exception.
-    """
+    """A tracer exception."""
 
     pass
 
@@ -24,10 +22,9 @@ class MockException(Exception):
 class DownloaderMock:
     """Mock for a Downloader.
 
-    URLs are expected to be the delay to wait to simulate downloading,
-    e.g `url='5'` will wait for 5 seconds. Negative numbers will raise
-    an exception after waiting for the absolute value, e.g. `url=-5` fails
-    after 5 seconds.
+    URLs are expected to be the delay to wait to simulate downloading, e.g `url='5'` will wait for 5
+    seconds. Negative numbers will raise an exception after waiting for the absolute value, e.g.
+    `url=-5` fails after 5 seconds.
     """
 
     def __init__(self, **kwargs):
@@ -120,8 +117,7 @@ def queue_dc(in_q, downloader_mock):
 @pytest_asyncio.fixture
 async def download_task(event_loop, in_q, out_q):
     async def _download_task():
-        """
-        A coroutine running the downloader stage with a mocked ProgressReport.
+        """A coroutine running the downloader stage with a mocked ProgressReport.
 
         Returns:
             The done count of the ProgressReport.
@@ -238,8 +234,9 @@ async def test_sparse_batches_dont_block_stage(
     """Regression test for issue https://pulp.plan.io/issues/4018."""
 
     def queue_content_with_a_single_download(batchsize=100, delay=100):
-        """
-        Queue a batch of `batchsize` declarative_content instances. Only the
+        """Queue a batch of `batchsize` declarative_content instances.
+
+        Only the
         first one triggers a download of duration `delay`.
         """
         queue_dc(delays=[delay])

--- a/pulpcore/tests/unit/stages/test_stages.py
+++ b/pulpcore/tests/unit/stages/test_stages.py
@@ -141,7 +141,7 @@ class LastStage(Stage):
 
 @pytest.mark.asyncio
 async def test_batch_queue_and_min_sizes():
-    """Test batches iterator in a small stages setting with various sizes"""
+    """Test batches iterator in a small stages setting with various sizes."""
     for num in range(10):
         for minsize in range(1, 5):
             for qsize in range(1, num + 1):

--- a/pulpcore/tests/unit/test_cache.py
+++ b/pulpcore/tests/unit/test_cache.py
@@ -15,7 +15,7 @@ def pulp_redisdb(settings, redisdb, monkeypatch):
 
 
 def test_basic_set_get(pulp_redisdb):
-    """Tests setting value, then getting it"""
+    """Tests setting value, then getting it."""
     cache = Cache()
     cache.set("key", "hello")
     ret = cache.get("key")
@@ -26,7 +26,7 @@ def test_basic_set_get(pulp_redisdb):
 
 
 def test_basic_exists(pulp_redisdb):
-    """Tests that keys already set exist"""
+    """Tests that keys already set exist."""
     cache = Cache()
     cache.set("key", "hello")
     assert cache.exists("key")
@@ -34,7 +34,7 @@ def test_basic_exists(pulp_redisdb):
 
 
 def test_basic_delete(pulp_redisdb):
-    """Tests deleting value"""
+    """Tests deleting value."""
     cache = Cache()
     cache.set("key", "hello")
     assert cache.exists("key")
@@ -44,7 +44,7 @@ def test_basic_delete(pulp_redisdb):
 
 
 def test_basic_expires(pulp_redisdb):
-    """Tests setting values with expiration times"""
+    """Tests setting values with expiration times."""
     cache = Cache()
     cache.set("key", "hi", expires=2)
     ret = cache.get("key")
@@ -55,7 +55,7 @@ def test_basic_expires(pulp_redisdb):
 
 
 def test_group_with_base_key(pulp_redisdb):
-    """Tests grouping multiple key-values under one base-key"""
+    """Tests grouping multiple key-values under one base-key."""
     cache = Cache()
     tuples = [
         ("key1", "hi", "base1"),
@@ -78,7 +78,7 @@ def test_group_with_base_key(pulp_redisdb):
 
 
 def test_delete_base_key(pulp_redisdb):
-    """Tests deleting multiple key-values under one base-key"""
+    """Tests deleting multiple key-values under one base-key."""
     cache = Cache()
     cache.delete(base_key="base1")
     assert not cache.exists("key1", base_key="base1")
@@ -93,7 +93,7 @@ def test_delete_base_key(pulp_redisdb):
 
 
 def test_clear(pulp_redisdb):
-    """Tests clearing the cache"""
+    """Tests clearing the cache."""
     cache = Cache()
     tuples = [
         ("key", "hi", None),

--- a/pulpcore/tests/unit/test_chunked_file.py
+++ b/pulpcore/tests/unit/test_chunked_file.py
@@ -11,7 +11,7 @@ from pulpcore.app.util import Crc32Hasher, compute_file_hash
 
 
 def write_chunk_files(tmp_path: Path, data_chunks: t.List[t.ByteString]):
-    """Utility to generate chunk-files fixtures"""
+    """Utility to generate chunk-files fixtures."""
     files = {}
 
     for i, chunk_bytes in enumerate(data_chunks):
@@ -26,8 +26,7 @@ def write_chunk_files(tmp_path: Path, data_chunks: t.List[t.ByteString]):
 def create_tocfile(
     tmp_path: Path, data_chunks: t.List[t.ByteString], chunk_size: int, corrupted: bool = False
 ):
-    """
-    Utility to generate a tocfile.json and return its path.
+    """Utility to generate a tocfile.json and return its path.
 
     It can optionally generate a corrupted toc-file with wrong first checksum.
 
@@ -74,7 +73,7 @@ def create_tocfile(
     ],
 )
 def test_chunked_file_fileobj_api(tmp_path, chunks_list, chunk_size):
-    """Methods tell, read and seek works inside context manager"""
+    """Methods tell, read and seek works inside context manager."""
     contiguous_data = b"".join(chunks_list)
 
     toc_path = create_tocfile(tmp_path, data_chunks=chunks_list, chunk_size=chunk_size)

--- a/pulpcore/tests/unit/test_files.py
+++ b/pulpcore/tests/unit/test_files.py
@@ -4,9 +4,7 @@ from pulpcore.app.files import validate_file_paths
 
 
 def test_valid_paths():
-    """
-    Test for valid paths.
-    """
+    """Test for valid paths."""
     paths = ["a/b", "a/c/b", "PULP_MANIFEST", "b"]
     validate_file_paths(paths)
 
@@ -15,18 +13,14 @@ def test_valid_paths():
 
 
 def test_dupes():
-    """
-    Test for two duplicate paths.
-    """
+    """Test for two duplicate paths."""
     paths = ["a/b", "PULP_MANIFEST", "PULP_MANIFEST"]
     with pytest.raises(ValueError, match="Path errors found. Paths are duplicated: PULP_MANIFEST"):
         validate_file_paths(paths)
 
 
 def test_overlaps():
-    """
-    Test for overlapping paths.
-    """
+    """Test for overlapping paths."""
     paths = ["a/b", "a/b/c"]
     with pytest.raises(ValueError):
         validate_file_paths(paths)

--- a/pulpcore/tests/unit/test_pulp_urls.py
+++ b/pulpcore/tests/unit/test_pulp_urls.py
@@ -13,8 +13,9 @@ def api_root(settings):
 
 
 def test_urlize_basic_url():
-    """
-    Text starts with V3_API_ROOT. Should be made clickable.
+    """Text starts with V3_API_ROOT.
+
+    Should be made clickable.
     """
     txt = "/baz/api/v3/foo/bar/"
     ret = pulp_urls.urlize(txt)
@@ -22,8 +23,9 @@ def test_urlize_basic_url():
 
 
 def test_urlize_quoted_href():
-    """
-    Text contains V3_API_ROOT in quotes. Should be made clickable.
+    """Text contains V3_API_ROOT in quotes.
+
+    Should be made clickable.
     """
     txt = json.dumps({"pulp_href": "/baz/api/v3/foo/bar/"})
     ret = pulp_urls.urlize(txt)
@@ -34,9 +36,7 @@ def test_urlize_quoted_href():
 
 
 def test_urlize_mixed_bag():
-    """
-    Text contains lots of stuff in json.
-    """
+    """Text contains lots of stuff in json."""
     txt = json.dumps(
         {
             "pulp_href": "/baz/api/v3/foo/bar/",
@@ -56,8 +56,9 @@ def test_urlize_mixed_bag():
 
 
 def test_urlize_quoted_href_no_autoescape():
-    """
-    Text contains V3_API_ROOT in quotes. Should be made clickable.
+    """Text contains V3_API_ROOT in quotes.
+
+    Should be made clickable.
     """
     txt = json.dumps({"pulp_href": "/baz/api/v3/foo/bar/"})
     ret = pulp_urls.urlize(txt, autoescape=False)
@@ -67,8 +68,9 @@ def test_urlize_quoted_href_no_autoescape():
 
 
 def test_urlize_url_xss_autoescape():
-    """
-    Text starts with API_ROOT, includes XSS. Should be made clickable, escape XSS.
+    """Text starts with API_ROOT, includes XSS.
+
+    Should be made clickable, escape XSS.
     """
     txt = "/baz/api/v3/foo/bar/<script>alert('ALERT!')</script>blech/"
     escapified_linked_text = (
@@ -80,8 +82,9 @@ def test_urlize_url_xss_autoescape():
 
 
 def test_urlize_url_xss_no_autoescape():
-    """
-    Text starts with API_ROOT, includes XSS. Should be made clickable, not escape XSS.
+    """Text starts with API_ROOT, includes XSS.
+
+    Should be made clickable, not escape XSS.
     """
     txt = "/baz/api/v3/foo/bar/<script>alert('ALERT!')</script>blech/"
     escapified_linked_text = (
@@ -93,8 +96,9 @@ def test_urlize_url_xss_no_autoescape():
 
 
 def test_urlize_autoescape():
-    """
-    Text contains XSS. Expect escaped.
+    """Text contains XSS.
+
+    Expect escaped.
     """
     txt = "foo/bar/<script>alert('ALERT!')</script>blech/"
     ret = pulp_urls.urlize(txt)
@@ -102,8 +106,9 @@ def test_urlize_autoescape():
 
 
 def test_urlize_no_autoescape():
-    """
-    Text contains XSS. Expect not escaped.
+    """Text contains XSS.
+
+    Expect not escaped.
     """
     txt = "foo/bar/<script>alert('ALERT!')</script>blech/"
     ret = pulp_urls.urlize(txt, autoescape=False)

--- a/pulpcore/tests/unit/test_util.py
+++ b/pulpcore/tests/unit/test_util.py
@@ -8,25 +8,19 @@ pytestmark = pytest.mark.usefixtures("fake_domain")
 
 
 def test_get_view_name_for_model_with_object():
-    """
-    Use Repository as an example that should work.
-    """
+    """Use Repository as an example that should work."""
     ret = util.get_view_name_for_model(models.Artifact(), "foo")
     assert ret == "artifacts-foo"
 
 
 def test_get_view_name_for_model_with_model():
-    """
-    Use Repository as an example that should work.
-    """
+    """Use Repository as an example that should work."""
     ret = util.get_view_name_for_model(models.Artifact, "foo")
     assert ret == "artifacts-foo"
 
 
 def test_get_view_name_for_model_not_found(monkeypatch):
-    """
-    Given an unknown viewset (in this case a Mock()), this should raise LookupError.
-    """
+    """Given an unknown viewset (in this case a Mock()), this should raise LookupError."""
     monkeypatch.setattr(util, "get_viewset_for_model", mock.Mock())
     with pytest.raises(LookupError):
         util.get_view_name_for_model(mock.Mock(), "foo")

--- a/pulpcore/tests/unit/test_viewsets.py
+++ b/pulpcore/tests/unit/test_viewsets.py
@@ -16,16 +16,14 @@ if settings.API_ROOT_REWRITE_HEADER:
 
 
 class TestGetResource(TestCase):
-    """
-    Test NamedViewSet from core using some detail endpoints provided by file.
+    """Test NamedViewSet from core using some detail endpoints provided by file.
 
     Note: This is really a pulpcore test, but we can't test it from pulpcore.
     """
 
     def test_no_errors(self):
-        """
-        Tests that get_resource() properly resolves a valid URI and returns the correct resource.
-        """
+        """Tests that get_resource() properly resolves a valid URI and returns the correct
+        resource."""
 
         repo = models.FileRepository.objects.create(name="foo")
         viewset = viewsets.FileRepositoryViewSet()
@@ -36,9 +34,8 @@ class TestGetResource(TestCase):
         assert repo == resource
 
     def test_multiple_matches(self):
-        """
-        Tests that get_resource() raises a ValidationError if you attempt to use a list endpoint.
-        """
+        """Tests that get_resource() raises a ValidationError if you attempt to use a list
+        endpoint."""
         models.FileRepository.objects.create(name="foo")
         models.FileRepository.objects.create(name="foo2")
         viewset = viewsets.FileRepositoryViewSet()
@@ -51,19 +48,15 @@ class TestGetResource(TestCase):
             )
 
     def test_invalid_uri(self):
-        """
-        Tests that get_resource raises a ValidationError if you attempt to use an invalid URI.
-        """
+        """Tests that get_resource raises a ValidationError if you attempt to use an invalid URI."""
         viewset = viewsets.FileRepositoryViewSet()
 
         with self.assertRaises(DRFValidationError):
             viewset.get_resource("/pulp/api/v2/nonexistent/", models.FileRepository)
 
     def test_resource_does_not_exist(self):
-        """
-        Tests that get_resource() raises a ValidationError if you use a URI for a resource that
-        does not exist.
-        """
+        """Tests that get_resource() raises a ValidationError if you use a URI for a resource that
+        does not exist."""
         pk = uuid4()
         viewset = viewsets.FileRepositoryViewSet()
 
@@ -74,10 +67,8 @@ class TestGetResource(TestCase):
             )
 
     def test_resource_with_field_error(self):
-        """
-        Tests that get_resource() raises a ValidationError if you use a URI that is not a valid
-        model.
-        """
+        """Tests that get_resource() raises a ValidationError if you use a URI that is not a valid
+        model."""
         repo = models.FileRepository.objects.create(name="foo")
         viewset = viewsets.FileRepositoryViewSet()
 

--- a/pulpcore/tests/unit/viewsets/test_viewset_base.py
+++ b/pulpcore/tests/unit/viewsets/test_viewset_base.py
@@ -9,10 +9,8 @@ from pulpcore.app import models, serializers, viewsets
 
 @pytest.mark.django_db
 def test_adds_filters():
-    """
-    Tests to make sure the correct lookup is being added to the queryset based on its
-    'parent_lookup_kwargs' value.
-    """
+    """Tests to make sure the correct lookup is being added to the queryset based on its
+    'parent_lookup_kwargs' value."""
     repo = models.Repository.objects.create(name="foo")
     repo2 = models.Repository.objects.create(name="foo2")
     # no concurrency so this is fine
@@ -28,10 +26,8 @@ def test_adds_filters():
 
 @pytest.mark.django_db
 def test_does_not_add_filters():
-    """
-    Tests to make sure no filters are applied, based on its empty 'parent_lookup_kwargs'
-    value.
-    """
+    """Tests to make sure no filters are applied, based on its empty 'parent_lookup_kwargs'
+    value."""
     models.Repository.objects.create(name="foo")
     viewset = viewsets.RepositoryViewSet()
     viewset.kwargs = {"name": "foo"}
@@ -42,10 +38,8 @@ def test_does_not_add_filters():
 
 
 def test_must_define_serializer_class():
-    """
-    Test that get_serializer_class() raises an AssertionError if you don't define the
-    serializer_class attribute.
-    """
+    """Test that get_serializer_class() raises an AssertionError if you don't define the
+    serializer_class attribute."""
 
     class TestTaskViewSet(viewsets.NamedModelViewSet):
         minimal_serializer_class = serializers.MinimalTaskSerializer
@@ -55,10 +49,8 @@ def test_must_define_serializer_class():
 
 
 def test_serializer_class():
-    """
-    Tests that get_serializer_class() returns the serializer_class attribute if it exists,
-    and that it doesn't error if no minimal serializer is defined, but minimal=True.
-    """
+    """Tests that get_serializer_class() returns the serializer_class attribute if it exists, and
+    that it doesn't error if no minimal serializer is defined, but minimal=True."""
 
     class TestTaskViewSet(viewsets.NamedModelViewSet):
         serializer_class = serializers.TaskSerializer
@@ -74,9 +66,8 @@ def test_serializer_class():
 
 
 def test_minimal_query_param():
-    """
-    Tests that get_serializer_class() returns the correct serializer in the correct situations.
-    """
+    """Tests that get_serializer_class() returns the correct serializer in the correct
+    situations."""
 
     class TestTaskViewSet(viewsets.NamedModelViewSet):
         serializer_class = serializers.TaskSerializer
@@ -101,10 +92,8 @@ def test_minimal_query_param():
 
 @pytest.mark.django_db
 def test_no_parent_object():
-    """
-    Tests that get_parent_field_and_object() raises django.http.Http404 if the parent object
-    does not exist on a nested viewset.
-    """
+    """Tests that get_parent_field_and_object() raises django.http.Http404 if the parent object does
+    not exist on a nested viewset."""
     viewset = viewsets.RepositoryVersionViewSet()
     viewset.kwargs = {"repository_pk": 500}
 
@@ -114,10 +103,8 @@ def test_no_parent_object():
 
 @pytest.mark.django_db
 def test_get_parent_field_and_object():
-    """
-    Tests that get_parent_field_and_object() returns the correct parent field and parent
-    object.
-    """
+    """Tests that get_parent_field_and_object() returns the correct parent field and parent
+    object."""
     repo = models.Repository.objects.create(name="foo")
     viewset = viewsets.RepositoryVersionViewSet()
     viewset.kwargs = {"repository_pk": repo.pk}
@@ -127,9 +114,7 @@ def test_get_parent_field_and_object():
 
 @pytest.mark.django_db
 def test_get_parent_object():
-    """
-    Tests that get_parent_object() returns the correct parent object.
-    """
+    """Tests that get_parent_object() returns the correct parent object."""
     repo = models.Repository.objects.create(name="foo")
     viewset = viewsets.RepositoryVersionViewSet()
     viewset.kwargs = {"repository_pk": repo.pk}
@@ -138,8 +123,6 @@ def test_get_parent_object():
 
 
 def test_get_nest_depth():
-    """
-    Test that _get_nest_depth() returns the correct nesting depths.
-    """
+    """Test that _get_nest_depth() returns the correct nesting depths."""
     assert viewsets.RepositoryViewSet._get_nest_depth() == 1
     assert viewsets.RepositoryVersionViewSet._get_nest_depth() == 2


### PR DESCRIPTION
Follow up to this thread: https://discourse.pulpproject.org/t/consistent-docstring-formatting/1108/5

## Command
```bash
docformatter -s google --wrap-summaries 100 --wrap-descriptions 100 --exclude tests --in-place -r pulpcore
```

## Considerations

* What is does:
  * Strip lines and whitespaces
  * Enforces line length breaks
  * Enforces structure of summary (oneliner) + . + space + description.
* Limitations
  * Does not enforces or validates a docstring style (e.g, google). E.g:
    * Check Args match method/function signature
    * Check if Args should or not have types (or types should be only on signature)
    * Has correct sections
    * Forbid other styles
* Others:
   * Some configurations of this formatter could reduce the amout of changes.
    
    For example, a lot of changes  are first line-break-strips of summary lines, but it should be possible to enforce the prevalent form used. (although I prefer the changed form).
    
    ```diff
    -"""Base pulpcore module."""
    +"""
    +Base pulpcore module.
    +"""
    ```
## Conclusion

It's a nice step for general consistency, but not enough. Follow ups:
1. Define/Agree on style rules for this general auto-formatting (optional).
2. Find/configure another tool that can do some docstring sytle enforcement. E.g [pydoclint](https://github.com/jsh9/pydoclint)