### PR TITLE
[PULP-570] Mark a failed heartbeat as a catastrophic failure

### DIFF
--- a/CHANGES/heartbeat.bugfix
+++ b/CHANGES/heartbeat.bugfix
@@ -1,0 +1,1 @@
+Made a failure to update the heartbeat catastrophic, so we can actually rely on workers that claim to be "online".

--- a/pulpcore/app/models/status.py
+++ b/pulpcore/app/models/status.py
@@ -103,6 +103,18 @@ class BaseAppStatus(BaseModel):
         """
         self.save(update_fields=["last_heartbeat"])
 
+    async def asave_heartbeat(self):
+        """
+        Update the last_heartbeat field to now and save it.
+
+        Only the last_heartbeat field will be saved. No other changes will be saved.
+
+        Raises:
+            ValueError: When the model instance has never been saved before. This method can
+                only update an existing database record.
+        """
+        await self.asave(update_fields=["last_heartbeat"])
+
     class Meta:
         abstract = True
 

--- a/pulpcore/tests/unit/content/test_heartbeat.py
+++ b/pulpcore/tests/unit/content/test_heartbeat.py
@@ -12,22 +12,25 @@ class MockException(Exception):
     pass
 
 
+@pytest.mark.parametrize("error_class", [InterfaceError, OperationalError])
 @pytest.mark.asyncio
-async def test_db_connection_interface_error(monkeypatch, settings):
+async def test_db_connection_interface_error(monkeypatch, settings, error_class):
     """
     Test that if an InterfaceError or OperationalError is raised,
     Handler._reset_db_connection() is called
     """
 
-    mock_aget_or_create = AsyncMock()
-    mock_aget_or_create.side_effect = [InterfaceError(), OperationalError(), MockException()]
-    monkeypatch.setattr(ContentAppStatus.objects, "aget_or_create", mock_aget_or_create)
+    mock_app_status = AsyncMock()
+    mock_app_status.asave_heartbeat.side_effect = [error_class(), error_class()]
+    mock_acreate = AsyncMock()
+    mock_acreate.return_value = mock_app_status
+    monkeypatch.setattr(ContentAppStatus.objects, "acreate", mock_acreate)
     mock_reset_db = Mock()
     monkeypatch.setattr(Handler, "_reset_db_connection", mock_reset_db)
     settings.CONTENT_APP_TTL = 1
 
-    with pytest.raises(MockException):
+    with pytest.raises(SystemExit):
         await _heartbeat()
 
-    mock_aget_or_create.assert_called()
-    mock_reset_db.assert_has_calls([call(), call()])
+    mock_app_status.asave_heartbeat.assert_called()
+    mock_reset_db.assert_has_calls([call()])


### PR DESCRIPTION
This is supposed to dectect situations where the workers fail to reach the database and therefore any type of network partitioning. By theory this should improve consistency in the face of partitioning. It sacrifices only the avaliablility of workers, that would not reach the database anyway to perform anything meaningful.