### PR TITLE
Update docs publish script to use new pulp-docs build commands

### DIFF
--- a/.github/workflows/scripts/build_all_docs.sh
+++ b/.github/workflows/scripts/build_all_docs.sh
@@ -4,6 +4,8 @@
 
 set -euv
 
+FETCHDIR="/tmp/fetchdir"
 pip install git+https://github.com/pulp/pulp-docs.git
-pulp-docs build
+pulp-docs fetch --dest "$FETCHDIR"
+pulp-docs build --path "$FETCHDIR"
 tar cvf pulpproject.org.tar site


### PR DESCRIPTION
This is a final change to transition to the revamped pulp-docs effort: https://issues.redhat.com/browse/PULP-385
Without it, the docs publish will fail, since the rewrite feature branch is already merged into main and has some breaking changes to the API.