### PR TITLE
Upper lowerbound for aiodns to fix hanging issue

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ classifiers=[
 ]
 requires-python = ">=3.9"
 dependencies = [
-  "aiodns>=3.0,<=3.5.0",
+  "aiodns>=3.3,<=3.5.0",
   "aiofiles>=22.1,<24.2.0",
   "aiohttp>=3.8.1,<3.13",  # semver https://docs.aiohttp.org/en/stable/faq.html#what-is-the-api-stability-and-deprecation-policy
   "asyncio-throttle>=1.0,<=1.0.2",


### PR DESCRIPTION
I've conducted some tests with the script below (independent from any Pulp logic) and tested that agains't a combination of python, aiodns and pycares versions, almost no changes (see below). 
The result were are marked `x` for hanging and `ok` for not-hanging. 

As the result shows, it has some unstable behavior for aiodns-3.2 combinations, but works for >=3.3 combinations.

**script.py**
```python
import aiohttp
import asyncio
import logging

logging.basicConfig(level=logging.DEBUG)
URL = "http://example.com"

async def main():
    async with aiohttp.ClientSession() as session:
        async with session.get(URL) as response:
            return response.status

status = asyncio.run(main())
assert status == 200, status
```

**results**
```
pycares==4.8 aiodns==3.2
py3.9  ok
py3.10 ok
py3.11 ok
py3.12 ok
py3.13 ok

pycares==4.9 aiodns==3.2
py3.9  x
py3.10 x
py3.11 x
py3.12 ok
py3.13 ok

pycares==4.8 aiodns==3.2
pycares==4.9 aiodns==3.3
pycares==4.8 aiodns==3.3
pycares==4.8 aiodns==3.4
pycares==4.8 aiodns==3.4
py3.9  ok
py3.10 ok
py3.11 ok
py3.12 ok
py3.13 ok
```

**Diff between python versions** (equal for every aiodns x pycares combination):
```diff
venv39.output venv310.output
No changes.

venv310.output venv311.output
diff --git a/venv310.output b/venv311.output
index 4faf2be..d7e6177 100644
--- a/venv310.output
+++ b/venv311.output
@@ -5 +4,0 @@ aiosignal==1.3.2
-async-timeout==5.0.1
@@ -8 +6,0 @@ cffi==1.17.1
-exceptiongroup==1.3.0
@@ -20,2 +17,0 @@ pytest==8.4.0
-tomli==2.2.1
-typing_extensions==4.14.0

venv311.output venv312.output
No changes.

venv312.output venv313.output
No changes.
```