### PR TITLE
Add a python version to pycares constraint

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -22,7 +22,8 @@ importlib-metadata>=6.0.1,<=6.0.1  # Pinned to fix opentelemetry dependency solv
 jinja2>=3.1,<=3.1.6
 json_stream>=2.3.2,<2.4
 jq>=1.6.0,<1.9.0
-pycares<4.9  # pycares==4.9 + aiodns==3.2.0 + python<3.12 = trouble
+# pycares is only a transitive dependency, but there is a combination of versions that expresses a bug.
+pycares<4.9;python_version<'3.12'  # pycares==4.9 + aiodns==3.2.0 + python<3.12 = trouble
 PyOpenSSL<26.0
 opentelemetry-distro[otlp]>=0.45b0,<=0.48b0
 opentelemetry-exporter-otlp-proto-http>=1.24.0,<=1.27.0


### PR DESCRIPTION
This should allow to install newer version if a recent version of python is used. It also documents nicely when exactly we can remove the constraint again.

(cherry picked from commit e864761b326616ff63e448feebce51addddc1b61)