### PR TITLE
Fix RepositoryVersion.content query failing when >65K units

### DIFF
--- a/CHANGES/6772.bugfix
+++ b/CHANGES/6772.bugfix
@@ -1,0 +1,1 @@
+Fixed the new content set optimization failing when the RepositoryVersion grew larger than 65K content units.

--- a/pulpcore/app/models/repository.py
+++ b/pulpcore/app/models/repository.py
@@ -890,7 +890,15 @@ class RepositoryVersion(BaseModel):
         if content_qs is None:
             content_qs = Content.objects
 
-        return content_qs.filter(pk__in=self._get_content_ids())
+        content_ids = self._get_content_ids()
+        if isinstance(content_ids, list) and len(content_ids) >= 65535:
+            # Workaround for PostgreSQL's limit on the number of parameters in a query
+            content_ids = (
+                RepositoryVersion.objects.filter(pk=self.pk)
+                .annotate(cids=Func(F("content_ids"), function="unnest"))
+                .values_list("cids", flat=True)
+            )
+        return content_qs.filter(pk__in=content_ids)
 
     @property
     def content(self):


### PR DESCRIPTION
fixes: #6772

This is the orm magic breaks down to this sql:
```SQL
SELECT *
FROM "core_content" 
WHERE "core_content"."pulp_id" IN (
    SELECT unnest(U0."content_ids") AS "cids" 
    FROM "core_repositoryversion" U0
    WHERE U0."pulp_id" = 01980713-3ed0-7f9a-b1f5-20e774f746ae
)
```