### PR TITLE
Add a setting to set the bucket boundaries for the API request duration metric.

### DIFF
--- a/CHANGES/6845.feature
+++ b/CHANGES/6845.feature
@@ -1,0 +1,1 @@
+Added a configurable bucket boundary for API request duration metric using the OTEL_PULP_API_HISTOGRAM_BUCKETS setting.

--- a/docs/admin/learn/architecture.md
+++ b/docs/admin/learn/architecture.md
@@ -165,3 +165,12 @@ steps:
 The information above is sent to the collector in the form of metrics. Thus, the data is  emitted
 either based on the user interaction with the system or on a regular basis. Consult
 [OpenTelemetry Metrics](https://opentelemetry.io/docs/concepts/signals/metrics/) to learn more.
+
+By default, the API request duration uses the default bucket boundaries from the OpenTelemetry SDK.
+It's possible to override it by setting a list of floats to the `OTEL_PULP_API_HISTOGRAM_BUCKETS`
+setting. For example:
+
+```
+OTEL_PULP_API_HISTOGRAM_BUCKETS = [0.005, 0.01, 0.025, 0.05, 0.075, 0.1, 0.25, 0.5, 0.75, 1.0, 2.5, 5.0, 7.5, 10.0]
+```
+

--- a/pulpcore/app/settings.py
+++ b/pulpcore/app/settings.py
@@ -421,6 +421,7 @@ KAFKA_SASL_PASSWORD = None
 
 # opentelemetry settings
 OTEL_ENABLED = False
+OTEL_PULP_API_HISTOGRAM_BUCKETS = []
 
 # Replaces asyncio event loop with uvloop
 UVLOOP_ENABLED = False
@@ -519,6 +520,16 @@ authentication_json_header_openapi_security_scheme_validator = Validator(
     messages={"is_type_of": "{name} must be a dictionary."},
 )
 
+otel_pulp_api_histogram_buckets_validator = Validator(
+    "OTEL_PULP_API_HISTOGRAM_BUCKETS",
+    is_type_of=list,
+    condition=lambda v: all([isinstance(value, float) for value in v]),
+    messages={
+        "is_type_of": "{name} must be a list.",
+        "condition": "All buckets must be declared as a float value",
+    },
+)
+
 
 def otel_middleware_hook(settings):
     data = {"dynaconf_merge": True}
@@ -545,6 +556,7 @@ settings = DjangoDynaconf(
         unknown_algs_validator,
         json_header_auth_validator,
         authentication_json_header_openapi_security_scheme_validator,
+        otel_pulp_api_histogram_buckets_validator,
     ],
     post_hooks=(otel_middleware_hook,),
 )


### PR DESCRIPTION
Closes #6845
