### PR TITLE
Fix RequiredVersion migration check

### DIFF
--- a/CHANGES/+migration_check.bugfix
+++ b/CHANGES/+migration_check.bugfix
@@ -1,0 +1,1 @@
+Fixed a bug that prevents migrations from running.


### PR DESCRIPTION
Modern components know how to clean up their status entries, so the check for migrations should not even depend them being missing.