### PR TITLE
Set OpenAPI version back to 3.0.3.

### DIFF
--- a/pulpcore/app/settings.py
+++ b/pulpcore/app/settings.py
@@ -328,7 +328,7 @@ CACHE_SETTINGS = {
 REMOTE_CONTENT_FETCH_FAILURE_COOLDOWN = 5 * 60  # 5 minutes
 
 SPECTACULAR_SETTINGS = {
-    "OAS_VERSION": "3.1.1",
+    "OAS_VERSION": "3.0.3",
     "SERVE_URLCONF": ROOT_URLCONF,
     "DEFAULT_GENERATOR_CLASS": "pulpcore.openapi.PulpSchemaGenerator",
     "DEFAULT_SCHEMA_CLASS": "pulpcore.openapi.PulpAutoSchema",


### PR DESCRIPTION
3.1.x results in client-binding-generation failures. Putting us back to 3.0.3 to give us some runway to address the oapi-generator issue.