### PR TITLE
Remove support for non-async immediate tasks

### DIFF
--- a/CHANGES/plugin_api/+remove-sync-immediate-suport.removal
+++ b/CHANGES/plugin_api/+remove-sync-immediate-suport.removal
@@ -1,0 +1,1 @@
+Removed support for synchronous immediate tasks.


### PR DESCRIPTION
I forget to remove this for 3.85, as announced in https://github.com/pulp/pulpcore/pull/6155
Because we just released 3.85 and are working on related issues, I'm doing it a little late and backporting it.

It's not clear if plugins have to take any action about that. I don't think so...