### PR TITLE
Fix app_lock-aquire filter query

### DIFF
--- a/CHANGES/6899.bugfix
+++ b/CHANGES/6899.bugfix
@@ -1,0 +1,1 @@
+Fixed error case where worker tried to aquire the app_lock for a Task that was already finished.


### PR DESCRIPTION
closes: #6899

---

According to the logs:
1. $W_A$ dispatched $T_0$
2. $W_B$ aquired $T_0$ and finished it
3. $W_A$ tries to get $T_0$

If $W_A$ tried to get $T_0$ after it was finished, it must have entered the `iter_task` for-loop when $T_0$ was in an `INCOMPLETE_STATE` (waiting or finished, in this case), otherwise it wouldn't have seen it.

Because of the timings, that could only have happened if it stayed in that for-loop for at least ~20s, which is odd.

Anyway, that check should ensure it won't try to acquire a Task `app_lock` if for *some-reason* it didnt know it was already finished.