### PR TITLE
Fix parameters passed for GCS URL generation

### DIFF
--- a/CHANGES/6917.bugfix
+++ b/CHANGES/6917.bugfix
@@ -1,0 +1,1 @@
+Fixed generation of signed URLs when using GCS as the storage backend.

--- a/pulpcore/constants.py
+++ b/pulpcore/constants.py
@@ -101,14 +101,11 @@ AZURE_RESPONSE_HEADER_MAP = {
     "Content-Language": "content_language",
     "Content-Encoding": "content_encoding",
 }
-# https://gcloud.readthedocs.io/en/latest/storage-blobs.html
+# https://gcloud.readthedocs.io/en/latest/storage-blobs.html#google.cloud.storage.blob.Blob.generate_signed_url
 # response-headers Google Cloud Storage respects, and what they map to in a GCS object
 GCS_RESPONSE_HEADER_MAP = {
-    "Content-Disposition": "content_disposition",
-    "Content-Type": "content_type",
-    "Cache-Control": "cache_control",
-    "Content-Language": "content_language",
-    "Content-Encoding": "content_encoding",
+    "Content-Disposition": "response_disposition",
+    "Content-Type": "response_type",
 }
 
 # Storage-type mapped to storage-response-map


### PR DESCRIPTION
When GCP support was originally added in https://github.com/pulp/pulpcore/pull/3481, the parameters were `response_disposition` and `content_type`. When it was refactored in https://github.com/pulp/pulpcore/pull/4251, the headers for GCS were mistakenly changed and expanded.

These parameters get used by `generate_signed_url` method defined in https://github.com/googleapis/python-storage/blob/a8109e0/google/cloud/storage/blob.py#L463, through
https://github.com/jschneier/django-storages/blob/758ad6f/storages/backends/gcloud.py#L350

This PR ensures only the supported parameters are passed to that function call.

closes #6917 