### PR TITLE
Change how the exceptions are propagated on the Content instrumentation middleware.

### DIFF
--- a/CHANGES/6925.bugfix
+++ b/CHANGES/6925.bugfix
@@ -1,0 +1,1 @@
+Fixed exception propagation in the pulp-content instrumentation middleware.


### PR DESCRIPTION
Closes #6925
