### PR TITLE
Enable immediate task from content app (2/2)

### DIFF
--- a/CHANGES/+task-immediate.misc
+++ b/CHANGES/+task-immediate.misc
@@ -1,0 +1,1 @@
+Enabled immediate tasks from content app to be prioritized.

--- a/pulpcore/tests/unit/content/test_handler.py
+++ b/pulpcore/tests/unit/content/test_handler.py
@@ -561,7 +561,7 @@ async def test_pull_through_repository_add(request123, monkeypatch):
 @pytest_asyncio.fixture
 async def app_status(monkeypatch):
     monkeypatch.setattr(AppStatus.objects, "_current_app_status", None)
-    app_status = await AppStatus.objects.acreate(app_type="content", name="test_runner")
+    app_status = await AppStatus.objects.acreate(app_type="api", name="test_runner")
     yield app_status
     await app_status.adelete()
 


### PR DESCRIPTION
When requiring immediate tasks to be async, we had a problem dispatching them from the content app due to the use of django transactions in the dispatch code and how that plays with asyncio.

Now that we no longer have that (due to the app_lock implementation) we can remove the workaround we had in place and prioritize immediate tasks on the worker.