### PR TITLE
[PULP-785] Remove advisory lock from janitorial work

### DIFF
--- a/CHANGES/+janitor_coordination.feature
+++ b/CHANGES/+janitor_coordination.feature
@@ -1,0 +1,1 @@
+Removed the use of session scoped advisory locks from workers janitorial work.

--- a/pulpcore/constants.py
+++ b/pulpcore/constants.py
@@ -6,11 +6,10 @@ from types import SimpleNamespace
 # The group will be 0.
 # The numbers are randomly chosen.
 # !!! Never change these values !!!
-TASK_DISPATCH_LOCK = 21
 TASK_SCHEDULING_LOCK = 42
 TASK_UNBLOCKING_LOCK = 84
-TASK_METRICS_HEARTBEAT_LOCK = 74
-STORAGE_METRICS_LOCK = 72
+TASK_METRICS_LOCK = 74
+WORKER_CLEANUP_LOCK = 11
 
 # Reasons to send along a task worker wakeup call.
 TASK_WAKEUP_UNBLOCK = "unblock"

--- a/pulpcore/exceptions/__init__.py
+++ b/pulpcore/exceptions/__init__.py
@@ -1,5 +1,4 @@
 from .base import (
-    AdvisoryLockError,
     PulpException,
     ResourceImmutableError,
     TimeoutException,

--- a/pulpcore/exceptions/base.py
+++ b/pulpcore/exceptions/base.py
@@ -64,10 +64,6 @@ class ResourceImmutableError(PulpException):
         return msg
 
 
-class AdvisoryLockError(Exception):
-    """Exception to signal that a lock could not be acquired."""
-
-
 class TimeoutException(PulpException):
     """
     Exception to signal timeout error.


### PR DESCRIPTION
All the corresponding cleanup work can equally well be organized using advisory locks within a transaction.