### PR TITLE
Revert "Add changes required by django 5"

### DIFF
--- a/CHANGES/+revert-django5.misc
+++ b/CHANGES/+revert-django5.misc
@@ -1,0 +1,1 @@
+Reverted Django upperbound bump to 5.2 as it may break plugins.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ dependencies = [
   "backoff>=2.1.2,<2.3",  # Looks like only bugfixes in z-Stream.
   "click>=8.1.0,<8.3",  # Uses milestone.feature.fix https://palletsprojects.com/versions .
   "cryptography>=44.0.3,<47.0",  # SemVer compatible https://cryptography.io/en/latest/api-stability/#versioning .
-  "Django>=4.2.24,<5.3",  # LTS version, switch only if we have a compelling reason to".
+  "Django~=4.2.0",  # LTS version, switch only if we have a compelling reason to".
   "django-filter>=23.1,<=25.1",  # Uses CalVer, not released often https://github.com/carltongibson/django-filter
   "django-guid>=3.3.0,<3.6",  # Looks like only bugfixes in z-Stream.
   "django-import-export>=2.9,<3.4.0",


### PR DESCRIPTION
This is a breaking change, as it may break users who have a custom installation. For example, one can update pulpcore to the version that can use Django 5, but some of the plugins are in versions that doesn't fully support it yet.

This reverts commit 70c670b03a1a5ae7c753e321c534bb569b449a67.