### PR TITLE
Fix immediate tasks from content app getting stuck in waiting

### DIFF
--- a/CHANGES/+content-immediate-task.bugfix
+++ b/CHANGES/+content-immediate-task.bugfix
@@ -1,0 +1,1 @@
+Fixed immediate tasks from the content app getting stuck in waiting.


### PR DESCRIPTION
Tasks from the content app never get executed immediately, even if marked as so, thus they need to be deferred to the task workers. However we were setting their app_lock to the content worker and never sending the unblock signal, so they would not get picked up by the task workers.