### PR TITLE
Allow adding custom metadata to exports

### DIFF
--- a/CHANGES/6712.feature
+++ b/CHANGES/6712.feature
@@ -1,0 +1,1 @@
+Updated API to allow adding custom metadata to exports

--- a/pulpcore/app/serializers/exporter.py
+++ b/pulpcore/app/serializers/exporter.py
@@ -125,7 +125,7 @@ class PulpExportSerializer(ExportSerializer):
     )
 
     toc_info = fields.JSONDictField(
-        help_text=_("Filename and sha256-checksum of table-of-contents for this export"),
+        help_text=_("Filename, sha256-checksum and meta of table-of-contents for this export"),
         read_only=True,
     )
 
@@ -162,6 +162,12 @@ class PulpExportSerializer(ExportSerializer):
     start_versions = RepositoryVersionRelatedField(
         help_text=_("List of explicit last-exported-repo-version hrefs (replaces last_export)."),
         many=True,
+        required=False,
+        write_only=True,
+    )
+
+    meta = serializers.DictField(
+        help_text=_("Dictionary of meta information about the export. Stored in the TOC JSON."),
         required=False,
         write_only=True,
     )
@@ -248,6 +254,7 @@ class PulpExportSerializer(ExportSerializer):
             "output_file_info",
             "start_versions",
             "toc_info",
+            "meta",
         )
 
 

--- a/pulpcore/app/tasks/export.py
+++ b/pulpcore/app/tasks/export.py
@@ -381,6 +381,8 @@ def pulp_export(exporter_pk, params):
     the_export.validated_start_versions = serializer.validated_data.get("start_versions", None)
     the_export.validated_chunk_size = serializer.validated_data.get("chunk_size", None)
 
+    meta = serializer.validated_data.get("meta", {})
+
     hasher = Crc32Hasher
     checksum_type = "crc32"
     try:
@@ -450,6 +452,7 @@ def pulp_export(exporter_pk, params):
         with open(output_file_info_path, "w") as outfile:
             table_of_contents = {
                 "meta": {
+                    **meta,
                     "checksum_type": checksum_type,
                 },
                 "files": {},
@@ -466,7 +469,7 @@ def pulp_export(exporter_pk, params):
         # store toc info
         toc_hash = compute_file_hash(output_file_info_path)
         the_export.output_file_info[output_file_info_path] = toc_hash
-        the_export.toc_info = {"file": output_file_info_path, "sha256": toc_hash}
+        the_export.toc_info = {"file": output_file_info_path, "sha256": toc_hash, "meta": meta}
     finally:
         # whatever may have happened, make sure we save the export
         the_export.save()


### PR DESCRIPTION
When exporting repositories from one Pulp instance and importing them on another, multiple exports may arrive simultaneously. It is currently difficult to identify key details (e.g., repository name, export type: full vs. incremental) without inspecting large tar files. This slows down automation and makes import order logic harder.

Closes  https://github.com/pulp/pulpcore/issues/6712

# Solution

This change introduces a new optional `meta` field to the export serializer.

- Accepts arbitrary key-value metadata at export time.
- Metadata is written into the toc.json file under the meta section.
- The same metadata is also stored in toc_info for quick lookup.

This allows exporters/importers to embed identifying information (e.g., repo name, export type, author) directly in the TOC, making exports easier to classify and manage.

# Example
## Export request

```python
client.post(
    f"{exporter_href}exports/",
    json={
        "full": full_export,
        "chunk_size": chunk_size,
        "meta": {
            "repositories": ["example/repository"],
            "author": "pulp"        
        },
    },
)
```

## TOC json

```json
{
  "meta": {
    "repositories": ["example/repository"],
    "author": "pulp",
    "checksum_type": "crc32",
    "chunk_size": 53687091200
  },
  "files": {
    "export-019a01ce-20251020_1328.tar.0000": "96903fec"
  }
}
```

## Exporter list output

```json
{
  "params": {
    "full": true,
    "meta": {
      "repositories": [
        "example/repository"
      ],
      "author": "pulp"
    },
  },
  "toc_info": {
    "file": "/export-019a01d7-20251020_1338-toc.json",
    "meta": {
      "repositories": [
        "example/repository"
      ],
      "author": "pulp"
    },
    "sha256": "49c9ea862f67efc04c4"
  }
  ...
}
```