### PR TITLE
Allow batch size of artifacts processed during sync to be configured

### DIFF
--- a/CHANGES/7024.feature
+++ b/CHANGES/7024.feature
@@ -1,0 +1,3 @@
+Add MAX_CONCURRENT_CONTENT as a global setting.
+During sync, this setting will be used to determine the size of batch of
+content being processed in one go. Default value is 200.

--- a/docs/admin/reference/settings.md
+++ b/docs/admin/reference/settings.md
@@ -424,6 +424,12 @@ Defaults to `/var/lib/pulp/tmp/`.
     Files are commonly staged in the `WORKING_DIRECTORY` and
     validated before being moved to their permanent home in `MEDIA_ROOT`.
 
+### MAX\_CONCURRENT\_CONTENT
+
+The size of the batch of content processed in one go when syncing content from
+a remote.
+
+Defaults to 200.
 
 ## Redis Settings
 

--- a/pulpcore/app/settings.py
+++ b/pulpcore/app/settings.py
@@ -381,6 +381,8 @@ HIDE_GUARDED_DISTRIBUTIONS = False
 
 DOMAIN_ENABLED = False
 
+MAX_CONCURRENT_CONTENT = 200
+
 SHELL_PLUS_IMPORTS = [
     "from pulpcore.app.util import get_domain, get_domain_pk, set_domain, get_url, extract_pk",
     "from pulpcore.tasking.tasks import dispatch, cancel_task, wakeup_worker",

--- a/pulpcore/plugin/stages/artifact_stages.py
+++ b/pulpcore/plugin/stages/artifact_stages.py
@@ -2,6 +2,8 @@ import asyncio
 from collections import defaultdict
 from gettext import gettext as _
 import logging
+from django.conf import settings
+
 
 from aiofiles import os as aos
 from asgiref.sync import sync_to_async
@@ -139,7 +141,7 @@ class GenericDownloader(Stage):
     PROGRESS_REPORTING_MESSAGE = "Downloading"
     PROGRESS_REPORTING_CODE = "sync.downloading"
 
-    def __init__(self, max_concurrent_content=200, *args, **kwargs):
+    def __init__(self, max_concurrent_content=settings.MAX_CONCURRENT_CONTENT, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.max_concurrent_content = max_concurrent_content
 


### PR DESCRIPTION
closes #7024

Instead of hardcoding a value of 200, which can cause the storage requirements to increase drastically, allow batch size of artifacts processed during sync to be configured by users.