### PR TITLE
Fix trying to dispatch an immediate non-async task for pull-through caching

### DIFF
--- a/CHANGES/+pull-through-immediate.bugfix
+++ b/CHANGES/+pull-through-immediate.bugfix
@@ -1,0 +1,1 @@
+Fixed an issue with dispatching repository.add_and_remove tasks for pull-through caching

--- a/pulpcore/app/models/repository.py
+++ b/pulpcore/app/models/repository.py
@@ -376,10 +376,10 @@ class Repository(MasterModel):
         if not cpk or already_present.exists():
             return None
 
-        from pulpcore.plugin.tasking import dispatch, add_and_remove
+        from pulpcore.plugin.tasking import dispatch, aadd_and_remove
 
         body = {"repository_pk": self.pk, "add_content_units": [cpk], "remove_content_units": []}
-        return dispatch(add_and_remove, kwargs=body, exclusive_resources=[self], immediate=True)
+        return dispatch(aadd_and_remove, kwargs=body, exclusive_resources=[self], immediate=True)
 
     async def async_pull_through_add_content(self, content_artifact):
         cpk = content_artifact.content_id

--- a/pulpcore/content/handler.py
+++ b/pulpcore/content/handler.py
@@ -903,7 +903,7 @@ class Handler:
                     ca = ra.content_artifact
                     # Try to add content to repository if present & supported
                     if repository and repository.PULL_THROUGH_SUPPORTED:
-                        await sync_to_async(repository.pull_through_add_content)(ca)
+                        await repository.async_pull_through_add_content(ca)
                     # Try to stream the ContentArtifact if already created
                     if ca.artifact:
                         return await self._serve_content_artifact(ca, headers, request)
@@ -1347,7 +1347,7 @@ class Handler:
                 )
             # Try to add content to repository if present & supported
             if repository and repository.PULL_THROUGH_SUPPORTED:
-                await sync_to_async(repository.pull_through_add_content)(ca)
+                await repository.async_pull_through_add_content(ca)
         await response.write_eof()
 
         if response.status == 404:

--- a/pulpcore/tests/unit/content/test_handler.py
+++ b/pulpcore/tests/unit/content/test_handler.py
@@ -533,7 +533,7 @@ async def test_pull_through_repository_add(request123, monkeypatch):
     await create_remote_artifact(remote, ca)
     repo = await create_repository()
     monkeypatch.setattr(Remote, "get_remote_artifact_content_type", Mock(return_value=Content))
-    monkeypatch.setattr(Repository, "pull_through_add_content", Mock())
+    monkeypatch.setattr(Repository, "async_pull_through_add_content", AsyncMock())
     distro = await create_distribution(remote, repository=repo)
 
     try:
@@ -541,7 +541,7 @@ async def test_pull_through_repository_add(request123, monkeypatch):
         await handler._match_and_stream(f"{distro.base_path}/c123", request123)
         handler._stream_content_artifact.assert_called_once()
         assert ca in handler._stream_content_artifact.call_args[0]
-        repo.pull_through_add_content.assert_not_called()
+        repo.async_pull_through_add_content.assert_not_called()
 
         # Now set PULL_THROUGH_SUPPORTED=True and see the method is called with CA
         monkeypatch.setattr(Repository, "PULL_THROUGH_SUPPORTED", True)
@@ -549,8 +549,8 @@ async def test_pull_through_repository_add(request123, monkeypatch):
         await handler._match_and_stream(f"{distro.base_path}/c123", request123)
         handler._stream_content_artifact.assert_called_once()
         assert ca in handler._stream_content_artifact.call_args[0]
-        repo.pull_through_add_content.assert_called_once()
-        assert ca in repo.pull_through_add_content.call_args[0]
+        repo.async_pull_through_add_content.assert_called_once()
+        assert ca in repo.async_pull_through_add_content.call_args[0]
     finally:
         await content.adelete()
         await repo.adelete()


### PR DESCRIPTION
Forgot to remove immediate=True from this task when I was fixing the content app immediate task dispatching issue. We don't allow non-async immediate tasks. So the correct behavior is: 
1. Dispatch non-async immediate task -> fail
2. Dispatch async immediate task -> good
3. Dispatch async immediate task from content app -> good, but task is not handled immediately, it is deferred to a worker
