### PR TITLE
Failed tasks no longer store traceback.

### DIFF
--- a/CHANGES/+no-traceback-task.removal
+++ b/CHANGES/+no-traceback-task.removal
@@ -1,0 +1,1 @@
+Stopped leaking sensitive information of failures in the task API.

--- a/pulpcore/app/models/task.py
+++ b/pulpcore/app/models/task.py
@@ -3,7 +3,6 @@ Django models related to the Tasking system
 """
 
 import logging
-import traceback
 from gettext import gettext as _
 
 from django.contrib.postgres.fields import ArrayField, HStoreField
@@ -261,7 +260,7 @@ class Task(BaseModel, AutoAddObjPermsMixin):
                 )
         self._cleanup_progress_reports(TASK_STATES.COMPLETED)
 
-    def set_failed(self, exc, tb):
+    def set_failed(self, exc):
         """
         Set this Task to the failed state and save it.
 
@@ -270,11 +269,9 @@ class Task(BaseModel, AutoAddObjPermsMixin):
 
         Args:
             exc (Exception): The exception raised by the task.
-            tb (traceback): Traceback instance for the current exception.
         """
         finished_at = timezone.now()
-        tb_str = "".join(traceback.format_tb(tb))
-        error = exception_to_dict(exc, tb_str)
+        error = exception_to_dict(exc)
         rows = Task.objects.filter(
             pk=self.pk,
             state=TASK_STATES.RUNNING,

--- a/pulpcore/app/tasks/repository.py
+++ b/pulpcore/app/tasks/repository.py
@@ -7,7 +7,7 @@ import hashlib
 
 from asgiref.sync import sync_to_async
 from django.db import transaction
-from rest_framework.serializers import ValidationError
+from pulpcore.exceptions import RepositoryVersionDeleteError
 
 from pulpcore.app import models
 from pulpcore.app.models import ProgressReport
@@ -44,12 +44,7 @@ def delete_version(pk):
             return
 
         if version.repository.versions.complete().count() <= 1:
-            raise ValidationError(
-                _(
-                    "Cannot delete repository version. Repositories must have at least one "
-                    "repository version."
-                )
-            )
+            raise RepositoryVersionDeleteError()
 
         log.info(
             "Deleting and squashing version {num} of repository '{repo}'".format(

--- a/pulpcore/download/factory.py
+++ b/pulpcore/download/factory.py
@@ -2,7 +2,6 @@ from aiohttp import __version__ as aiohttp_version
 import asyncio
 import atexit
 import copy
-from gettext import gettext as _
 from multidict import MultiDict
 import platform
 import ssl
@@ -15,6 +14,7 @@ import aiohttp
 from pulpcore.app.apps import PulpAppConfig
 from .http import HttpDownloader
 from .file import FileDownloader
+from pulpcore.exceptions import UrlSchemeNotSupportedError
 
 
 PROTOCOL_MAP = {
@@ -177,7 +177,7 @@ class DownloaderFactory:
             builder = self._handler_map[scheme]
             download_class = self._download_class_map[scheme]
         except KeyError:
-            raise ValueError(_("URL: {u} not supported.".format(u=url)))
+            raise UrlSchemeNotSupportedError(url)
         else:
             return builder(download_class, url, **kwargs)
 

--- a/pulpcore/exceptions/__init__.py
+++ b/pulpcore/exceptions/__init__.py
@@ -4,6 +4,11 @@ from .base import (
     TimeoutException,
     exception_to_dict,
     DomainProtectedError,
+    DnsDomainNameException,
+    UrlSchemeNotSupportedError,
+    ProxyAuthenticationError,
+    InternalErrorException,
+    RepositoryVersionDeleteError,
 )
 from .validation import (
     DigestValidationError,

--- a/pulpcore/exceptions/base.py
+++ b/pulpcore/exceptions/base.py
@@ -44,6 +44,18 @@ def exception_to_dict(exc, traceback=None):
     return {"description": str(exc), "traceback": traceback}
 
 
+class InternalErrorException(PulpException):
+    """
+    Exception to signal that an unexpected internal error occurred.
+    """
+
+    def __init__(self):
+        super().__init__("PLP0000")
+
+    def __str__(self):
+        return _("An internal error occurred.")
+
+
 class ResourceImmutableError(PulpException):
     """
     Exceptions that are raised due to trying to update an immutable resource
@@ -94,3 +106,73 @@ class DomainProtectedError(PulpException):
 
     def __str__(self):
         return _("You cannot delete a domain that still contains repositories with content.")
+
+
+class DnsDomainNameException(PulpException):
+    """
+    Exception to signal that dns could not resolve the domain name for specified url.
+    """
+
+    def __init__(self, url):
+        """
+        :param url: the url that dns could not resolve
+        :type url: str
+        """
+        super().__init__("PLP0008")
+        self.url = url
+
+    def __str__(self):
+        return _("URL lookup failed.")
+
+
+class UrlSchemeNotSupportedError(PulpException):
+    """
+    Exception raised when a URL scheme (e.g. 'ftp://') is provided that
+    Pulp does not have a registered handler for.
+    """
+
+    def __init__(self, url):
+        """
+        :param url: The full URL that failed validation.
+        :type url: str
+        """
+        super().__init__("PLP0009")
+        self.url = url
+
+    def __str__(self):
+        return _("URL: {u} not supported.").format(u=self.url)
+
+
+class ProxyAuthenticationError(PulpException):
+    """
+    Exception to signal that the proxy server requires authentication
+    but it was not provided or is invalid
+    """
+
+    def __init__(self, proxy_url):
+        """
+        :param proxy_url: The URL of the proxy server.
+        :type proxy_url: str
+        """
+        super().__init__("PLP0010")
+        self.proxy_url = proxy_url
+
+    def __str__(self):
+        return _(
+            "Proxy authentication failed for {proxy_url}. Please check your proxy credentials."
+        ).format(proxy_url=self.proxy_url)
+
+
+class RepositoryVersionDeleteError(PulpException):
+    """
+    Raised when attempting to delete a repository version that cannot be deleted
+    """
+
+    def __init__(self):
+        super().__init__("PLP0011")
+
+    def __str__(self):
+        return _(
+            "Cannot delete repository version. Repositories must have at least one "
+            "repository version."
+        )

--- a/pulpcore/tests/functional/api/test_tasking.py
+++ b/pulpcore/tests/functional/api/test_tasking.py
@@ -468,7 +468,9 @@ class TestImmediateTaskWithNoResource:
                 "pulpcore.app.tasks.test.sleep", args=(LT_TIMEOUT,), immediate=True
             )
             monitor_task(task_href)
-        assert "Immediate tasks must be async functions" in ctx.value.task.error["description"]
+        # Assert masked internal error
+        # Underlying cause is ValueError("Immediate tasks must be async functions")
+        assert "An internal error occurred." in ctx.value.task.error["description"]
 
     @pytest.mark.parallel
     def test_timeouts_on_api_worker(self, pulpcore_bindings, dispatch_task):
@@ -484,7 +486,8 @@ class TestImmediateTaskWithNoResource:
         )
         task = pulpcore_bindings.TasksApi.read(task_href)
         assert task.state == "failed"
-        assert "timed out after" in task.error["description"]
+        # Assert masked internal error; underlying cause is asyncio.TimeoutError
+        assert "An internal error occurred." in task.error["description"]
 
 
 @pytest.fixture
@@ -576,4 +579,5 @@ class TestImmediateTaskWithBlockedResource:
                     exclusive_resources=[COMMON_RESOURCE],
                 )
             monitor_task(task_href)
-        assert "timed out after" in ctx.value.task.error["description"]
+        # Assert masked internal error; underlying cause is asyncio.TimeoutError
+        assert "An internal error occurred." in ctx.value.task.error["description"]

--- a/pulpcore/tests/functional/api/using_plugin/test_proxy.py
+++ b/pulpcore/tests/functional/api/using_plugin/test_proxy.py
@@ -101,7 +101,7 @@ def test_sync_https_through_http_proxy_with_auth_but_auth_not_configured(
     try:
         _run_basic_sync_and_assert(file_bindings, monitor_task, remote_on_demand, file_repo)
     except PulpTaskError as exc:
-        assert "407, message='Proxy Authentication Required'" in exc.task.error["description"]
+        assert "Proxy authentication failed for" in exc.task.error["description"]
 
 
 @pytest.mark.parallel

--- a/pulpcore/tests/unit/models/test_task.py
+++ b/pulpcore/tests/unit/models/test_task.py
@@ -32,8 +32,8 @@ def test_report_state_changes(monkeypatch, to_state, use_canceled):
             try:
                 raise ValueError("test")
             except ValueError:
-                exc_type, exc, tb = sys.exc_info()
-                task.set_failed(exc, tb)
+                exc_type, exc, _ = sys.exc_info()
+                task.set_failed(exc)
     elif TASK_STATES.CANCELED == to_state:
         task.set_canceling()
         task.set_canceled()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,7 +52,7 @@ dependencies = [
   "opentelemetry-sdk>=1.27.0,<1.40",
   "opentelemetry-exporter-otlp-proto-http>=1.27.0,<1.40",
   "protobuf>=4.21.1,<7.0",
-  "pulp-glue>=0.28.0,<0.38",
+  "pulp-glue>=0.30.0,<0.38",
   "pygtrie>=2.5,<=2.5.0",
   "psycopg[binary]>=3.1.8,<3.4",  # SemVer, not explicitely stated, but mentioned on multiple changes.
   "pyparsing>=3.1.0,<3.4",    # Looks like only bugfixes in z-Stream.


### PR DESCRIPTION
Failed task tracebacks are currently a part of task model, it can expose sensitive information from an exception via the API. This change stops this behavior by only logging tracebacks and not storing them inside of tasks.

_execute_task and _aexecute_task are modified to log tracebacks for unknown exceptions but never save them to the Task record.

Task.set_failed() is updated to make the tb (traceback) argument optional.

A new PulpExceptionNoTraceback base class is added for known, user-facing errors (like a DNS failure) where the traceback is not useful and should not be logged.

A new DnsDomainNameException (inheriting from PulpExceptionNoTraceback) is added to handle DNS lookup failures (e.g., bad remote URLs) as a known user error.