### PR TITLE
Handle edge cases in task diagnostics handling

### DIFF
--- a/CHANGES/7020.bugfix
+++ b/CHANGES/7020.bugfix
@@ -1,0 +1,1 @@
+Improve handling of some edge cases in task diagnostics code.

--- a/pulpcore/tasking/_util.py
+++ b/pulpcore/tasking/_util.py
@@ -10,8 +10,6 @@ import time
 import tempfile
 from gettext import gettext as _
 
-from contextlib import suppress
-
 from django.conf import settings
 from django.db import connection, transaction, IntegrityError
 from django.db.models import Q
@@ -167,12 +165,16 @@ def _memory_diagnostic_decorator(temp_dir, func):
 
         stop_event.set()
         artifact = Artifact.init_and_validate(mem_diagnostics_file_path)
-        with suppress(IntegrityError):
+        try:
+            # it is possible for the diagnostic artifact (memory report) to be identical to
+            # a previous report, in which case we need to handle the case where saving a new
+            # artifact fails.
             artifact.save()
-            ProfileArtifact.objects.get_or_create(
-                artifact=artifact, name="memory_profile", task=task
-            )
-            _logger.info("Created memory diagnostic data.")
+        except IntegrityError:
+            artifact = Artifact.objects.get(sha256=artifact.sha256)
+
+        ProfileArtifact.objects.get_or_create(artifact=artifact, name="memory_profile", task=task)
+        _logger.info("Created memory diagnostic data.")
 
     return __memory_diagnostic_decorator
 
@@ -191,12 +193,18 @@ def _pyinstrument_diagnostic_decorator(temp_dir, func):
                 f.flush()
 
             artifact = Artifact.init_and_validate(str(profile_file_path))
-            with suppress(IntegrityError):
+            try:
+                # it is possible for the diagnostic artifact (memory report) to be identical to
+                # a previous report, in which case we need to handle the case where saving a new
+                # artifact fails.
                 artifact.save()
-                ProfileArtifact.objects.get_or_create(
-                    artifact=artifact, name="pyinstrument_profile", task=task
-                )
-                _logger.info("Created pyinstrument profile data.")
+            except IntegrityError:
+                artifact = Artifact.objects.get(sha256=artifact.sha256)
+
+            ProfileArtifact.objects.get_or_create(
+                artifact=artifact, name="pyinstrument_profile", task=task
+            )
+            _logger.info("Created pyinstrument profile data.")
         else:
             func(task)
 
@@ -217,12 +225,18 @@ def _memray_diagnostic_decorator(temp_dir, func):
                 func(task)
 
             artifact = Artifact.init_and_validate(str(profile_file_path))
-            with suppress(IntegrityError):
+            try:
+                # it is possible for the diagnostic artifact (memory report) to be identical to
+                # a previous report, in which case we need to handle the case where saving a new
+                # artifact fails.
                 artifact.save()
-                ProfileArtifact.objects.get_or_create(
-                    artifact=artifact, name="memray_profile", task=task
-                )
-                _logger.info("Created memray memory profile data.")
+            except IntegrityError:
+                artifact = Artifact.objects.get(sha256=artifact.sha256)
+
+            ProfileArtifact.objects.get_or_create(
+                artifact=artifact, name="memray_profile", task=task
+            )
+            _logger.info("Created memray memory profile data.")
         else:
             func(task)
 


### PR DESCRIPTION
When an Artifact fails to save (likely due to a memory report being identical between two tasks by chance), we should be handling the case instead of failing out faster.

closes #7020