### PR TITLE
Fix resolve_prn handling of non-uuid pks [3.63]

### DIFF
--- a/CHANGES/plugin_api/+resolve_prn.bugfix
+++ b/CHANGES/plugin_api/+resolve_prn.bugfix
@@ -1,0 +1,1 @@
+Fixed `resolved_prn` failing when the object's pk wasn't an UUID.

--- a/pulpcore/app/util.py
+++ b/pulpcore/app/util.py
@@ -15,7 +15,7 @@ from uuid import UUID
 from django.apps import apps
 from django.conf import settings
 from django.db import connection
-from django.db.models import Model, Sum
+from django.db.models import Model, Sum, UUIDField
 from django.urls import Resolver404, resolve
 from opentelemetry import metrics
 
@@ -153,10 +153,11 @@ def resolve_prn(prn):
                 full_model_label
             )
         )
-    try:
-        UUID(pk, version=4)
-    except ValueError:
-        raise ValidationError(_("PK invalid: {}").format(pk))
+    if isinstance(model._meta.pk, UUIDField):
+        try:
+            UUID(pk, version=4)
+        except ValueError:
+            raise ValidationError(_("PK invalid: {}").format(pk))
 
     return model, pk
 


### PR DESCRIPTION
(cherry picked from commit b32e1b5ff0d5585af36edb745d193eeca0623c9e)