### PR TITLE
Add name_template to entrypoints

### DIFF
--- a/CHANGES/+name_template.bugfix
+++ b/CHANGES/+name_template.bugfix
@@ -1,0 +1,1 @@
+Allow to specify a template for the status names of the processes using '--name-template` to overcome conflicts in certain containerized environments.

--- a/pulpcore/app/settings.py
+++ b/pulpcore/app/settings.py
@@ -41,6 +41,8 @@ else:
 # Build paths inside the project like this: BASE_DIR / ...
 BASE_DIR = Path(__file__).absolute().parent
 
+WORKER_NAME_TEMPLATE = "{pid}@{hostname}"
+
 # Quick-start development settings - unsuitable for production
 # See https://docs.djangoproject.com/en/3.2/howto/deployment/checklist/
 

--- a/pulpcore/app/util.py
+++ b/pulpcore/app/util.py
@@ -633,7 +633,9 @@ def cache_key(base_path):
 
 @lru_cache(maxsize=1)
 def get_worker_name():
-    return f"{os.getpid()}@{socket.gethostname()}"
+    return settings.WORKER_NAME_TEMPLATE.format(
+        pid=os.getpid(), hostname=socket.gethostname(), fqdn=socket.getfqdn()
+    )
 
 
 class PGAdvisoryLock:

--- a/pulpcore/content/entrypoint.py
+++ b/pulpcore/content/entrypoint.py
@@ -1,5 +1,8 @@
+import sys
+
 import click
 from pulpcore.app.pulpcore_gunicorn_application import PulpcoreGunicornApplication
+from django.conf import settings
 
 
 class PulpcoreContentApplication(PulpcoreGunicornApplication):
@@ -39,7 +42,16 @@ class PulpcoreContentApplication(PulpcoreGunicornApplication):
 @click.option("--chdir")
 @click.option("--user", "-u")
 @click.option("--group", "-g")
+@click.option(
+    "--name-template",
+    type=str,
+    help="Format string to use for the status name. "
+    "'{pid}', '{hostname}', and '{fqdn} will be substituted.",
+)
 @click.command()
-def main(bind, **options):
+def main(bind, name_template, **options):
+    if name_template:
+        settings.set("WORKER_NAME_TEMPLATE", name_template)
     options["bind"] = list(bind)
+    sys.argv = sys.argv[:1]
     PulpcoreContentApplication(options).run()

--- a/pulpcore/tasking/entrypoint.py
+++ b/pulpcore/tasking/entrypoint.py
@@ -8,6 +8,7 @@ os.environ.setdefault("DJANGO_SETTINGS_MODULE", "pulpcore.app.settings")
 
 django.setup()
 
+from django.conf import settings  # noqa: E402: module level not at top
 from pulpcore.tasking.worker import PulpcoreWorker  # noqa: E402: module level not at top
 
 
@@ -21,8 +22,19 @@ _logger = logging.getLogger(__name__)
 @click.option(
     "--reload/--no-reload", help="Reload worker on code changes. [requires hupper to be installed.]"
 )
+@click.option(
+    "--name-template",
+    type=str,
+    help="Format string to use for the status name. "
+    "'{pid}', '{hostname}', and '{fqdn} will be substituted.",
+)
 @click.command()
-def worker(pid, burst, reload):
+def worker(
+    pid,
+    burst,
+    reload,
+    name_template,
+):
     """A Pulp worker."""
 
     if reload:
@@ -37,6 +49,9 @@ def worker(pid, burst, reload):
     if pid:
         with open(os.path.expanduser(pid), "w") as fp:
             fp.write(str(os.getpid()))
+
+    if name_template:
+        settings.set("WORKER_NAME_TEMPLATE", name_template)
 
     _logger.info("Starting distributed type worker")
 

--- a/pulpcore/tasking/worker.py
+++ b/pulpcore/tasking/worker.py
@@ -5,7 +5,6 @@ import os
 import random
 import select
 import signal
-import socket
 import contextlib
 from datetime import datetime, timedelta
 from multiprocessing import Process
@@ -27,7 +26,7 @@ from pulpcore.constants import (
 from pulpcore.metrics import init_otel_meter
 from pulpcore.app.apps import pulp_plugin_configs
 from pulpcore.app.models import Worker, Task, ApiAppStatus, ContentAppStatus
-from pulpcore.app.util import PGAdvisoryLock, get_domain
+from pulpcore.app.util import PGAdvisoryLock, get_domain, get_worker_name
 from pulpcore.exceptions import AdvisoryLockError
 
 from pulpcore.tasking.storage import WorkerDirectory
@@ -63,7 +62,7 @@ class PulpcoreWorker:
         self.cancel_task = False
 
         self.task = None
-        self.name = f"{os.getpid()}@{socket.getfqdn()}"
+        self.name = get_worker_name()
         self.heartbeat_period = timedelta(seconds=settings.WORKER_TTL / 3)
         self.last_metric_heartbeat = timezone.now()
         self.versions = {app.label: app.version for app in pulp_plugin_configs()}


### PR DESCRIPTION
All entrypoints are allowed to override the WORKER_NAME_TEMPLATE setting via the --name-template option.

(cherry picked from commit 1cb07447e979ab7fa75be35ec91f9ba2031c542f) (cherry picked from commit 9647c3f536eb1eef0644ceaa46f347110a8998f9)