### PR TITLE
Mitigate a disk consumption issue during sync

### DIFF
--- a/CHANGES/7064.bugfix
+++ b/CHANGES/7064.bugfix
@@ -1,0 +1,1 @@
+Restrict batch processing `minsize` to the settings value defined for `MAX_CONCURRENT_CONTENT`. Smaller values will increase sync times but reduce the amount of outstanding content in the pipeline, which reduces peak resource consumption (memory, temporary disk requirements).

--- a/docs/admin/reference/settings.md
+++ b/docs/admin/reference/settings.md
@@ -429,7 +429,7 @@ Defaults to `/var/lib/pulp/tmp/`.
 The size of the batch of content processed in one go when syncing content from
 a remote.
 
-Defaults to 200.
+Defaults to 25.
 
 ## Redis Settings
 

--- a/pulpcore/app/settings.py
+++ b/pulpcore/app/settings.py
@@ -381,7 +381,7 @@ HIDE_GUARDED_DISTRIBUTIONS = False
 
 DOMAIN_ENABLED = False
 
-MAX_CONCURRENT_CONTENT = 200
+MAX_CONCURRENT_CONTENT = 25
 
 SHELL_PLUS_IMPORTS = [
     "from pulpcore.app.util import get_domain, get_domain_pk, set_domain, get_url, extract_pk",

--- a/pulpcore/plugin/stages/artifact_stages.py
+++ b/pulpcore/plugin/stages/artifact_stages.py
@@ -269,7 +269,7 @@ class ArtifactSaver(Stage):
         Returns:
             The coroutine for this stage.
         """
-        async for batch in self.batches():
+        async for batch in self.batches(minsize=settings.MAX_CONCURRENT_CONTENT):
             da_to_save = []
             for d_content in batch:
                 for d_artifact in d_content.d_artifacts:


### PR DESCRIPTION
The ArtifactSaver stage is acting as a bottleneck due to batching, and as a result artifacts downloaded by the ArtifactDownloader stage aren't being flushed out quickly enough. Using a default batch size of 500 is too much for some stages.

closes #7064