### PR TITLE
[3.73] Fix pre migration cleanup hook

### DIFF
--- a/CHANGES/+fix-cleanup-on-migration.bugfix
+++ b/CHANGES/+fix-cleanup-on-migration.bugfix
@@ -1,0 +1,1 @@
+Fixed a bug in the pre-migration hook that prevented proper cleanup of all Pulp app db records (content, api, worker).

--- a/pulpcore/app/apps.py
+++ b/pulpcore/app/apps.py
@@ -286,7 +286,7 @@ def _clean_app_status(sender, apps, verbosity, **kwargs):
 
     for app_name, app_ttl in app_ttl_map:
         try:
-            app_cls = apps.get_model("core", "ContentAppStatus")
+            app_cls = apps.get_model("core", app_name)
         except LookupError:
             if verbosity >= 1:
                 print(


### PR DESCRIPTION
This is fixed in later versions ([e.g, 3.85](https://github.com/pulp/pulpcore/blob/fa56e461cbce260983e0536d89903c32886a1c7f/pulpcore/app/apps.py#L279)).