### PR TITLE
Ensure we're passing an int to randint [Backport 3.28]

### DIFF
--- a/CHANGES/5861.bugfix
+++ b/CHANGES/5861.bugfix
@@ -1,0 +1,1 @@
+pulp-worker fails to start with "float object cannot be interpreted as an integer" on some versions of python.

--- a/pulpcore/tasking/pulpcore_worker.py
+++ b/pulpcore/tasking/pulpcore_worker.py
@@ -103,7 +103,7 @@ class NewPulpWorker:
         self.worker = self.handle_worker_heartbeat()
         self.task_grace_timeout = 0
         self.worker_cleanup_countdown = random.randint(
-            WORKER_CLEANUP_INTERVAL / 10, WORKER_CLEANUP_INTERVAL
+            int(WORKER_CLEANUP_INTERVAL / 10), WORKER_CLEANUP_INTERVAL
         )
 
         # Add a file descriptor to trigger select on signals


### PR DESCRIPTION
closes #5861

(cherry picked from commit a6df7e14ed724524d95b53d18a1ef40b83f5ebd5)