### PR TITLE
Improve migration error message with extra instructions

### DIFF
--- a/CHANGES/+improve-migration-err-msg.misc
+++ b/CHANGES/+improve-migration-err-msg.misc
@@ -1,0 +1,2 @@
+Improved the error message for incompatible component versions when doing a migration.
+Now it instructs the user with a safe path to take when the components were improperly shutdown.

--- a/pulpcore/migrations.py
+++ b/pulpcore/migrations.py
@@ -78,7 +78,10 @@ class RequireVersion(Operation):
                         f"({self.plugin} >= {self.version} needed):",
                         *errors,
                         "Please shutdown or upgrade the outdated components before you "
-                        "continue the migration.",
+                        "continue the migration. \n"
+                        "If the components were not gracefully shutdown, wait for the "
+                        "larger component TTL period before running the migration ",
+                        "(API_APP_TTL, CONTENT_APP_TTL or WORKER_TTL).",
                     ]
                 )
             )


### PR DESCRIPTION
There are cases where user set components TTL to huge values (e,g > 1 hour, believe it or not). In this case, the migrations might fail if it tried to force shutdown the compoments (e.g, workers) to perform the migration, as there will be stale AppStatus entries in the database.