### PR TITLE
[backport/3.63] Expose RepositoryVersionSerializer in the plugin API

### DIFF
--- a/pulpcore/plugin/serializers/__init__.py
+++ b/pulpcore/plugin/serializers/__init__.py
@@ -29,6 +29,7 @@ from pulpcore.app.serializers import (
     RepositorySerializer,
     RepositorySyncURLSerializer,
     RepositoryVersionRelatedField,
+    RepositoryVersionSerializer,
     SingleArtifactContentSerializer,
     SingleContentArtifactField,
     TaskGroupOperationResponseSerializer,


### PR DESCRIPTION
In pulpcore 3.88 it was added a feature that would the return value of task functions, and those return must be serializable or None.

In 3.100 that would be required by pulpcore, so plugins that wante to adapt before might use the RepositoryVersionSerializer. In this case, regardless of whether pulpcore >=3.88 or <3.88 is used, the plugin must be able to import the serializer or it will throw a runtime import error.

(cherry picked from commit 20f3b7a7d01675fc4dcc08ccb8580e1a50a01012)