### PR TITLE
[3.85] Add changes entry to "expose RepositoryVersionSerializer"

### DIFF
--- a/CHANGES/plugin_api/+expose-repository-version-serializer.bugfix
+++ b/CHANGES/plugin_api/+expose-repository-version-serializer.bugfix
@@ -1,0 +1,3 @@
+Exposed `RepositoryVersionSerializer` to the plugin API.
+In some cases a plugin might have used that serializer for a newer pulpcore version
+but it could also be installed with a lower pulpcore version.


### PR DESCRIPTION
Missing changes entry for:
- 3.85: https://github.com/pulp/pulpcore/pull/7170
- 3.73: https://github.com/pulp/pulpcore/pull/7171
- 3.63: https://github.com/pulp/pulpcore/pull/7172
- 3.49: https://github.com/pulp/pulpcore/pull/7173