### PR TITLE
feat: allow empty base_path for distributions (cache)

### DIFF
--- a/pulpcore/app/models/publication.py
+++ b/pulpcore/app/models/publication.py
@@ -615,7 +615,7 @@ class Distribution(MasterModel):
 
     name = models.TextField(db_index=True)
     pulp_labels = HStoreField(default=dict)
-    base_path = models.TextField()
+    base_path = models.TextField(blank=True)
     pulp_domain = models.ForeignKey("Domain", default=get_domain_pk, on_delete=models.PROTECT)
     hidden = models.BooleanField(default=False, null=True)
     checkpoint = models.BooleanField(default=False)

--- a/pulpcore/app/serializers/publication.py
+++ b/pulpcore/app/serializers/publication.py
@@ -221,6 +221,7 @@ class DistributionSerializer(ModelSerializer):
                     overlap with other distribution base paths (e.g. "foo" and "foo/bar")'
         ),
         validators=[DomainUniqueValidator(queryset=models.Distribution.objects.all())],
+        allow_blank=True,
     )
     base_url = BaseURLField(
         source="*",


### PR DESCRIPTION
This enables Docker registry mirror compatibility by allowing pull-through distributions to serve at the root path (empty base_path).

When base_path is empty, the distribution matches all incoming paths, making it work as a transparent Docker Hub mirror.