### PR TITLE
[PULP-1094][backport/3.85] Add changes required by django 5

### DIFF
--- a/pulpcore/app/management/commands/shell.py
+++ b/pulpcore/app/management/commands/shell.py
@@ -1,0 +1,8 @@
+from django.core.management.commands import shell
+
+
+class Command(shell.Command):
+    def get_auto_imports(self):
+        # disable automatic imports. See
+        # https://docs.djangoproject.com/en/5.2/howto/custom-shell/
+        return None

--- a/pulpcore/app/serializers/domain.py
+++ b/pulpcore/app/serializers/domain.py
@@ -2,7 +2,7 @@ from gettext import gettext as _
 import json
 
 from django.conf import settings
-from django.core.files.storage import import_string
+from django.utils.module_loading import import_string
 from django.core.exceptions import ImproperlyConfigured
 from drf_spectacular.types import OpenApiTypes
 from drf_spectacular.utils import extend_schema_field


### PR DESCRIPTION
The changes were tested against Django 5 but are compatible with Django 4:

* bump django-guid
* bump django-filter
* shell.Command override

Co-authored-by: Matthias Dellweg <2500@gmx.de>

(cherry picked from commit e7f742f68c107e9b854d6056c0a7ad9f2747ada8)