### PR TITLE
Add a list-signing-services command

### DIFF
--- a/CHANGES/+list-signing-services-cmd.feature
+++ b/CHANGES/+list-signing-services-cmd.feature
@@ -1,0 +1,1 @@
+Added a `pulpcore-manager list-signing-services` command.

--- a/pulpcore/app/management/commands/list-signing-services.py
+++ b/pulpcore/app/management/commands/list-signing-services.py
@@ -1,0 +1,18 @@
+from django.apps import apps
+from django.core.management import BaseCommand
+
+
+class Command(BaseCommand):
+    """
+    Django management command for listing signing services.
+    """
+
+    help = "List all SigningServices."
+
+    def add_arguments(self, parser):
+        pass
+
+    def handle(self, *args, **options):
+        SigningService = apps.get_model("core", "SigningService")
+        results = list(SigningService.objects.all().values_list("name", flat=True))
+        self.stdout.write(results)


### PR DESCRIPTION
Adding a new list-signing-services command which makes it easier to manage signing services alongside the add/remove signing services command. This is helpful if you don't have immediate access to the Pulp API.