### PR TITLE
Handle edge cases in task diagnostics handling

### DIFF
--- a/CHANGES/7020.bugfix
+++ b/CHANGES/7020.bugfix
@@ -1,0 +1,1 @@
+Improve handling of some edge cases in task diagnostics code.


### PR DESCRIPTION
When an Artifact fails to save (likely due to a memory report being identical between two tasks by chance), we should be handling the case instead of failing out faster.

closes #7020

(cherry picked from commit eda59a9e83e5726cd2b07066deb7dc5a0b53a7d5)