### PR TITLE
Fix list-signing-services command

### DIFF
--- a/CHANGES/+fix-list-signing-services-cmd.bugfix
+++ b/CHANGES/+fix-list-signing-services-cmd.bugfix
@@ -1,0 +1,1 @@
+Fix an error when running `pulpcore-manager list-signing-services`.

--- a/pulpcore/app/management/commands/list-signing-services.py
+++ b/pulpcore/app/management/commands/list-signing-services.py
@@ -15,4 +15,4 @@ class Command(BaseCommand):
     def handle(self, *args, **options):
         SigningService = apps.get_model("core", "SigningService")
         results = list(SigningService.objects.all().values_list("name", flat=True))
-        self.stdout.write(results)
+        self.stdout.write("\n".join(results))

--- a/pulpcore/tests/unit/test_list_signing_services_command.py
+++ b/pulpcore/tests/unit/test_list_signing_services_command.py
@@ -1,0 +1,44 @@
+import pytest
+from io import StringIO
+from unittest.mock import patch
+
+from django.core.management import call_command
+
+from pulpcore.app.models.content import AsciiArmoredDetachedSigningService
+
+
+@pytest.mark.django_db
+def test_list_signing_services_empty():
+    """Test the list-signing-services command with no signing services."""
+    out = StringIO()
+    call_command("list-signing-services", stdout=out)
+    assert out.getvalue().strip() == ""
+
+
+@pytest.mark.django_db
+def test_list_signing_services(tmp_path):
+    """Test the list-signing-services command with multiple signing services."""
+    # Create a dummy script file
+    script_file = tmp_path / "signing_script.sh"
+    script_file.write_text("#!/bin/bash\necho 'test'")
+
+    # Create multiple signing services with mocked validate() method
+    for name in ["service-a", "service-b", "service-c"]:
+        service = AsciiArmoredDetachedSigningService(
+            name=name,
+            public_key=f"key-{name[-1]}",
+            pubkey_fingerprint=f"fingerprint-{name[-1]}",
+            script=str(script_file),
+        )
+        # Mock the validate method to bypass GPG verification
+        with patch.object(service, "validate", return_value=None):
+            service.save()
+
+    out = StringIO()
+    call_command("list-signing-services", stdout=out)
+    output_lines = out.getvalue().strip().split("\n")
+
+    # Check that all service names are present
+    assert "service-a" in output_lines
+    assert "service-b" in output_lines
+    assert "service-c" in output_lines


### PR DESCRIPTION
Fix an error when passing results to stdout.write() since unlike print() it expects a string and can't handle a list.