### PR TITLE
Add more useful PulpExceptions for general tasks

### DIFF
--- a/CHANGES/plugin_api/7270.feature
+++ b/CHANGES/plugin_api/7270.feature
@@ -1,0 +1,1 @@
+Added more useful error exceptions for general tasks.

--- a/pulp_file/pytest_plugin.py
+++ b/pulp_file/pytest_plugin.py
@@ -172,6 +172,14 @@ def duplicate_filename_paths(write_3_iso_file_fixture_data_factory):
 
 
 @pytest.fixture(scope="class")
+def missing_file_path(file_fixtures_root):
+    file_fixtures_root.joinpath("missing_file").mkdir()
+    file = {"name": "missing_file/1.iso", "digest": "1234567890", "size": 100}
+    generate_manifest(file_fixtures_root.joinpath("missing_file/PULP_MANIFEST"), [file])
+    return "/missing_file/PULP_MANIFEST"
+
+
+@pytest.fixture(scope="class")
 def file_fixture_server_ssl_client_cert_req(
     ssl_ctx_req_client_auth, file_fixtures_root, gen_fixture_server
 ):

--- a/pulpcore/app/models/content.py
+++ b/pulpcore/app/models/content.py
@@ -7,6 +7,7 @@ from gettext import gettext as _
 import asyncio
 import datetime
 import json
+import logging
 import os
 import tempfile
 import shutil
@@ -34,7 +35,10 @@ from pulpcore.exceptions import (
     SizeValidationError,
     MissingDigestValidationError,
     UnsupportedDigestValidationError,
+    ExternalServiceError,
 )
+
+logger = logging.getLogger(__name__)
 
 # All available digest fields ordered by algorithm strength.
 _DIGEST_FIELDS = []
@@ -821,7 +825,7 @@ class SigningService(BaseModel):
             env_vars (dict): dictionary of environment variables
 
         Raises:
-            RuntimeError: If the return code of the script is not equal to 0.
+            ExternalServiceError: If the return code of the script is not equal to 0.
 
         Returns:
             A dictionary as validated by the validate() method.
@@ -834,12 +838,13 @@ class SigningService(BaseModel):
         )
 
         if completed_process.returncode != 0:
-            raise RuntimeError(str(completed_process.stderr))
+            logger.info("Signing service script failed: {}".format(str(completed_process.stderr)))
+            raise ExternalServiceError("Signing service script")
 
         try:
             return_value = json.loads(completed_process.stdout)
         except json.JSONDecodeError:
-            raise RuntimeError("The signing service script did not return valid JSON!")
+            raise ExternalServiceError("Signing service script", "did not return valid JSON")
 
         return return_value
 
@@ -855,12 +860,13 @@ class SigningService(BaseModel):
 
         stdout, stderr = await process.communicate()
         if process.returncode != 0:
-            raise RuntimeError(str(stderr))
+            logger.info("Signing service script failed: {}".format(str(stderr)))
+            raise ExternalServiceError("Signing service script")
 
         try:
             return_value = json.loads(stdout)
         except json.JSONDecodeError:
-            raise RuntimeError("The signing service script did not return valid JSON!")
+            raise ExternalServiceError("Signing service script", "did not return valid JSON")
 
         return return_value
 

--- a/pulpcore/app/tasks/importer.py
+++ b/pulpcore/app/tasks/importer.py
@@ -12,10 +12,9 @@ from django.conf import settings
 from django.core.files.storage import default_storage
 from django.db.models import F
 from io import StringIO
-from rest_framework.serializers import ValidationError
 from tablib import Dataset
 
-from pulpcore.exceptions.plugin import MissingPlugin
+from pulpcore.exceptions import MissingPlugin, ImportError
 from pulpcore.app.apps import get_plugin_config
 from pulpcore.app.models import (
     AppStatus,
@@ -78,7 +77,7 @@ class ChunkedFile(ExitStack):
         with open(toc_path, "r") as toc_file:
             self.toc = json.load(toc_file)
         if "files" not in self.toc or "meta" not in self.toc:
-            raise ValidationError(_("Missing 'files' or 'meta' keys in table-of-contents!"))
+            raise ImportError(_("Missing 'files' or 'meta' keys in table-of-contents!"))
 
         toc_dir = os.path.dirname(toc_path)
         # sorting-by-filename is REALLY IMPORTANT here
@@ -126,7 +125,7 @@ class ChunkedFile(ExitStack):
             if read_size < current_size:
                 # Reached EOF (should only happen on the last chunk)
                 if self.chunk != len(self.chunks) - 1:
-                    raise Exception(f"Short read from chunk {self.chunk}.")
+                    raise ImportError(f"Short read from chunk {self.chunk}.")
                 return data
             if remaining_size == 0:
                 return data
@@ -154,7 +153,7 @@ class ChunkedFile(ExitStack):
           * point to chunks whose checksums match the checksums stored in the 'toc' file
 
         Raises:
-            ValidationError: When toc points to chunked-export-files that can't be found in the
+            ImportError: When toc points to chunked-export-files that can't be found in the
             same directory as the toc-file, or the checksums of the chunks do not match the
             checksums stored in toc.
         """
@@ -164,7 +163,7 @@ class ChunkedFile(ExitStack):
             if not os.path.isfile(chunk_path):
                 missing_files.append(chunk_path)
         if missing_files:
-            raise ValidationError(
+            raise ImportError(
                 _(
                     "Missing import-chunks named in table-of-contents: {}.".format(
                         str(missing_files)
@@ -190,7 +189,7 @@ class ChunkedFile(ExitStack):
 
         # if there are any errors, report and fail
         if errs:
-            raise ValidationError(_("Import chunk hash mismatch: {}).").format(str(errs)))
+            raise ImportError(_("Import chunk hash mismatch: {}).").format(str(errs)))
 
 
 def _get_destination_repo_name(importer, source_repo_name):
@@ -293,7 +292,7 @@ def _check_versions(version_json):
     Compare the export version_json to the installed components.
 
     An upstream whose db-metadata doesn't match the downstream won't import successfully; check
-    for compatibility and raise a ValidationError if incompatible versions are found.
+    for compatibility and raise a ImportError if incompatible versions are found.
     """
     error_messages = []
     for component in version_json:
@@ -320,7 +319,7 @@ def _check_versions(version_json):
                 )
 
     if error_messages:
-        raise ValidationError((" ".join(error_messages)))
+        raise ImportError((" ".join(error_messages)))
 
 
 def import_repository_version(
@@ -366,7 +365,7 @@ def import_repository_version(
                         tar.extract(mem, path=temp_dir)
 
                 if not rv_name:
-                    raise ValidationError(_("No RepositoryVersion found for {}").format(rv_name))
+                    raise ImportError(_("No RepositoryVersion found for {}").format(rv_name))
 
                 rv_path = os.path.join(temp_dir, rv_name)
 
@@ -478,7 +477,7 @@ def pulp_import(importer_pk, path, toc, create_repositories):
                     for member in tar.getmembers():
                         member_path = os.path.join(path, member.name)
                         if not is_within_directory(path, member_path):
-                            raise Exception("Attempted Path Traversal in Tar File")
+                            raise ImportError("Attempted Path Traversal in Tar File")
 
                     tar.extractall(path, members, numeric_owner=numeric_owner)
 

--- a/pulpcore/app/tasks/migrate.py
+++ b/pulpcore/app/tasks/migrate.py
@@ -2,7 +2,7 @@ import logging
 from gettext import gettext as _
 
 from django.utils.timezone import now
-from rest_framework.serializers import ValidationError
+from pulpcore.exceptions import ValidationError
 from pulpcore.app.models import Artifact, storage, ProgressReport
 from pulpcore.app.serializers import DomainBackendMigratorSerializer
 from pulpcore.app.util import get_domain

--- a/pulpcore/app/tasks/purge.py
+++ b/pulpcore/app/tasks/purge.py
@@ -13,6 +13,7 @@ from pulpcore.app.models import (
 from pulpcore.app.role_util import get_objects_for_user
 from pulpcore.app.util import get_domain, get_current_authenticated_user
 from pulpcore.constants import TASK_STATES, TASK_FINAL_STATES
+from pulpcore.exceptions import SystemStateError
 
 log = getLogger(__name__)
 
@@ -107,7 +108,7 @@ def purge(finished_before=None, states=None, **kwargs):
         if not scheduled:
             current_user = get_current_authenticated_user()
             if current_user is None:
-                raise RuntimeError(
+                raise SystemStateError(
                     "This task should have been dispatched by a user. Cannot find it though. "
                     "Maybe it got deleted."
                 )

--- a/pulpcore/app/tasks/replica.py
+++ b/pulpcore/app/tasks/replica.py
@@ -9,6 +9,7 @@ from pulpcore.constants import TASK_STATES
 from pulpcore.app.apps import pulp_plugin_configs, PulpAppConfig
 from pulpcore.app.models import UpstreamPulp, Task, TaskGroup
 from pulpcore.app.replica import ReplicaContext
+from pulpcore.exceptions import ReplicateError
 from pulpcore.tasking.tasks import dispatch
 
 from pulp_glue.common import __version__ as pulp_glue_version
@@ -119,7 +120,7 @@ def finalize_replication(server_pk):
     task_group = TaskGroup.current()
     server = UpstreamPulp.objects.get(pk=server_pk)
     if task_group.tasks.exclude(pk=task.pk).exclude(state=TASK_STATES.COMPLETED).exists():
-        raise Exception("Replication failed.")
+        raise ReplicateError()
 
     # Record timestamp of last successful replication.
     started_at = task_group.tasks.aggregate(Min("started_at"))["started_at__min"]

--- a/pulpcore/app/tasks/upload.py
+++ b/pulpcore/app/tasks/upload.py
@@ -1,9 +1,11 @@
 from gettext import gettext as _
 from logging import getLogger
 from tempfile import NamedTemporaryFile
+from rest_framework.exceptions import ValidationError as DRFValidationError
 
 from pulpcore.app import files, models
 from pulpcore.app.serializers import ArtifactSerializer
+from pulpcore.exceptions import ValidationError
 
 log = getLogger(__name__)
 
@@ -34,7 +36,10 @@ def commit(upload_id, sha256):
 
         data = {"file": file, "sha256": sha256}
         serializer = ArtifactSerializer(data=data)
-        serializer.is_valid(raise_exception=True)
+        try:
+            serializer.is_valid(raise_exception=True)
+        except DRFValidationError as e:
+            raise ValidationError(e.detail)
         artifact = serializer.save()
 
     resource = models.CreatedResource(content_object=artifact)

--- a/pulpcore/app/tasks/vulnerability_report.py
+++ b/pulpcore/app/tasks/vulnerability_report.py
@@ -9,6 +9,7 @@ from pulpcore.app.util import get_domain
 from pulpcore.app.models.progress import ProgressReport
 from pulpcore.app.models.vulnerability_report import VulnerabilityReport
 from pulpcore.constants import OSV_QUERY_URL, TASK_STATES
+from pulpcore.exceptions import ExternalServiceError
 
 
 class VulnerabilityReportScanner:
@@ -118,7 +119,7 @@ class VulnerabilityReportScanner:
             try:
                 return await response.json()
             except aiohttp.ContentTypeError:
-                raise RuntimeError("Vuln report task failed to query osv.dev data.")
+                raise ExternalServiceError("osv.dev", "Failed to query vulnerability data.")
 
     async def _save_vulnerability_report(self, vulns, content, repo_version):
         """

--- a/pulpcore/download/http.py
+++ b/pulpcore/download/http.py
@@ -3,7 +3,6 @@ import logging
 import aiohttp
 import asyncio
 import backoff
-import socket
 
 from .base import BaseDownloader, DownloadResult
 from pulpcore.exceptions import (
@@ -300,11 +299,8 @@ class HttpDownloader(BaseDownloader):
                 self.raise_for_status(response)
                 to_return = await self._handle_response(response)
                 await response.release()
-        except aiohttp.ClientConnectorError as e:
-            # Check if this is a DNS error
-            if isinstance(e.os_error, socket.gaierror):
-                raise DnsDomainNameException(self.url)
-            raise
+        except aiohttp.ClientConnectorDNSError:
+            raise DnsDomainNameException(self.url)
         if self._close_session_on_finalize:
             await self.session.close()
         return to_return

--- a/pulpcore/exceptions/__init__.py
+++ b/pulpcore/exceptions/__init__.py
@@ -9,6 +9,13 @@ from .base import (
     ProxyAuthenticationError,
     InternalErrorException,
     RepositoryVersionDeleteError,
+    ExternalServiceError,
+    ExportError,
+    ImportError,
+    SystemStateError,
+    ReplicateError,
+    SyncError,
+    PublishError,
 )
 from .validation import (
     DigestValidationError,
@@ -18,3 +25,4 @@ from .validation import (
     MissingDigestValidationError,
     UnsupportedDigestValidationError,
 )
+from .plugin import MissingPlugin

--- a/pulpcore/exceptions/plugin.py
+++ b/pulpcore/exceptions/plugin.py
@@ -10,12 +10,13 @@ class MissingPlugin(PulpException):
     Exception that is raised when a requested plugin is not installed.
     """
 
+    error_code = "PLP0002"
+
     def __init__(self, plugin_app_label):
         """
         :param resources: keyword arguments of resource_type=resource_id
         :type resources: dict
         """
-        super().__init__("PLP0002")
         self.plugin_app_label = plugin_app_label
 
     def __str__(self):

--- a/pulpcore/plugin/exceptions.py
+++ b/pulpcore/plugin/exceptions.py
@@ -1,4 +1,5 @@
 from pulpcore.exceptions import (
+    ValidationError,
     DigestValidationError,
     InvalidSignatureError,
     PulpException,
@@ -6,10 +7,16 @@ from pulpcore.exceptions import (
     MissingDigestValidationError,
     TimeoutException,
     UnsupportedDigestValidationError,
+    PublishError,
+    SyncError,
+    ExternalServiceError,
+    SystemStateError,
+    ReplicateError,
 )
 
 
 __all__ = [
+    "ValidationError",
     "DigestValidationError",
     "InvalidSignatureError",
     "PulpException",
@@ -17,4 +24,9 @@ __all__ = [
     "MissingDigestValidationError",
     "TimeoutException",
     "UnsupportedDigestValidationError",
+    "PublishError",
+    "SyncError",
+    "ExternalServiceError",
+    "SystemStateError",
+    "ReplicateError",
 ]

--- a/pulpcore/plugin/stages/artifact_stages.py
+++ b/pulpcore/plugin/stages/artifact_stages.py
@@ -4,12 +4,12 @@ from gettext import gettext as _
 import logging
 from django.conf import settings
 
-
+import aiohttp.client_exceptions
 from aiofiles import os as aos
 from asgiref.sync import sync_to_async
 from django.db.models import Prefetch, prefetch_related_objects
 
-from pulpcore.plugin.exceptions import UnsupportedDigestValidationError
+from pulpcore.plugin.exceptions import UnsupportedDigestValidationError, SyncError
 from pulpcore.plugin.models import (
     Artifact,
     ContentArtifact,
@@ -240,7 +240,10 @@ class ArtifactDownloader(GenericDownloader):
             and not d_artifact.artifact.file
         ]
         if downloaders_for_content:
-            await asyncio.gather(*downloaders_for_content)
+            try:
+                await asyncio.gather(*downloaders_for_content)
+            except aiohttp.client_exceptions.ClientResponseError as e:
+                raise SyncError(_("Error downloading artifact: {error}").format(error=e))
         await self.put(d_content)
         return len(downloaders_for_content)
 
@@ -407,7 +410,7 @@ class RemoteArtifactSaver(Stage):
                                 "No declared artifact with relative path '{rp}' for content '{c}'"
                                 " from remote '{rname}', and no paths available."
                             )
-                            raise ValueError(
+                            raise SyncError(
                                 msg.format(
                                     rp=d_artifact.relative_path,
                                     c=d_content.content.natural_key(),
@@ -416,7 +419,7 @@ class RemoteArtifactSaver(Stage):
                             )
                     else:
                         msg = _('No declared artifact with relative path "{rp}" for content "{c}"')
-                        raise ValueError(
+                        raise SyncError(
                             msg.format(rp=d_artifact.relative_path, c=d_content.content)
                         )
 

--- a/pulpcore/plugin/stages/content_stages.py
+++ b/pulpcore/plugin/stages/content_stages.py
@@ -1,3 +1,4 @@
+from gettext import gettext as _
 from collections import defaultdict
 
 from asgiref.sync import sync_to_async
@@ -7,6 +8,7 @@ from django.db.models import Q
 
 from pulpcore.plugin.sync import sync_to_async_iterable
 
+from pulpcore.plugin.exceptions import SyncError
 from pulpcore.plugin.models import Content, ContentArtifact, ProgressReport
 
 from .api import Stage
@@ -115,13 +117,14 @@ class ContentSaver(Stage):
                             try:
                                 with transaction.atomic():
                                     d_content.content.save()
-                            except IntegrityError as e:
+                            except IntegrityError:
                                 try:
                                     d_content.content = d_content.content.__class__.objects.get(
                                         d_content.content.q()
                                     )
                                 except ObjectDoesNotExist:
-                                    raise e
+                                    msg = _('Content not found during save "{c}"')
+                                    raise SyncError(msg.format(c=d_content.content.natural_key()))
                             else:
                                 for d_artifact in d_content.d_artifacts:
                                     if not d_artifact.artifact._state.adding:

--- a/pulpcore/tests/unit/test_chunked_file.py
+++ b/pulpcore/tests/unit/test_chunked_file.py
@@ -3,11 +3,11 @@ import typing as t
 from pathlib import Path
 
 import pytest
-from rest_framework.exceptions import ValidationError
 
 from pulpcore.app.models import ProgressReport
 from pulpcore.app.tasks.importer import ChunkedFile
 from pulpcore.app.util import Crc32Hasher, compute_file_hash
+from pulpcore.exceptions import ImportError
 
 
 def write_chunk_files(tmp_path: Path, data_chunks: t.List[t.ByteString]):
@@ -131,7 +131,7 @@ def test_chunked_file_validate_raises(tmp_path, monkeypatch):
         tmp_path, data_chunks=chunks_list, chunk_size=chunk_size, corrupted=True
     )
     chunked_file = ChunkedFile(toc_path)
-    with pytest.raises(ValidationError, match="Import chunk hash mismatch.*"):
+    with pytest.raises(ImportError, match="Import chunk hash mismatch.*"):
         chunked_file.validate_chunks()
 
 
@@ -144,7 +144,7 @@ def test_chunked_file_shortread_exception(tmp_path):
     toc_path = create_tocfile(tmp_path, data_chunks=malformed_chunks_list, chunk_size=chunk_size)
     chunked_file = ChunkedFile(toc_path)
 
-    with pytest.raises(Exception, match=r"Short read from chunk \d*."):
+    with pytest.raises(ImportError, match=r"Short read from chunk \d*."):
         with chunked_file as fp:
             content_size = len(contiguous_data)
             fp.read(content_size)

--- a/pulpcore/tests/unit/test_import_checks.py
+++ b/pulpcore/tests/unit/test_import_checks.py
@@ -1,9 +1,8 @@
 import pytest
 
-from rest_framework.serializers import ValidationError
-
 import pulpcore.app.apps
 from pulpcore.app.tasks.importer import _check_versions
+from pulpcore.exceptions import ImportError
 
 
 def _pulp_plugin_configs():
@@ -34,20 +33,20 @@ def test_vers_check(monkeypatch):
     _check_versions(export_json)
 
     export_json = [{"component": "123", "version": "1.4.3"}]
-    with pytest.raises(ValidationError):
+    with pytest.raises(ImportError):
         _check_versions(export_json)
 
     export_json = [{"component": "123", "version": "2.2.3"}]
-    with pytest.raises(ValidationError):
+    with pytest.raises(ImportError):
         _check_versions(export_json)
 
     export_json = [{"component": "non_existent", "version": "1.2.3"}]
-    with pytest.raises(ValidationError):
+    with pytest.raises(ImportError):
         _check_versions(export_json)
 
     export_json = [
         {"component": "123", "version": "1.2.3"},
         {"component": "non_existent", "version": "1.2.3"},
     ]
-    with pytest.raises(ValidationError):
+    with pytest.raises(ImportError):
         _check_versions(export_json)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ requires-python = ">=3.11"
 dependencies = [
   "aiodns>=3.3.0,<3.7",  # Looks like only bugfixes in z-Stream.
   "aiofiles>=22.1,<=25.1.0",  # Uses sort of CalVer, luckily not released often https://github.com/Tinche/aiofiles/issues/144 .
-  "aiohttp>=3.8.3,<3.14",  # SemVer https://docs.aiohttp.org/en/stable/faq.html#what-is-the-api-stability-and-deprecation-policy .
+  "aiohttp>=3.10.10,<3.14",  # SemVer https://docs.aiohttp.org/en/stable/faq.html#what-is-the-api-stability-and-deprecation-policy .
   "asyncio-throttle>=1.0,<=1.0.2",  # Unsure about versioning, but not released often anyway.
   "backoff>=2.1.2,<2.3",  # Looks like only bugfixes in z-Stream.
   "click>=8.1.0,<8.4",  # Uses milestone.feature.fix https://palletsprojects.com/versions .
@@ -63,7 +63,7 @@ dependencies = [
   "url-normalize>=1.4.3,<2.3",  # SemVer. https://github.com/niksite/url-normalize/blob/master/CHANGELOG.md#changelog
   "uuid6>=2023.5.2,<=2025.0.1",
   "whitenoise>=5.0,<6.12.0",
-  "yarl>=1.9.1,<1.23",  # Seems to follow SemVer https://yarl.aio-libs.org/en/latest/contributing/release_guide/#pre-release-activities .
+  "yarl>=1.12.0,<1.23",  # Seems to follow SemVer https://yarl.aio-libs.org/en/latest/contributing/release_guide/#pre-release-activities .
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
- general_create/update now properly raise their ValidationErrors
- there are new Sync/PublishErrors for plugins
- import/export get their own errors
- rest of the validation errors now inherit from PulpException

After looking through the plugins, most exceptions are some Runtime or ValueError and I'm not sure if there is an easy generic we can put into Pulpcore to cover all. Many of them are in our big tasks like sync/publish so I created two catch-alls for Sync & Publish. I was thinking of creating a specific error for Download failures, but our download logic is too convoluted to find a good place, and all the plugins do their own thing to check if a download failed. One big exception I didn't bother with is RBAC hooks. If they fail on object creation then the task won't show useful info, but this should only happen if the user customizes their access policies incorrectly.

fixes: #7270
Assisted-by: claude-4.5-sonnet
https://issues.redhat.com/browse/PULP-1171

<!---
Thank you for submitting a PR to the Pulp Project!

If this is your first time contributing, please read the Pull Request Walkthrough documentation
(https://pulpproject.org/pulpcore/docs/dev/guides/pull-request-walkthrough/).
-->

### 📜 Checklist

- [ ] Commits are cleanly separated with meaningful messages (simple features and bug fixes should be [squashed](https://pulpproject.org/pulpcore/docs/dev/guides/git/#rebasing-and-squashing) to one commit)
- [ ] A [changelog entry](https://pulpproject.org/pulpcore/docs/dev/guides/git/#changelog-update) or entries has been added for any significant changes
- [ ] Follows the [Pulp policy on AI Usage](https://pulpproject.org/help/more/governance/ai_policy/)
- [ ] (For new features) - User documentation and test coverage has been added

See: [Pull Request Walkthrough](https://pulpproject.org/pulpcore/docs/dev/guides/pull-request-walkthrough/)