### PR TITLE
Improve logging for heartbeat failures by including the actual Exception

### DIFF
--- a/CHANGES/7235.feature
+++ b/CHANGES/7235.feature
@@ -1,0 +1,1 @@
+Improve the logging for heartbeat failures by including the actual Exception. It helps with troubleshooting.

--- a/pulpcore/app/entrypoint.py
+++ b/pulpcore/app/entrypoint.py
@@ -35,8 +35,8 @@ class PulpApiWorker(SyncWorker):
             try:
                 self.app_status.save_heartbeat()
                 logger.debug(self.beat_msg)
-            except (InterfaceError, DatabaseError):
-                logger.error(self.fail_beat_msg)
+            except (InterfaceError, DatabaseError) as e:
+                logger.error(f"{self.fail_beat_msg} Exception: {str(e)}")
                 exit(Arbiter.WORKER_BOOT_ERROR)
 
     def init_process(self):

--- a/pulpcore/content/__init__.py
+++ b/pulpcore/content/__init__.py
@@ -77,8 +77,8 @@ async def _heartbeat():
                 try:
                     await app_status.asave_heartbeat()
                     log.debug(msg)
-                except (InterfaceError, DatabaseError):
-                    log.error(fail_msg)
+                except (InterfaceError, DatabaseError) as e:
+                    log.error(f"{fail_msg} Exception: {str(e)}")
                     exit(Arbiter.WORKER_BOOT_ERROR)
     finally:
         if app_status:


### PR DESCRIPTION
Improving the logging for heartbeat failures. Right now we have a static message, which doesn't show the Exception details.
This will help with troubleshooting. 