### PR TITLE
Add dedicated publish config for GitHub releases

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -142,7 +142,7 @@ jobs:
         run: |
           # The last commit before the release commit contains the release CHANGES fragments
           git checkout "${TAG_NAME}~"
-          NOTES=$(towncrier build --draft --version $TAG_NAME)
+          NOTES=$(towncrier build --config towncrier-gh-release.toml --draft --version $TAG_NAME)
           echo "body<<EOF" >> $GITHUB_OUTPUT
           echo "$NOTES" >> $GITHUB_OUTPUT
           echo "EOF" >> $GITHUB_OUTPUT

--- a/CHANGES/+improve-github-docs.docs
+++ b/CHANGES/+improve-github-docs.docs
@@ -1,0 +1,1 @@
+Improve release text for GitHub releases via dedicated

--- a/CHANGES/.TEMPLATE-gh-release.md
+++ b/CHANGES/.TEMPLATE-gh-release.md
@@ -1,0 +1,44 @@
+{# TOWNCRIER TEMPLATE #}
+
+> [!NOTE]  
+> Changes are also available on [Pulp docs](https://pulpproject.org/pulpcore/changes/#{{ versiondata.version }})
+
+{% for section, _ in sections.items() %}
+{%- set section_slug = "-" + section|replace(" ", "-")|replace("_", "-")|lower %}
+{%- if section %}
+
+### {{section}}
+{% else %}
+{%- set section_slug = "" %}
+{% endif %}
+{% if sections[section] %}
+{% for category, val in definitions.items() if category in sections[section]%}
+
+#### {{ definitions[category]['name'] }}
+
+{% if definitions[category]['showcontent'] %}
+{% for text, values in sections[section][category].items() %}
+- {{ text }}
+{% if values %}
+  {{ values|join(',\n  ') }}
+{% endif %}
+{% endfor %}
+{% else %}
+- {{ sections[section][category]['']|join(', ') }}
+{% endif %}
+{% if sections[section][category]|length == 0 %}
+
+No significant changes.
+{% else %}
+{% endif %}
+{% endfor %}
+{% else %}
+
+No significant changes.
+{% endif %}
+{% endfor %}
+
+
+---
+
+

--- a/towncrier-gh-release.toml
+++ b/towncrier-gh-release.toml
@@ -1,0 +1,55 @@
+[tool.towncrier]
+package = "pulpcore"
+filename = "CHANGES.md"
+directory = "CHANGES/"
+title_format = "## {version} ({project_date})"
+template = "CHANGES/.TEMPLATE-gh-release.md"
+issue_format = "[#{issue}](https://github.com/pulp/pulpcore/issues/{issue})"
+start_string = "[//]: # (towncrier release notes start)\n"
+underlines = ["", "", ""]
+
+    [[tool.towncrier.section]]
+        path = ""
+        name = "REST API"
+
+    [[tool.towncrier.section]]
+        path = "plugin_api"
+        name = "Plugin API"
+
+    [[tool.towncrier.section]]
+        path = "pulp_file"
+        name = "Pulp File"
+
+    [[tool.towncrier.section]]
+        path = "pulp_certguard"
+        name = "Pulp Cert Guard"
+
+    [[tool.towncrier.type]]
+        directory = "feature"
+        name = "Features"
+        showcontent = true
+
+    [[tool.towncrier.type]]
+        directory = "bugfix"
+        name = "Bugfixes"
+        showcontent = true
+
+    [[tool.towncrier.type]]
+        directory = "doc"
+        name = "Improved Documentation"
+        showcontent = true
+
+    [[tool.towncrier.type]]
+        directory = "removal"
+        name = "Removals"
+        showcontent = true
+
+    [[tool.towncrier.type]]
+        directory = "deprecation"
+        name = "Deprecations"
+        showcontent = true
+
+    [[tool.towncrier.type]]
+        directory = "misc"
+        name = "Misc"
+        showcontent = false


### PR DESCRIPTION
Release notes are done for GitHub since a bit of time, but the towncrier template contains some metadata that is probably useful for the Pulp docs, but horrible for the GitHub release pages. Emphasizing the "cry" in towncrier or something.

I've modified the template for the purpose of GitHub releases to not have that metadata in there. Additionally this is also linking to the pulpcore docs.

I did a release on my [fork](https://github.com/StopMotionCuber/pulpcore/releases/tag/4.0.0), to give an example on how this would look.

My implementation is duplicating the configuration at 2 places (2 towncrier configs, 2 towncrier templates). This could also be done by some `sed` magic for the towncrier config (during gh publish process) and making the template more complicated, like more conditional rendering instead of a second template. Not sure what is the better path here.

### 📜 Checklist

- [x] Commits are cleanly separated with meaningful messages (simple features and bug fixes should be [squashed](https://pulpproject.org/pulpcore/docs/dev/guides/git/#rebasing-and-squashing) to one commit)
- [x] A [changelog entry](https://pulpproject.org/pulpcore/docs/dev/guides/git/#changelog-update) or entries has been added for any significant changes
- [x] Follows the [Pulp policy on AI Usage](https://pulpproject.org/help/more/governance/ai_policy/)
- [x] (For new features) - User documentation and test coverage has been added

