### PR TITLE
[PULP-1118] Add better error handling for repover duplicate content

### DIFF
--- a/CHANGES/7184.feature
+++ b/CHANGES/7184.feature
@@ -1,0 +1,2 @@
+Added better error handling for errors when creating RepositoryVersions.
+Now the duplicate content pks are shown in the logs.

--- a/pulpcore/exceptions/__init__.py
+++ b/pulpcore/exceptions/__init__.py
@@ -24,5 +24,6 @@ from .validation import (
     ValidationError,
     MissingDigestValidationError,
     UnsupportedDigestValidationError,
+    DuplicateContentInRepositoryError,
 )
 from .plugin import MissingPlugin

--- a/pulpcore/exceptions/validation.py
+++ b/pulpcore/exceptions/validation.py
@@ -119,3 +119,21 @@ class InvalidSignatureError(ValidationError):
 
     def __str__(self):
         return f"[{self.error_code}] {self.message}"
+
+
+class DuplicateContentInRepositoryError(ValidationError):
+    """
+    Raised when duplicate content is detected within a Repository (Version).
+    """
+
+    error_code = "PLP0022"
+
+    def __init__(self, duplicate_count: int, correlation_id: str):
+        self.dup_count = duplicate_count
+        self.cid = correlation_id
+
+    def __str__(self):
+        return f"[{self.error_code}] " + _(
+            "Found {n} duplicate contents in repository version"
+            "(see the logs (cid={cid}) for details).".format(n=self.dup_count, cid=self.cid)
+        )


### PR DESCRIPTION
Added a proper error class for duplicate content handling and some more logging to inform exactly what are the conflicting content.

When duplicates are detected, we do some extra work to collect duplicate content.
A simple performance test shows it's not *too bad*:

```python
In [1]: import pulpcore.plugin.repo_version_utils as ut

In [2]: content_qs = Package.objects.all()

In [3]: unique_keys = Package.repo_key_fields

In [4]: content_qs.count()
Out[4]: 24547

In [5]: ut.count_duplicates(content_qs, unique_keys)
Out[5]: 7701

In [6]: %timeit ut.count_duplicates(content_qs, unique_keys)
35.1 ms ± 154 μs per loop (mean ± std. dev. of 7 runs, 10 loops each)

In [7]: %timeit ut.collect_duplicates(content_qs, unique_keys)
61.4 ms ± 266 μs per loop (mean ± std. dev. of 7 runs, 10 loops each)
```

Closes: #7184

### 📜 Checklist

- [x] Commits are cleanly separated with meaningful messages (simple features and bug fixes should be [squashed](https://pulpproject.org/pulpcore/docs/dev/guides/git/#rebasing-and-squashing) to one commit)
- [x] A [changelog entry](https://pulpproject.org/pulpcore/docs/dev/guides/git/#changelog-update) or entries has been added for any significant changes
- [x] Follows the [Pulp policy on AI Usage](https://pulpproject.org/help/more/governance/ai_policy/)
- [x] (For new features) - User documentation and test coverage has been added

See: [Pull Request Walkthrough](https://pulpproject.org/pulpcore/docs/dev/guides/pull-request-walkthrough/)