### PR TITLE
Remove extra db query on PRNField for generic list endpoints

### DIFF
--- a/CHANGES/+prn-field-db-cast.bugfix
+++ b/CHANGES/+prn-field-db-cast.bugfix
@@ -1,0 +1,1 @@
+Fixed PRNField slowing down the generic list endpoints with extra database queries.

--- a/pulpcore/app/serializers/base.py
+++ b/pulpcore/app/serializers/base.py
@@ -170,6 +170,10 @@ class PRNField(serializers.StringRelatedField):
         super().__init__(**kwargs)
 
     def to_representation(self, value):
+        if isinstance(value, MasterModel):
+            # Cast optimization to avoid performing a database query
+            model = value.get_model_for_pulp_type(value.pulp_type)
+            value = model(pk=value.pk)
         return get_prn(instance=value)
 
 


### PR DESCRIPTION
When I introduced the PRNField I also introduced this little N+1 db query for our generic list endpoints since the PRNField does a quick `cast()` before returning the result. Just reuse the same trick we do for the href field. 

### 📜 Checklist

- [ ] Commits are cleanly separated with meaningful messages (simple features and bug fixes should be [squashed](https://pulpproject.org/pulpcore/docs/dev/guides/git/#rebasing-and-squashing) to one commit)
- [ ] A [changelog entry](https://pulpproject.org/pulpcore/docs/dev/guides/git/#changelog-update) or entries has been added for any significant changes
- [ ] Follows the [Pulp policy on AI Usage](https://pulpproject.org/help/more/governance/ai_policy/)
- [ ] (For new features) - User documentation and test coverage has been added

See: [Pull Request Walkthrough](https://pulpproject.org/pulpcore/docs/dev/guides/pull-request-walkthrough/)