### PR TITLE
[PULP-817] Django5 support and adjustments to make imp/exp work with django-imp-exp 4.x.

### DIFF
--- a/.ci/assets/ci_constraints.txt
+++ b/.ci/assets/ci_constraints.txt
@@ -16,3 +16,4 @@ azure-storage-blob!=12.28.*
 
 pycares<5
 # older aiodns versions don't pin pycares UB, and are broken by pycares>=5
+

--- a/.github/workflows/scripts/install.sh
+++ b/.github/workflows/scripts/install.sh
@@ -79,7 +79,7 @@ cat >> vars/main.yaml << VARSYAML
 pulp_env: {"PULP_CA_BUNDLE": "/etc/pulp/certs/pulp_webserver.crt"}
 pulp_settings: {"allowed_export_paths": ["/tmp"], "allowed_import_paths": ["/tmp"], "orphan_protection_time": 0}
 pulp_scheme: https
-pulp_default_container: ghcr.io/pulp/pulp-ci-centos:latest
+pulp_default_container: ghcr.io/pulp/pulp-ci-centos9:latest
 VARSYAML
 
 SCENARIOS=("pulp" "performance" "azure" "gcp" "s3" "generate-bindings" "lowerbounds")
@@ -105,7 +105,7 @@ if [ "$TEST" = "s3" ]; then
   sed -i -e '$a s3_test: true\
 minio_access_key: "'$MINIO_ACCESS_KEY'"\
 minio_secret_key: "'$MINIO_SECRET_KEY'"\
-pulp_scenario_settings: {"AWS_ACCESS_KEY_ID": "AKIAIT2Z5TDYPX3ARJBA", "AWS_DEFAULT_ACL": "@none None", "AWS_S3_ADDRESSING_STYLE": "path", "AWS_S3_ENDPOINT_URL": "http://minio:9000", "AWS_S3_REGION_NAME": "eu-central-1", "AWS_S3_SIGNATURE_VERSION": "s3v4", "AWS_SECRET_ACCESS_KEY": "fqRvjWaPU5o0fCqQuUWbj9Fainj2pVZtBCiDiieS", "AWS_STORAGE_BUCKET_NAME": "pulp3", "DEFAULT_FILE_STORAGE": "storages.backends.s3boto3.S3Boto3Storage", "MEDIA_ROOT": "", "domain_enabled": true, "hide_guarded_distributions": true}\
+pulp_scenario_settings: {"MEDIA_ROOT": "", "STORAGES": {"default": {"BACKEND": "storages.backends.s3boto3.S3Boto3Storage", "OPTIONS": {"access_key": "AKIAIT2Z5TDYPX3ARJBA", "addressing_style": "path", "bucket_name": "pulp3", "default_acl": "@none", "endpoint_url": "http://minio:9000", "region_name": "eu-central-1", "secret_key": "fqRvjWaPU5o0fCqQuUWbj9Fainj2pVZtBCiDiieS", "signature_version": "s3v4"}}, "staticfiles": {"BACKEND": "django.contrib.staticfiles.storage.StaticFilesStorage"}}, "domain_enabled": true, "hide_guarded_distributions": true}\
 pulp_scenario_env: {}\
 ' vars/main.yaml
   export PULP_API_ROOT="/rerouted/djnd/"
@@ -119,7 +119,7 @@ if [ "$TEST" = "azure" ]; then
       - ./azurite:/etc/pulp\
     command: "azurite-blob --skipApiVersionCheck --blobHost 0.0.0.0"' vars/main.yaml
   sed -i -e '$a azure_test: true\
-pulp_scenario_settings: {"AZURE_ACCOUNT_KEY": "Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==", "AZURE_ACCOUNT_NAME": "devstoreaccount1", "AZURE_CONNECTION_STRING": "DefaultEndpointsProtocol=http;AccountName=devstoreaccount1;AccountKey=Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==;BlobEndpoint=http://ci-azurite:10000/devstoreaccount1;", "AZURE_CONTAINER": "pulp-test", "AZURE_LOCATION": "pulp3", "AZURE_OVERWRITE_FILES": true, "AZURE_URL_EXPIRATION_SECS": 120, "DEFAULT_FILE_STORAGE": "storages.backends.azure_storage.AzureStorage", "MEDIA_ROOT": "", "domain_enabled": true}\
+pulp_scenario_settings: {"MEDIA_ROOT": "", "STORAGES": {"default": {"BACKEND": "storages.backends.azure_storage.AzureStorage", "OPTIONS": {"account_key": "Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==", "account_name": "devstoreaccount1", "azure_container": "pulp-test", "connection_string": "DefaultEndpointsProtocol=http;AccountName=devstoreaccount1;AccountKey=Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==;BlobEndpoint=http://ci-azurite:10000/devstoreaccount1;", "expiration_secs": 120, "location": "pulp3", "overwrite_files": true}}, "staticfiles": {"BACKEND": "django.contrib.staticfiles.storage.StaticFilesStorage"}}, "domain_enabled": true}\
 pulp_scenario_env: {}\
 ' vars/main.yaml
 fi

--- a/CHANGES/5324.feature
+++ b/CHANGES/5324.feature
@@ -1,0 +1,1 @@
+Adapted PulpImport/Export to allow update django-import-export==4.x.

--- a/CHANGES/6988.feature
+++ b/CHANGES/6988.feature
@@ -1,0 +1,1 @@
+Allow use of Django5 as well as Django4.

--- a/lint_requirements.txt
+++ b/lint_requirements.txt
@@ -6,6 +6,9 @@
 # For more info visit https://github.com/pulp/plugin_template
 
 black==24.3.0
+# Click is pinned because of:
+# https://github.com/pallets/click/issues/3065
+click<8.3
 bump-my-version
 check-manifest
 flake8

--- a/pulpcore/app/apps.py
+++ b/pulpcore/app/apps.py
@@ -5,7 +5,6 @@ from gettext import gettext as _
 from importlib import import_module
 
 from django import apps
-from django.conf import settings
 from django.core.exceptions import ImproperlyConfigured
 from django.db import connection, transaction
 from django.db.models.signals import post_migrate
@@ -66,6 +65,12 @@ class PulpPluginAppConfig(apps.AppConfig):
 
     def __init__(self, app_name, app_module):
         super().__init__(app_name, app_module)
+        # begin compatibility layer for DEFAULT_FILE_STORAGE deprecation
+        # Workaround for getting the up-to-date settings instance
+        from django.conf import settings
+
+        self.settings = settings
+        # end
 
         try:
             self.version
@@ -307,6 +312,7 @@ def _populate_system_id(sender, apps, verbosity, **kwargs):
 
 
 def _ensure_default_domain(sender, **kwargs):
+    settings = sender.settings
     table_names = connection.introspection.table_names()
     if "core_domain" in table_names:
         from pulpcore.app.util import get_default_domain
@@ -316,11 +322,11 @@ def _ensure_default_domain(sender, **kwargs):
         if (
             settings.HIDE_GUARDED_DISTRIBUTIONS != default.hide_guarded_distributions
             or settings.REDIRECT_TO_OBJECT_STORAGE != default.redirect_to_object_storage
-            or settings.DEFAULT_FILE_STORAGE != default.storage_class
+            or settings.STORAGES["default"]["BACKEND"] != default.storage_class
         ):
             default.hide_guarded_distributions = settings.HIDE_GUARDED_DISTRIBUTIONS
             default.redirect_to_object_storage = settings.REDIRECT_TO_OBJECT_STORAGE
-            default.storage_class = settings.DEFAULT_FILE_STORAGE
+            default.storage_class = settings.STORAGES["default"]["BACKEND"]
             default.save(skip_hooks=True)
 
 
@@ -386,8 +392,9 @@ def adjust_roles(apps, role_prefix, desired_roles, verbosity=1):
 
 
 def _populate_artifact_serving_distribution(sender, apps, verbosity, **kwargs):
+    settings = sender.settings
     if (
-        settings.DEFAULT_FILE_STORAGE == "pulpcore.app.models.storage.FileSystem"
+        settings.STORAGES["default"]["BACKEND"] == "pulpcore.app.models.storage.FileSystem"
         or not settings.REDIRECT_TO_OBJECT_STORAGE
     ):
         try:

--- a/pulpcore/app/checks.py
+++ b/pulpcore/app/checks.py
@@ -23,7 +23,7 @@ def content_origin_check(app_configs, **kwargs):
 def storage_paths(app_configs, **kwargs):
     warnings = []
 
-    if settings.DEFAULT_FILE_STORAGE == "pulpcore.app.models.storage.FileSystem":
+    if settings.STORAGES["default"]["BACKEND"] == "pulpcore.app.models.storage.FileSystem":
         try:
             media_root_dev = Path(settings.MEDIA_ROOT).stat().st_dev
         except OSError:

--- a/pulpcore/app/importexport.py
+++ b/pulpcore/app/importexport.py
@@ -47,6 +47,10 @@ def _write_export(the_tarfile, resource, dest_dir=None):
     # the data in batches to memory and concatenate the json lists via string manipulation.
     with tempfile.NamedTemporaryFile(dir=".", mode="w", encoding="utf8") as temp_file:
         if isinstance(resource.queryset, QuerySet):
+            # If we don't have any of "these" - skip writing
+            if resource.queryset.count() == 0:
+                return
+
             temp_file.write("[")
 
             def process_batch(batch):
@@ -117,7 +121,7 @@ def export_artifacts(export, artifacts):
     with ProgressReport(**data) as pb:
         pb.BATCH_INTERVAL = 5000
 
-        if settings.DEFAULT_FILE_STORAGE != "pulpcore.app.models.storage.FileSystem":
+        if settings.STORAGES["default"]["BACKEND"] != "pulpcore.app.models.storage.FileSystem":
             with tempfile.TemporaryDirectory(dir=".") as temp_dir:
                 for artifact in pb.iter(artifacts.only("file").iterator()):
                     with tempfile.NamedTemporaryFile(dir=temp_dir) as temp_file:

--- a/pulpcore/app/modelresource.py
+++ b/pulpcore/app/modelresource.py
@@ -1,3 +1,4 @@
+from django.conf import settings
 from import_export import fields
 from import_export.widgets import ForeignKeyWidget
 from logging import getLogger
@@ -36,8 +37,8 @@ class ArtifactResource(QueryModelResource):
         # the export converts None to blank strings but sha384 and sha512 have unique constraints
         # that get triggered if they are blank. convert checksums back into None if they are blank.
         for checksum in ALL_KNOWN_CONTENT_CHECKSUMS:
-            if row[checksum] == "":
-                row[checksum] = None
+            if row[checksum] == "" or checksum not in settings.ALLOWED_CONTENT_CHECKSUMS:
+                del row[checksum]
 
     class Meta:
         model = Artifact

--- a/pulpcore/app/models/domain.py
+++ b/pulpcore/app/models/domain.py
@@ -1,4 +1,5 @@
-from django.core.files.storage import get_storage_class, default_storage
+from django.core.files.storage import default_storage
+from django.utils.module_loading import import_string
 from django.db import models
 from django_lifecycle import hook, BEFORE_DELETE, BEFORE_UPDATE
 
@@ -41,7 +42,7 @@ class Domain(BaseModel, AutoAddObjPermsMixin):
         """Returns this domain's instantiated storage class."""
         if self.name == "default":
             return default_storage
-        storage_class = get_storage_class(self.storage_class)
+        storage_class = import_string(self.storage_class)
         return storage_class(**self.storage_settings)
 
     @hook(BEFORE_DELETE, when="name", is_now="default")

--- a/pulpcore/app/serializers/domain.py
+++ b/pulpcore/app/serializers/domain.py
@@ -1,7 +1,7 @@
 from gettext import gettext as _
 
 from django.conf import settings
-from django.core.files.storage import import_string
+from django.utils.module_loading import import_string
 from django.core.exceptions import ImproperlyConfigured
 from drf_spectacular.types import OpenApiTypes
 from drf_spectacular.utils import extend_schema_field
@@ -40,7 +40,10 @@ class BaseSettingsClass(HiddenFieldsMixin, serializers.Serializer):
         # Should I convert back the saved settings to their Setting names for to_representation?
         if getattr(self.context.get("domain", None), "name", None) == "default":
             for setting_name, field in self.SETTING_MAPPING.items():
-                if value := getattr(settings, setting_name.upper(), None):
+                value = getattr(settings, setting_name, None) or settings.STORAGES["default"].get(
+                    "OPTIONS", {}
+                ).get(field)
+                if value:
                     instance[field] = value
         return super().to_representation(instance)
 

--- a/pulpcore/app/tasks/export.py
+++ b/pulpcore/app/tasks/export.py
@@ -71,7 +71,7 @@ def _export_to_file_system(path, relative_paths_to_artifacts, method=FS_EXPORT_M
         ValidationError: When path is not in the ALLOWED_EXPORT_PATHS setting
     """
     using_filesystem_storage = (
-        settings.DEFAULT_FILE_STORAGE == "pulpcore.app.models.storage.FileSystem"
+        settings.STORAGES["default"]["BACKEND"] == "pulpcore.app.models.storage.FileSystem"
     )
 
     if method != FS_EXPORT_METHODS.WRITE and not using_filesystem_storage:

--- a/pulpcore/app/tasks/importer.py
+++ b/pulpcore/app/tasks/importer.py
@@ -101,6 +101,9 @@ def _import_file(fpath, resource_class, retry=False):
     """
     try:
         log.info(f"Importing file {fpath}.")
+        if not os.path.isfile(fpath):
+            log.info("...empty - skipping.")
+            return []
         with open(fpath, "r") as json_file:
             resource = resource_class()
             log.info(f"...Importing resource {resource.__class__.__name__}.")
@@ -109,6 +112,8 @@ def _import_file(fpath, resource_class, retry=False):
             # overlapping content.
             for batch_str in _impfile_iterator(json_file):
                 data = Dataset().load(StringIO(batch_str))
+                if not data:
+                    return []
                 if retry:
                     curr_attempt = 1
 
@@ -140,6 +145,7 @@ def _import_file(fpath, resource_class, retry=False):
                         try:
                             a_result = resource.import_data(data, raise_errors=True)
                         except Exception as e:  # noqa log on ANY exception and then re-raise
+                            log.error(e)
                             log.error(f"FATAL import-failure importing {fpath}")
                             raise
                 else:

--- a/pulpcore/app/util.py
+++ b/pulpcore/app/util.py
@@ -387,7 +387,7 @@ def get_artifact_url(artifact, headers=None, http_method=None):
         if settings.DOMAIN_ENABLED:
             loc = f"domain {artifact_domain.name}.storage_class"
         else:
-            loc = "settings.DEFAULT_FILE_STORAGE"
+            loc = "settings.STORAGES['default']['BACKEND']"
 
         raise NotImplementedError(
             f"The value {loc}={artifact_domain.storage_class} does not allow redirecting."
@@ -433,7 +433,9 @@ def get_default_domain():
         try:
             default_domain = Domain.objects.get(name="default")
         except Domain.DoesNotExist:
-            default_domain = Domain(name="default", storage_class=settings.DEFAULT_FILE_STORAGE)
+            default_domain = Domain(
+                name="default", storage_class=settings.STORAGES["default"]["BACKEND"]
+            )
             default_domain.save(skip_hooks=True)
 
     return default_domain

--- a/pulpcore/app/views/status.py
+++ b/pulpcore/app/views/status.py
@@ -18,7 +18,7 @@ _logger = logging.getLogger(__name__)
 
 
 def _disk_usage():
-    if settings.DEFAULT_FILE_STORAGE == "pulpcore.app.models.storage.FileSystem":
+    if settings.STORAGES["default"]["BACKEND"] == "pulpcore.app.models.storage.FileSystem":
         try:
             return shutil.disk_usage(default_storage.location)
         except Exception:

--- a/pulpcore/plugin/importexport.py
+++ b/pulpcore/plugin/importexport.py
@@ -41,6 +41,9 @@ class QueryModelResource(resources.ModelResource):
     def dehydrate_pulp_domain(self, content):
         return str(content.pulp_domain_id)
 
+    def render(self, value, obj=None, **kwargs):
+        return super().render(value, obj, coerce_to_string=False, **kwargs)
+
     def __init__(self, repo_version=None):
         self.repo_version = repo_version
         if repo_version:

--- a/pulpcore/tests/functional/api/test_artifact_distribution.py
+++ b/pulpcore/tests/functional/api/test_artifact_distribution.py
@@ -2,9 +2,6 @@ import requests
 import subprocess
 from hashlib import sha256
 
-from django.conf import settings
-
-
 OBJECT_STORAGES = (
     "storages.backends.s3boto3.S3Boto3Storage",
     "storages.backends.azure_storage.AzureStorage",
@@ -12,7 +9,7 @@ OBJECT_STORAGES = (
 )
 
 
-def test_artifact_distribution(random_artifact):
+def test_artifact_distribution(random_artifact, pulp_settings):
     artifact_uuid = random_artifact.pulp_href.split("/")[-2]
 
     commands = (
@@ -29,7 +26,7 @@ def test_artifact_distribution(random_artifact):
     hasher = sha256()
     hasher.update(response.content)
     assert hasher.hexdigest() == random_artifact.sha256
-    if settings.DEFAULT_FILE_STORAGE in OBJECT_STORAGES:
+    if pulp_settings.STORAGES["default"]["BACKEND"] in OBJECT_STORAGES:
         content_disposition = response.headers.get("Content-Disposition")
         assert content_disposition is not None
         filename = artifact_uuid

--- a/pulpcore/tests/functional/api/test_crd_artifacts.py
+++ b/pulpcore/tests/functional/api/test_crd_artifacts.py
@@ -6,7 +6,6 @@ import os
 import uuid
 import pytest
 
-from django.conf import settings
 from pulpcore.client.pulpcore import ApiException
 
 
@@ -144,11 +143,11 @@ def test_upload_mixed_attrs(artifacts_api_client, pulpcore_random_file):
 
 
 @pytest.mark.parallel
-def test_delete_artifact(artifacts_api_client, pulpcore_random_file):
+def test_delete_artifact(artifacts_api_client, pulpcore_random_file, pulp_settings):
     """Delete an artifact, it is removed from the filesystem."""
-    if settings.DEFAULT_FILE_STORAGE != "pulpcore.app.models.storage.FileSystem":
+    if pulp_settings.STORAGES["default"]["BACKEND"] != "pulpcore.app.models.storage.FileSystem":
         pytest.skip("this test only works for filesystem storage")
-    media_root = settings.MEDIA_ROOT
+    media_root = pulp_settings.MEDIA_ROOT
 
     artifact = artifacts_api_client.create(pulpcore_random_file["name"])
     path_to_file = os.path.join(media_root, artifact.file)

--- a/pulpcore/tests/functional/api/test_status.py
+++ b/pulpcore/tests/functional/api/test_status.py
@@ -2,7 +2,6 @@
 
 import pytest
 
-from django.conf import settings
 from jsonschema import validate
 from pulpcore.client.pulpcore import ApiException
 
@@ -59,9 +58,9 @@ STATUS = {
 
 
 @pytest.fixture(scope="module")
-def expected_pulp_status_schema():
+def expected_pulp_status_schema(pulp_settings):
     """Returns the expected status response."""
-    if settings.DEFAULT_FILE_STORAGE != "pulpcore.app.models.storage.FileSystem":
+    if pulp_settings.STORAGES["default"]["BACKEND"] != "pulpcore.app.models.storage.FileSystem":
         STATUS["properties"]["storage"].pop("properties")
         STATUS["properties"]["storage"]["type"] = "null"
 

--- a/pulpcore/tests/unit/models/test_content.py
+++ b/pulpcore/tests/unit/models/test_content.py
@@ -43,7 +43,7 @@ def test_create_read_delete_content(tmp_path):
 
 @pytest.mark.django_db
 def test_storage_location(tmp_path, settings):
-    if settings.DEFAULT_FILE_STORAGE != "pulpcore.app.models.storage.FileSystem":
+    if settings.STORAGES["default"]["BACKEND"] != "pulpcore.app.models.storage.FileSystem":
         pytest.skip("Skipping test for nonlocal storage.")
 
     tf = tmp_path / "ab"

--- a/pulpcore/tests/unit/viewsets/test_viewset_base.py
+++ b/pulpcore/tests/unit/viewsets/test_viewset_base.py
@@ -1,5 +1,5 @@
 import pytest
-from pytest_django.asserts import assertQuerysetEqual
+from pytest_django.asserts import assertQuerySetEqual
 import unittest
 
 from django.http import Http404, QueryDict
@@ -23,7 +23,7 @@ def test_adds_filters():
     queryset = viewset.get_queryset()
     expected = models.RepositoryVersion.objects.filter(repository__pk=repo.pk)
 
-    assertQuerysetEqual(queryset, expected)
+    assertQuerySetEqual(queryset, expected)
 
 
 @pytest.mark.django_db
@@ -38,7 +38,7 @@ def test_does_not_add_filters():
     queryset = viewset.get_queryset()
     expected = models.Repository.objects.all()
 
-    assertQuerysetEqual(queryset, expected)
+    assertQuerySetEqual(queryset, expected)
 
 
 def test_must_define_serializer_class():

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,15 +1,15 @@
 aiodns>=3.0,<=3.2.0
 aiofiles>=22.1,<23.3.0
-aiohttp>=3.8.1,<3.10.12
+aiohttp>=3.9.0,<3.10.12
 asyncio-throttle>=1.0,<=1.0.2
 async-timeout>=4.0.3,<4.0.4;python_version<"3.11"
 backoff>=2.1.2,<2.2.2
 click>=8.1.0,<=8.1.7
 cryptography>=38.0.1,<42.0.9
-Django~=4.2.0  # LTS version, switch only if we have a compelling reason to
+Django>=4.2.24,<5.3, !=5.0, !=5.1  # LTS version, switch only if we have a compelling reason to
 django-filter>=23.1,<=23.5
 django-guid>=3.3,<=3.4.0
-django-import-export>=2.9,<3.4.0
+django-import-export>=2.9,<5.0
 django-lifecycle>=1.0,<=1.1.2
 djangorestframework>=3.14.0,<=3.15.2
 djangorestframework-queryfields>=1.0,<=1.1.0
@@ -35,8 +35,8 @@ python-gnupg>=0.5,<=0.5.2
 PyYAML>=5.1.1,<=6.0.1
 redis>=4.3,<5.0.3
 setuptools>=39.2,<69.1.0
-tablib<3.6.0
+tablib>=3.5.0,<4.0, !=3.6
 url-normalize>=1.4.3,<=1.4.3
 uuid6>=2023.5.2,<=2024.1.12
 whitenoise>=5.0,<6.7.0
-yarl>=1.8,<1.15.3
+yarl>=1.9.0,<1.15.3

--- a/template_config.yml
+++ b/template_config.yml
@@ -1,15 +1,10 @@
-# This config represents the latest values used when running the plugin-template. Any settings that
-# were not present before running plugin-template have been added with their default values.
-
-# generated with plugin_template
-
 api_root: /pulp/
 black: true
 check_commit_message: true
 check_gettext: true
 check_manifest: true
 check_stray_pulpcore_imports: false
-ci_base_image: ghcr.io/pulp/pulp-ci-centos
+ci_base_image: ghcr.io/pulp/pulp-ci-centos9
 ci_env: {}
 ci_trigger: '{pull_request: {branches: [''*'']}}'
 cli_package: pulp-cli
@@ -51,30 +46,40 @@ pulp_settings:
   - /tmp
   orphan_protection_time: 0
 pulp_settings_azure:
-  AZURE_ACCOUNT_KEY: Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==
-  AZURE_ACCOUNT_NAME: devstoreaccount1
-  AZURE_CONNECTION_STRING: DefaultEndpointsProtocol=http;AccountName=devstoreaccount1;AccountKey=Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==;BlobEndpoint=http://ci-azurite:10000/devstoreaccount1;
-  AZURE_CONTAINER: pulp-test
-  AZURE_LOCATION: pulp3
-  AZURE_OVERWRITE_FILES: true
-  AZURE_URL_EXPIRATION_SECS: 120
-  DEFAULT_FILE_STORAGE: storages.backends.azure_storage.AzureStorage
   MEDIA_ROOT: ''
+  STORAGES:
+    default:
+      BACKEND: storages.backends.azure_storage.AzureStorage
+      OPTIONS:
+        account_key: Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==
+        account_name: devstoreaccount1
+        connection_string: DefaultEndpointsProtocol=http;AccountName=devstoreaccount1;AccountKey=Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==;BlobEndpoint=http://ci-azurite:10000/devstoreaccount1;
+        azure_container: pulp-test
+        location: pulp3
+        overwrite_files: true
+        expiration_secs: 120
+    staticfiles:
+      BACKEND: django.contrib.staticfiles.storage.StaticFilesStorage
   domain_enabled: true
 pulp_settings_gcp: null
 pulp_settings_s3:
-  AWS_ACCESS_KEY_ID: AKIAIT2Z5TDYPX3ARJBA
-  AWS_DEFAULT_ACL: '@none None'
-  AWS_S3_ADDRESSING_STYLE: path
-  AWS_S3_ENDPOINT_URL: http://minio:9000
-  AWS_S3_REGION_NAME: eu-central-1
-  AWS_S3_SIGNATURE_VERSION: s3v4
-  AWS_SECRET_ACCESS_KEY: fqRvjWaPU5o0fCqQuUWbj9Fainj2pVZtBCiDiieS
-  AWS_STORAGE_BUCKET_NAME: pulp3
-  DEFAULT_FILE_STORAGE: storages.backends.s3boto3.S3Boto3Storage
   MEDIA_ROOT: ''
   domain_enabled: true
   hide_guarded_distributions: true
+  STORAGES:
+    default:
+      BACKEND: storages.backends.s3boto3.S3Boto3Storage
+      OPTIONS:
+        access_key: AKIAIT2Z5TDYPX3ARJBA
+        secret_key: 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
+        bucket_name: pulp3
+        endpoint_url: http://minio:9000
+        region_name: eu-central-1
+        signature_version: s3v4
+        addressing_style: path
+        default_acl: '@none'
+    staticfiles:
+      BACKEND: django.contrib.staticfiles.storage.StaticFilesStorage
 pydocstyle: true
 release_email: pulp-infra@redhat.com
 release_user: pulpbot
@@ -99,4 +104,3 @@ test_performance: false
 test_reroute: true
 test_s3: true
 use_issue_template: true
-


### PR DESCRIPTION
(cherry picked from commit 793c0ad638254ef76fb379e44d49a5dea0613751)

closes #5324.
closes #6988.


Assisted by: cursor agent

<!---
Thank you for submitting a PR to the Pulp Project!

If this is your first time contributing, please read the Pull Request Walkthrough documentation
(https://pulpproject.org/pulpcore/docs/dev/guides/pull-request-walkthrough/).
-->

### 📜 Checklist

- [ ] Commits are cleanly separated with meaningful messages (simple features and bug fixes should be [squashed](https://pulpproject.org/pulpcore/docs/dev/guides/git/#rebasing-and-squashing) to one commit)
- [ ] A [changelog entry](https://pulpproject.org/pulpcore/docs/dev/guides/git/#changelog-update) or entries has been added for any significant changes
- [ ] Follows the [Pulp policy on AI Usage](https://pulpproject.org/help/more/governance/ai_policy/)
- [ ] (For new features) - User documentation and test coverage has been added

See: [Pull Request Walkthrough](https://pulpproject.org/pulpcore/docs/dev/guides/pull-request-walkthrough/)