### PR TITLE
Fix accidental API-break to PulpException

### DIFF
--- a/CHANGES/+pulp-exception.bugfix
+++ b/CHANGES/+pulp-exception.bugfix
@@ -1,0 +1,1 @@
+Fixed an accidental API-breaking change to `PulpException` in the previous release.

--- a/pulpcore/exceptions/base.py
+++ b/pulpcore/exceptions/base.py
@@ -1,5 +1,6 @@
 import http.client
 from gettext import gettext as _
+from pulpcore.app.loggers import deprecation_logger
 
 
 class PulpException(Exception):
@@ -10,7 +11,14 @@ class PulpException(Exception):
     http_status_code = http.client.INTERNAL_SERVER_ERROR
     error_code = None
 
-    def __init__(self):
+    def __init__(self, error_code=None):
+        if error_code:
+            deprecation_logger.warning(
+                "Constructing a PulpException with argument `error_code` is deprecated and will "
+                "be removed in a future release. Instead please create a new error Subclass with "
+                "predefined `error_code` attribute"
+            )
+            self.error_code = error_code
         if not isinstance(self.error_code, str):
             raise NotImplementedError("ABC error. Subclass must define a unique error code.")
 


### PR DESCRIPTION
Fixes an API break introduced in https://github.com/pulp/pulpcore/pull/7271

<!---
Thank you for submitting a PR to the Pulp Project!

If this is your first time contributing, please read the Pull Request Walkthrough documentation
(https://pulpproject.org/pulpcore/docs/dev/guides/pull-request-walkthrough/).
-->

### 📜 Checklist

- [ ] Commits are cleanly separated with meaningful messages (simple features and bug fixes should be [squashed](https://pulpproject.org/pulpcore/docs/dev/guides/git/#rebasing-and-squashing) to one commit)
- [ ] A [changelog entry](https://pulpproject.org/pulpcore/docs/dev/guides/git/#changelog-update) or entries has been added for any significant changes
- [ ] Follows the [Pulp policy on AI Usage](https://pulpproject.org/help/more/governance/ai_policy/)
- [ ] (For new features) - User documentation and test coverage has been added

See: [Pull Request Walkthrough](https://pulpproject.org/pulpcore/docs/dev/guides/pull-request-walkthrough/)