### PR TITLE
Add caching around apidoc endpoints

### DIFF
--- a/CHANGES/+api_doc_cache.feature
+++ b/CHANGES/+api_doc_cache.feature
@@ -1,0 +1,1 @@
+Add memory caching for api doc endpoints.

--- a/pulpcore/app/settings.py
+++ b/pulpcore/app/settings.py
@@ -318,6 +318,13 @@ ALLOWED_IMPORT_PATHS = []
 
 ALLOWED_EXPORT_PATHS = []
 
+# https://docs.djangoproject.com/en/5.2/ref/settings/#std-setting-CACHES
+CACHES = {
+    "default": {
+        "BACKEND": "django.core.cache.backends.locmem.LocMemCache",
+    },
+}
+
 # https://pulpproject.org/pulpcore/docs/admin/reference/settings/?h=settings#cache_enabled
 CACHE_ENABLED = False
 CACHE_SETTINGS = {

--- a/pulpcore/app/urls.py
+++ b/pulpcore/app/urls.py
@@ -2,6 +2,7 @@
 
 from django.conf import settings
 from django.urls import path, include
+from django.views.decorators.cache import cache_page
 from drf_spectacular.utils import extend_schema
 from drf_spectacular.views import (
     SpectacularJSONAPIView,
@@ -174,34 +175,44 @@ special_views = [
     ),
 ]
 
+hundred_days = 100 * 24 * 60 * 60
+
 docs_and_status = [
     path("livez/", LivezView.as_view()),
     path("status/", StatusView.as_view()),
     path(
         "docs/api.json",
-        SpectacularJSONAPIView.as_view(authentication_classes=[], permission_classes=[]),
+        cache_page(hundred_days)(
+            SpectacularJSONAPIView.as_view(authentication_classes=[], permission_classes=[])
+        ),
         name="schema",
     ),
     path(
         "docs/api.yaml",
-        SpectacularYAMLAPIView.as_view(authentication_classes=[], permission_classes=[]),
+        cache_page(hundred_days)(
+            SpectacularYAMLAPIView.as_view(authentication_classes=[], permission_classes=[])
+        ),
         name="schema-yaml",
     ),
     path(
         "docs/",
-        SpectacularRedocView.as_view(
-            authentication_classes=[],
-            permission_classes=[],
-            url=f"{V3_API_ROOT}docs/api.json?include_html=1&pk_path=1",
+        cache_page(hundred_days)(
+            SpectacularRedocView.as_view(
+                authentication_classes=[],
+                permission_classes=[],
+                url=f"{V3_API_ROOT}docs/api.json?include_html=1&pk_path=1",
+            )
         ),
         name="schema-redoc",
     ),
     path(
         "swagger/",
-        SpectacularSwaggerView.as_view(
-            authentication_classes=[],
-            permission_classes=[],
-            url=f"{V3_API_ROOT}docs/api.json?include_html=1&pk_path=1",
+        cache_page(hundred_days)(
+            SpectacularSwaggerView.as_view(
+                authentication_classes=[],
+                permission_classes=[],
+                url=f"{V3_API_ROOT}docs/api.json?include_html=1&pk_path=1",
+            )
         ),
         name="schema-swagger",
     ),


### PR DESCRIPTION
This may not be the solution th reported memory leaks all over the place, but it's at least a circumvention thereof.

<!---
Thank you for submitting a PR to the Pulp Project!

If this is your first time contributing, please read the Pull Request Walkthrough documentation
(https://pulpproject.org/pulpcore/docs/dev/guides/pull-request-walkthrough/).
-->

### 📜 Checklist

- [ ] Commits are cleanly separated with meaningful messages (simple features and bug fixes should be [squashed](https://pulpproject.org/pulpcore/docs/dev/guides/git/#rebasing-and-squashing) to one commit)
- [ ] A [changelog entry](https://pulpproject.org/pulpcore/docs/dev/guides/git/#changelog-update) or entries has been added for any significant changes
- [ ] Follows the [Pulp policy on AI Usage](https://pulpproject.org/help/more/governance/ai_policy/)
- [ ] (For new features) - User documentation and test coverage has been added

See: [Pull Request Walkthrough](https://pulpproject.org/pulpcore/docs/dev/guides/pull-request-walkthrough/)
