### PR TITLE
Fix OpenAPI spec to use string instead of UUID format

### DIFF
--- a/CHANGES/+uuid-api-param.bugfix
+++ b/CHANGES/+uuid-api-param.bugfix
@@ -1,0 +1,1 @@
+Fix OpenAPI spec to use string instead of UUID format.

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -15,4 +15,6 @@ include pulpcore/app/templates/rest_framework/api.html
 include manage.py
 include test_requirements.txt
 exclude releasing.md
+exclude AGENTS.md
+exclude CLAUDE.md
 recursive-exclude pulpcore/tasking/task_trigger_demonstration *

--- a/pulpcore/app/viewsets/custom_filters.py
+++ b/pulpcore/app/viewsets/custom_filters.py
@@ -11,6 +11,8 @@ from gettext import gettext as _
 from django.conf import settings
 from django.db.models import ObjectDoesNotExist
 from django_filters import BaseInFilter, CharFilter, Filter
+from drf_spectacular.types import OpenApiTypes
+from drf_spectacular.utils import extend_schema_field
 from rest_framework import serializers
 from rest_framework.serializers import ValidationError as DRFValidationError
 
@@ -114,6 +116,7 @@ class CreatedResourcesFilter(Filter):
         return qs.filter(created_resources__object_id=resource.pk)
 
 
+@extend_schema_field(OpenApiTypes.STR)
 class RepoVersionHrefPrnFilter(Filter):
     """
     Filter Content by a Repository Version.

--- a/pulpcore/filters.py
+++ b/pulpcore/filters.py
@@ -18,6 +18,7 @@ from rest_framework import serializers
 
 from drf_spectacular.types import OpenApiTypes
 from drf_spectacular.plumbing import build_basic_type
+from drf_spectacular.utils import extend_schema_field
 from drf_spectacular.contrib.django_filters import DjangoFilterExtension
 
 from pulpcore.app.util import extract_pk, resolve_prn, get_domain_pk
@@ -42,6 +43,7 @@ class StableOrderingFilter(filters.OrderingFilter):
         return qs.order_by(*ordering)
 
 
+@extend_schema_field(OpenApiTypes.STR)
 class HyperlinkRelatedFilter(filters.Filter):
     """
     Enables a user to filter by a foreign key using that FK's href/prn.


### PR DESCRIPTION
Prevent UUID format in OpenAPI spec. Fixes Pydantic validation errors in generated python bindings when passing HREF strings to filter parameters like `repository` or `repsitory_version`