### PR TITLE
Skip re-upload of unchanged metadata artifacts on creating a publication

### DIFF
--- a/CHANGES/7344.bugfix
+++ b/CHANGES/7344.bugfix
@@ -1,0 +1,1 @@
+Fixed metadata artifacts being re-uploaded to storage when creating a publication for an already-published repository version.


### PR DESCRIPTION
PublishedMetadata.create_from_file() unconditionally saved artifacts to storage on every publish. When a publication was created for an already-published repository version, this overwrote identical metadata blobs with new timestamps, causing problems with CDN caching layers that use last-modified times.

Applied the same deduplication pattern used for content artifact uploads: look up the artifact by checksum first, verify the file exists in storage, and skip the write if it does.

closes #7344

<!---
Thank you for submitting a PR to the Pulp Project!

If this is your first time contributing, please read the Pull Request Walkthrough documentation
(https://pulpproject.org/pulpcore/docs/dev/guides/pull-request-walkthrough/).
-->

### 📜 Checklist

- [x] Commits are cleanly separated with meaningful messages (simple features and bug fixes should be [squashed](https://pulpproject.org/pulpcore/docs/dev/guides/git/#rebasing-and-squashing) to one commit)
- [x] A [changelog entry](https://pulpproject.org/pulpcore/docs/dev/guides/git/#changelog-update) or entries has been added for any significant changes
- [x] Follows the [Pulp policy on AI Usage](https://pulpproject.org/help/more/governance/ai_policy/)
- [x] (For new features) - User documentation and test coverage has been added

See: [Pull Request Walkthrough](https://pulpproject.org/pulpcore/docs/dev/guides/pull-request-walkthrough/)
