### PR TITLE
[backport/3.73] Fix leaking file descriptors in streamed download

### DIFF
--- a/CHANGES/7157.bugfix
+++ b/CHANGES/7157.bugfix
@@ -1,0 +1,1 @@
+Fixed file handle leak when content app access triggers downloads due to on_demand or streamed policy.

--- a/pulpcore/content/handler.py
+++ b/pulpcore/content/handler.py
@@ -1177,6 +1177,12 @@ class Handler:
             response.headers["X-PULP-ARTIFACT-SIZE"] = str(size)
             artifacts_size_counter.add(size)
 
+        # manually close the DownloadFactory's (HTTP-)session, the next artifact-download will
+        # create a new DownloadFactory anyway because it will use a new remote-object.
+        # Leaving it open also left open file-descriptors to /dev/urandom. Most likely these FDs are
+        # held by the underlying SSL library.
+        await downloader.session.close()
+
         if save_artifact and remote.policy != Remote.STREAMED:
             await asyncio.shield(
                 sync_to_async(self._save_artifact)(download_result, remote_artifact, request)


### PR DESCRIPTION
Fixes #7157


(cherry picked from commit 4307aaacd4169a78fde43e2a5cbf664e50c9ef2e)

<!---
Thank you for submitting a PR to the Pulp Project!

If this is your first time contributing, please read the Pull Request Walkthrough documentation
(https://pulpproject.org/pulpcore/docs/dev/guides/pull-request-walkthrough/).
-->

### 📜 Checklist

- [ ] Commits are cleanly separated with meaningful messages (simple features and bug fixes should be [squashed](https://pulpproject.org/pulpcore/docs/dev/guides/git/#rebasing-and-squashing) to one commit)
- [ ] A [changelog entry](https://pulpproject.org/pulpcore/docs/dev/guides/git/#changelog-update) or entries has been added for any significant changes
- [ ] Follows the [Pulp policy on AI Usage](https://pulpproject.org/help/more/governance/ai_policy/)
- [ ] (For new features) - User documentation and test coverage has been added

See: [Pull Request Walkthrough](https://pulpproject.org/pulpcore/docs/dev/guides/pull-request-walkthrough/)
