### PR TITLE
Fix a regression in repository version cleanup / squash

### DIFF
--- a/CHANGES/7371.bugfix
+++ b/CHANGES/7371.bugfix
@@ -1,0 +1,1 @@
+Fix regression (crash) during retain_repo_versions cleanup.

--- a/pulpcore/app/models/repository.py
+++ b/pulpcore/app/models/repository.py
@@ -1313,7 +1313,8 @@ class RepositoryVersion(BaseModel):
         """
         with transaction.atomic():
             # relatively inexpensive sanity check for memoization
-            assert len(self.content_ids) == self._content_relationships().count()
+            if self.content_ids:
+                assert len(self.content_ids) == self._content_relationships().count()
             # delete existing content details and recompute them all
             RepositoryVersionContentDetails.objects.filter(repository_version=self).delete()
             counts_list = []


### PR DESCRIPTION
Old repository versions don't have self.content_ids set, so this line fails.

closes #7371
