### PR TITLE
Fix content app directory listing links with colons in base_path

### DIFF
--- a/CHANGES/6955.bugfix
+++ b/CHANGES/6955.bugfix
@@ -1,0 +1,1 @@
+Fixed content app directory listing generating broken links when distribution base paths contain colons.

--- a/pulpcore/content/handler.py
+++ b/pulpcore/content/handler.py
@@ -567,7 +567,7 @@ class Handler:
 {% else -%}
 {% set size = "" -%}
 {% endif -%}
-<a href="{{ name|e }}">{{ name|e }}</a>{% for number in range(100 - name|e|length) %} """
+<a href="./{{ name|e }}">{{ name|e }}</a>{% for number in range(100 - name|e|length) %} """
             """{% endfor %}{{ date }}  {{ size }}
 {% endfor -%}
 </pre><hr></body>

--- a/pulpcore/tests/functional/api/using_plugin/test_content_directory.py
+++ b/pulpcore/tests/functional/api/using_plugin/test_content_directory.py
@@ -9,9 +9,9 @@ def test_hidden_distros(file_distribution_factory, pulp_content_url, http_get):
     content = http_get(pulp_content_url).decode("utf-8")
 
     for d in visible:
-        assert content.count(f'a href="{d.base_path}/"') == 1
+        assert content.count(f'a href="./{d.base_path}/"') == 1
     for d in hidden:
-        assert content.count(f'a href="{d.base_path}/"') == 0
+        assert content.count(f'a href="./{d.base_path}/"') == 0
 
 
 @pytest.mark.parallel
@@ -39,7 +39,7 @@ def test_zero_byte_file_listing(
     monitor_task(task)
     distribution = file_distribution_factory(repository=file_repo_with_auto_publish.pulp_href)
     response = http_get(distribution_base_url(distribution.base_url))
-    z_line = [i for i in response.decode("utf-8").split("\n") if i.startswith('<a href="zero">')]
+    z_line = [i for i in response.decode("utf-8").split("\n") if i.startswith('<a href="./zero">')]
     assert len(z_line) == 1
     assert z_line[0].endswith("0 Bytes")
 

--- a/pulpcore/tests/functional/api/using_plugin/test_content_path.py
+++ b/pulpcore/tests/functional/api/using_plugin/test_content_path.py
@@ -45,19 +45,19 @@ def test_content_directory_listing(
     if pulp_settings.DOMAIN_ENABLED:
         base_url = urljoin(base_url, "default/")
     response = http_get(base_url).decode("utf-8")
-    assert response.count(f'a href="{base_path}/"') == 1
+    assert response.count(f'a href="./{base_path}/"') == 1
     assert response.count('a href="../"') == 0
 
     url = urljoin(base_url, base_path + "/")
     response = http_get(url).decode("utf-8")
-    assert response.count('a href="foo1/"') == 1
-    assert response.count('a href="foo2/"') == (0 if HIDE_GUARDED_DISTRIBUTIONS else 1)
-    assert response.count('a href="boo1/"') == 1
-    assert response.count('a href="boo2/"') == (0 if HIDE_GUARDED_DISTRIBUTIONS else 1)
+    assert response.count('a href="./foo1/"') == 1
+    assert response.count('a href="./foo2/"') == (0 if HIDE_GUARDED_DISTRIBUTIONS else 1)
+    assert response.count('a href="./boo1/"') == 1
+    assert response.count('a href="./boo2/"') == (0 if HIDE_GUARDED_DISTRIBUTIONS else 1)
     assert response.count('a href="../"') == 1
 
     response = http_get(urljoin(url, "boo1/")).decode("utf-8")
-    assert response.count('a href="foo1/"') == 1
+    assert response.count('a href="./foo1/"') == 1
 
     # Assert that not using a trailing slash on the root returns a 301
     base_url = urljoin(

--- a/pulpcore/tests/unit/content/test_handler.py
+++ b/pulpcore/tests/unit/content/test_handler.py
@@ -574,6 +574,18 @@ async def test_app_status_fixture_is_reusable(app_status, repeat):
     assert app_status
 
 
+def test_render_html_colon_in_name():
+    """Links with colons in the name should use './' prefix to avoid being treated as a scheme."""
+    html = Handler.render_html(["copr-pull-requests:pr:3825/"])
+    assert '<a href="./copr-pull-requests:pr:3825/">copr-pull-requests:pr:3825/</a>' in html
+
+
+def test_render_html_normal_name():
+    """Normal directory names should also get the './' prefix."""
+    html = Handler.render_html(["simple-dir/"])
+    assert '<a href="./simple-dir/">simple-dir/</a>' in html
+
+
 @pytest.mark.asyncio
 @pytest.mark.django_db
 async def test_async_pull_through_add(ca1, monkeypatch, app_status):


### PR DESCRIPTION
## Summary
- Fixes broken links in the content app's directory listing when a distribution's `base_path` contains colons (e.g. `copr-pull-requests:pr:3825/`).
- Browsers were interpreting the text before the colon as a URL scheme. Prepending `./` to the `href` ensures the link is always treated as a relative path.

## Test plan
- [x] Added unit tests for `render_html` with and without colons in directory names.
- [ ] CI passes.

closes #6955

Made with [Cursor](https://cursor.com)