### PR TITLE
Add support for syncing Git LFS during git sync

### DIFF
--- a/CHANGES/pulp_file/+lfs-git-sync.feature
+++ b/CHANGES/pulp_file/+lfs-git-sync.feature
@@ -1,0 +1,1 @@
+Added support for Git LFS in pulp-file git sync.

--- a/pulp_file/app/tasks/synchronizing.py
+++ b/pulp_file/app/tasks/synchronizing.py
@@ -1,5 +1,6 @@
 import logging
 import os
+import re
 import shutil
 import tempfile
 
@@ -14,7 +15,6 @@ from pulpcore.plugin.exceptions import SyncError
 from pulpcore.plugin.models import Artifact, ProgressReport, Remote, PublishedMetadata
 from pulpcore.plugin.serializers import RepositoryVersionSerializer
 from pulpcore.plugin.stages import (
-    ArtifactDownloader,
     DeclarativeArtifact,
     DeclarativeContent,
     DeclarativeVersion,
@@ -66,7 +66,7 @@ def synchronize(remote_pk, repository_pk, mirror, url=None):
         dv.pipeline_stages = lambda new_version: [
             stage
             for stage in old_pipeline_stages(new_version)
-            if not isinstance(stage, (ArtifactDownloader, RemoteArtifactSaver))
+            if not isinstance(stage, (RemoteArtifactSaver))
         ]
     else:
         first_stage = FileFirstStage(remote, url)
@@ -242,6 +242,13 @@ def _build_clone_url(remote):
     return url
 
 
+_LFS_POINTER_RE = re.compile(
+    rb"^version https://git-lfs\.github\.com/spec/v1\n"
+    rb"oid sha256:([0-9a-f]{64})\n"
+    rb"size (\d+)\n$"
+)
+
+
 class GitFirstStage(Stage):
     """
     The first stage of a pulp_file sync pipeline for Git repositories.
@@ -259,6 +266,38 @@ class GitFirstStage(Stage):
         """
         super().__init__()
         self.remote = remote
+
+    def _parse_lfs_pointer(self, data):
+        """Returns the oid and size of an LFS pointer if present."""
+        match = _LFS_POINTER_RE.match(data)
+        if match:
+            return match.group(1).decode(), int(match.group(2))
+        return None
+
+    def _build_lfs_api_url(self):
+        """Derive the LFS API endpoint from the git remote URL."""
+        url = self.remote.url.rstrip("/")
+        if not url.endswith(".git"):
+            url += ".git"
+        return f"{url}/info/lfs/objects/batch"
+
+    async def _fetch_lfs_batch(self, lfs_blobs):
+        """Resolves the LFS pointers to downloadable links."""
+        lfs_api_url = self._build_lfs_api_url()
+        headers = {
+            "Content-Type": "application/vnd.git-lfs+json",
+            "Accept": "application/vnd.git-lfs+json",
+        }
+        data = {
+            "operation": "download",
+            "transfer": "basic",
+            "objects": [{"oid": oid, "size": size} for rp, oid, size in lfs_blobs],
+        }
+        downloader = self.remote.get_downloader(url=lfs_api_url)
+        session = downloader.session
+        async with session.post(lfs_api_url, headers=headers, json=data) as response:
+            response.raise_for_status()
+            return await response.json()
 
     async def run(self):
         """
@@ -310,14 +349,20 @@ class GitFirstStage(Stage):
             code="sync.git.parsing_tree",
         ) as pb:
             blobs = [item for item in commit.tree.traverse() if item.type == "blob"]
+            lfs_blobs = {}
             pb.total = len(blobs)
             await pb.asave()
 
             for blob in blobs:
                 relative_path = blob.path
                 size = blob.size
-                with tempfile.NamedTemporaryFile(dir=".", delete=False, mode="wb") as file:
+                with tempfile.NamedTemporaryFile(dir=".", delete=False, mode="w+b") as file:
                     shutil.copyfileobj(blob.data_stream, file)
+                    file.seek(0)
+                    # Check to see if the blob is an LFS pointer
+                    if size < 1024 and (lfs_tuple := self._parse_lfs_pointer(file.read())):
+                        lfs_blobs[lfs_tuple[0]] = (relative_path, *lfs_tuple)
+                        continue
 
                 artifact = Artifact.init_and_validate(file.name, expected_size=size)
                 file_content = FileContent(relative_path=relative_path, digest=artifact.sha256)
@@ -331,3 +376,32 @@ class GitFirstStage(Stage):
                 dc = DeclarativeContent(content=file_content, d_artifacts=[da])
                 await pb.aincrement()
                 await self.put(dc)
+
+            if lfs_blobs:
+                lfs_results = await self._fetch_lfs_batch(lfs_blobs.values())
+                for lfs_object in lfs_results.get("objects", []):
+                    relative_path, oid, size = lfs_blobs[lfs_object["oid"]]
+                    if lfs_object.get("error"):
+                        raise SyncError(
+                            _("Failed to resolve LFS blob '{rp}': {error}").format(
+                                rp=relative_path, error=lfs_object.get("error", "Unknown error")
+                            )
+                        )
+                    url = lfs_object["actions"]["download"]["href"]
+                    artifact = Artifact(size=size, sha256=oid)
+                    file_content = FileContent(relative_path=relative_path, digest=artifact.sha256)
+                    if headers := lfs_object["actions"]["download"].get("header"):
+                        extra_data = {"request_kwargs": {"headers": headers}}
+                    else:
+                        extra_data = None
+                    da = DeclarativeArtifact(
+                        artifact=artifact,
+                        url=url,
+                        relative_path=relative_path,
+                        remote=remote,
+                        deferred_download=False,
+                        extra_data=extra_data,
+                    )
+                    dc = DeclarativeContent(content=file_content, d_artifacts=[da])
+                    await pb.aincrement()
+                    await self.put(dc)

--- a/pulp_file/tests/functional/api/test_git_sync.py
+++ b/pulp_file/tests/functional/api/test_git_sync.py
@@ -14,6 +14,13 @@ FILE_COUNT = {
     "2016.02.18": 95,  # tag
     "63651d3": 306,  # commit for tag 2018.02.15
 }
+LFS_REMOTE_URL = "https://huggingface.co/julien-c/dummy-unknown"
+LFS_BLOBS = [
+    "tf_model.h5,4a8fce317e36e320941d2d200a1747c94d2a8ee0b24c8289522b579ea53eac40,157312",
+    "pytorch_model.bin,4b243c475af8d0a7754e87d7d096c92e5199ec2fe168a2ee7998e3b8e9bcb1d3,65074",
+    "flax_model.msgpack,da73dde871fe14bf876064a40368cefa5e014aa49f408b61ca8350c54456b198,58499",
+]
+LFS_FILE_COUNT = 8
 
 
 # CRUD tests
@@ -114,3 +121,30 @@ def test_git_sync_invalid_ref(file_bindings, file_repo, file_git_remote_factory,
         monitor_task(file_bindings.RepositoriesFileApi.sync(file_repo.pulp_href, body).task)
     error_desc = exc.value.task.error["description"]
     assert "Failed to clone" in error_desc or "Could not resolve git ref" in error_desc
+
+
+@pytest.mark.parallel
+def test_git_sync_lfs(
+    file_bindings,
+    file_repo_with_auto_publish,
+    file_git_remote_factory,
+    file_distribution_factory,
+    download_content_unit,
+    monitor_task,
+):
+    """Test syncing from a public Git repository with LFS."""
+    remote = file_git_remote_factory(url=LFS_REMOTE_URL)
+    file_repo = file_repo_with_auto_publish
+
+    body = RepositorySyncURL(remote=remote.pulp_href)
+    monitor_task(file_bindings.RepositoriesFileApi.sync(file_repo.pulp_href, body).task)
+
+    file_repo = file_bindings.RepositoriesFileApi.read(file_repo.pulp_href)
+    assert file_repo.latest_version_href.endswith("/versions/1/")
+    version = file_bindings.RepositoriesFileVersionsApi.read(file_repo.latest_version_href)
+    assert version.content_summary.present["file.file"]["count"] == LFS_FILE_COUNT
+
+    distribution = file_distribution_factory(repository=file_repo.pulp_href)
+    manifest = download_content_unit(distribution.base_path, "PULP_MANIFEST").decode("utf-8")
+    for line in LFS_BLOBS:
+        assert line in manifest

--- a/pulpcore/download/http.py
+++ b/pulpcore/download/http.py
@@ -289,9 +289,14 @@ class HttpDownloader(BaseDownloader):
         """
         if self.download_throttler:
             await self.download_throttler.acquire()
-        async with self.session.get(
-            self.url, proxy=self.proxy, proxy_auth=self.proxy_auth, auth=self.auth
-        ) as response:
+        request_kwargs = {
+            "proxy": self.proxy,
+            "proxy_auth": self.proxy_auth,
+            "auth": self.auth,
+        }
+        if extra_data and extra_data.get("request_kwargs"):
+            request_kwargs.update(extra_data["request_kwargs"])
+        async with self.session.get(self.url, **request_kwargs) as response:
             self.raise_for_status(response)
             to_return = await self._handle_response(response)
             await response.release()

--- a/pulpcore/pytest_plugin.py
+++ b/pulpcore/pytest_plugin.py
@@ -768,8 +768,11 @@ def pulp_content_origin(pulp_settings):
 
 
 @pytest.fixture(scope="session")
-def pulp_content_origin_with_prefix(pulp_settings):
-    return pulp_settings.CONTENT_ORIGIN + pulp_settings.CONTENT_PATH_PREFIX[:-1]
+def pulp_content_origin_with_prefix(pulp_settings, bindings_cfg):
+    if pulp_settings.CONTENT_ORIGIN:
+        return pulp_settings.CONTENT_ORIGIN + pulp_settings.CONTENT_PATH_PREFIX[:-1]
+    else:
+        return f"{bindings_cfg.host}{pulp_settings.CONTENT_PATH_PREFIX[:-1]}"
 
 
 @pytest.fixture(scope="session")


### PR DESCRIPTION
Would like to get this reviewed and merged before we release git sync in 3.105.

### 📜 Checklist

- [ ] Commits are cleanly separated with meaningful messages (simple features and bug fixes should be [squashed](https://pulpproject.org/pulpcore/docs/dev/guides/git/#rebasing-and-squashing) to one commit)
- [ ] A [changelog entry](https://pulpproject.org/pulpcore/docs/dev/guides/git/#changelog-update) or entries has been added for any significant changes
- [ ] Follows the [Pulp policy on AI Usage](https://pulpproject.org/help/more/governance/ai_policy/)
- [ ] (For new features) - User documentation and test coverage has been added

See: [Pull Request Walkthrough](https://pulpproject.org/pulpcore/docs/dev/guides/pull-request-walkthrough/)
