### PR TITLE
[PULP-1285] Fail RemoteSerializer on invalid parameters

### DIFF
--- a/CHANGES/7385.bugfix
+++ b/CHANGES/7385.bugfix
@@ -1,0 +1,1 @@
+Fixed RemoteSerializer to fail when it contains invalid parameters.

--- a/pulpcore/app/serializers/repository.py
+++ b/pulpcore/app/serializers/repository.py
@@ -73,7 +73,7 @@ class RepositorySerializer(ModelSerializer):
         )
 
 
-class RemoteSerializer(RemoteNetworkConfigSerializer, ModelSerializer, HiddenFieldsMixin):
+class RemoteSerializer(ModelSerializer, RemoteNetworkConfigSerializer, HiddenFieldsMixin):
     """
     Every remote defined by a plugin should have a Remote serializer that inherits from this
     class. Please import from `pulpcore.plugin.serializers` rather than from this module directly.

--- a/pulpcore/tests/unit/serializers/test_repository.py
+++ b/pulpcore/tests/unit/serializers/test_repository.py
@@ -255,3 +255,13 @@ def test_validate_repo_remote_via_publication(monkeypatch, field):
     serializer = DistributionSerializer()
     with pytest.raises(serializers.ValidationError, match=error_msg):
         serializer.validate(data)
+
+
+def test_create_remote_with_invalid_parameter():
+    """
+    Test that the creation of a RemoteSerializer with an invalid parameter fails.
+    """
+    data = {**MINIMAL_DATA, "foo": "bar"}
+    serializer = RemoteSerializer(data=data)
+    with pytest.raises(serializers.ValidationError, match="Unexpected field"):
+        serializer.validate(data)


### PR DESCRIPTION
fixes: #7385

<!---
Thank you for submitting a PR to the Pulp Project!

If this is your first time contributing, please read the Pull Request Walkthrough documentation
(https://pulpproject.org/pulpcore/docs/dev/guides/pull-request-walkthrough/).
-->

### 📜 Checklist

- [ ] Commits are cleanly separated with meaningful messages (simple features and bug fixes should be [squashed](https://pulpproject.org/pulpcore/docs/dev/guides/git/#rebasing-and-squashing) to one commit)
- [ ] A [changelog entry](https://pulpproject.org/pulpcore/docs/dev/guides/git/#changelog-update) or entries has been added for any significant changes
- [ ] Follows the [Pulp policy on AI Usage](https://pulpproject.org/help/more/governance/ai_policy/)
- [ ] (For new features) - User documentation and test coverage has been added

See: [Pull Request Walkthrough](https://pulpproject.org/pulpcore/docs/dev/guides/pull-request-walkthrough/)
