### PR TITLE
Allow syncing custom repos without password

### DIFF
--- a/CHANGES/7425.bugfix
+++ b/CHANGES/7425.bugfix
@@ -1,0 +1,2 @@
+Fixed a bug when syncing a custom repository using the upstream username only (no password)
+did not send any authentication since both were required by the download factory.

--- a/pulpcore/download/factory.py
+++ b/pulpcore/download/factory.py
@@ -16,7 +16,6 @@ from pulpcore.app.apps import PulpAppConfig
 from .http import HttpDownloader
 from .file import FileDownloader
 
-
 PROTOCOL_MAP = {
     "http": HttpDownloader,
     "https": HttpDownloader,
@@ -204,10 +203,10 @@ class DownloaderFactory:
                     login=self._remote.proxy_username, password=self._remote.proxy_password
                 )
 
-        if self._remote.username and self._remote.password:
-            options["auth"] = aiohttp.BasicAuth(
-                login=self._remote.username, password=self._remote.password
-            )
+        if self._remote.username:
+            # Support username-only auth with empty passwords
+            password = self._remote.password or str()
+            options["auth"] = aiohttp.BasicAuth(login=self._remote.username, password=password)
 
         kwargs["throttler"] = self._remote.download_throttler if self._remote.rate_limit else None
 


### PR DESCRIPTION
When a custom repository requires upstream_username only (no password), we should be able to proceed with the username only.

Closes #7425

<!---
Thank you for submitting a PR to the Pulp Project!

If this is your first time contributing, please read the Pull Request Walkthrough documentation
(https://pulpproject.org/pulpcore/docs/dev/guides/pull-request-walkthrough/).
-->

### 📜 Checklist

- [x] Commits are cleanly separated with meaningful messages (simple features and bug fixes should be [squashed](https://pulpproject.org/pulpcore/docs/dev/guides/git/#rebasing-and-squashing) to one commit)
- [x] A [changelog entry](https://pulpproject.org/pulpcore/docs/dev/guides/git/#changelog-update) or entries has been added for any significant changes
- [x] Follows the [Pulp policy on AI Usage](https://pulpproject.org/help/more/governance/ai_policy/)
- [ ] (For new features) - User documentation and test coverage has been added

See: [Pull Request Walkthrough](https://pulpproject.org/pulpcore/docs/dev/guides/pull-request-walkthrough/)
