### PR TITLE
Fix not cleaning up on-demand temp files after failed download

### DIFF
--- a/CHANGES/6975.bugfix
+++ b/CHANGES/6975.bugfix
@@ -1,0 +1,1 @@
+Clean up on-demand temporary file left over on an aborted download.

--- a/pulpcore/content/handler.py
+++ b/pulpcore/content/handler.py
@@ -1304,8 +1304,10 @@ class Handler:
                 await original_handle_data(data)
 
         async def finalize():
+            nonlocal failed_download
             if save_artifact and remote.policy != Remote.STREAMED:
                 await original_finalize()
+            failed_download = False
 
         downloader = remote.get_downloader(
             remote_artifact=remote_artifact,
@@ -1315,6 +1317,7 @@ class Handler:
         downloader.handle_data = handle_data
         original_finalize = downloader.finalize
         downloader.finalize = finalize
+        failed_download = True
         try:
             download_result = await downloader.run(
                 extra_data={"disable_retry_list": (DigestValidationError,)}
@@ -1337,12 +1340,18 @@ class Handler:
                 "Learn more on <https://pulpproject.org/pulpcore/docs/user/learn/"
                 "on-demand-downloading/#on-demand-and-streamed-limitations>"
             )
+        finally:
+            if failed_download:
+                # remove the temporary file
+                if downloader.path:
+                    await sync_to_async(os.unlink)(downloader.path)
 
-        # manually close the DownloadFactory's (HTTP-)session, the next artifact-download will
-        # create a new DownloadFactory anyway because it will use a new remote-object.
-        # Leaving it open also left open file-descriptors to /dev/urandom. Most likely these FDs are
-        # held by the underlying SSL library.
-        await downloader.session.close()
+            # manually close the DownloadFactory's (HTTP-)session, the next artifact-download will
+            # create a new DownloadFactory anyway because it will use a new remote-object.
+            # Leaving it open also left open file-descriptors to /dev/urandom. Most likely these FDs
+            # are held by the underlying SSL library.
+            if hasattr(downloader, "session"):
+                await downloader.session.close()
 
         if save_artifact and remote.policy != Remote.STREAMED:
             content_artifacts = await asyncio.shield(


### PR DESCRIPTION
fixes: #6975

<!---
Thank you for submitting a PR to the Pulp Project!

If this is your first time contributing, please read the Pull Request Walkthrough documentation
(https://pulpproject.org/pulpcore/docs/dev/guides/pull-request-walkthrough/).
-->

### 📜 Checklist

- [ ] Commits are cleanly separated with meaningful messages (simple features and bug fixes should be [squashed](https://pulpproject.org/pulpcore/docs/dev/guides/git/#rebasing-and-squashing) to one commit)
- [ ] A [changelog entry](https://pulpproject.org/pulpcore/docs/dev/guides/git/#changelog-update) or entries has been added for any significant changes
- [ ] Follows the [Pulp policy on AI Usage](https://pulpproject.org/help/more/governance/ai_policy/)
- [ ] (For new features) - User documentation and test coverage has been added

See: [Pull Request Walkthrough](https://pulpproject.org/pulpcore/docs/dev/guides/pull-request-walkthrough/)
