### PR TITLE
Pin uvloop<0.22 and add sanity test for it

### DIFF
--- a/CHANGES/7213.bugfix
+++ b/CHANGES/7213.bugfix
@@ -1,0 +1,1 @@
+Added upperbounds to uvloop (an optional dependency) to prevent a known bug in newer releases.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -79,7 +79,7 @@ kafka = [
   "confluent-kafka>=2.4.0,<2.14.0",
 ]
 diagnostics = ["pyinstrument~=5.0", "memray~=1.17"]
-uvloop = ["uvloop>=0.20,<0.23"]
+uvloop = ["uvloop>=0.20,<0.22"]
 
 [project.urls]
 Homepage = "https://pulpproject.org"


### PR DESCRIPTION
`0.22.1` is known to broke some existing behavior. Maybe there is a fix in our code, but we'll wait if they can revert/fix it on their side.
See <https://github.com/MagicStack/uvloop/issues/702>.

Closes: #7213

<!---
Thank you for submitting a PR to the Pulp Project!

If this is your first time contributing, please read the Pull Request Walkthrough documentation
(https://pulpproject.org/pulpcore/docs/dev/guides/pull-request-walkthrough/).
-->

### 📜 Checklist

- [ ] Commits are cleanly separated with meaningful messages (simple features and bug fixes should be [squashed](https://pulpproject.org/pulpcore/docs/dev/guides/git/#rebasing-and-squashing) to one commit)
- [ ] A [changelog entry](https://pulpproject.org/pulpcore/docs/dev/guides/git/#changelog-update) or entries has been added for any significant changes
- [ ] Follows the [Pulp policy on AI Usage](https://pulpproject.org/help/more/governance/ai_policy/)
- [ ] (For new features) - User documentation and test coverage has been added

See: [Pull Request Walkthrough](https://pulpproject.org/pulpcore/docs/dev/guides/pull-request-walkthrough/)
