### PR TITLE
Fix pulp_hashlib.new() on FIPS systems

### DIFF
--- a/CHANGES/7434.bugfix
+++ b/CHANGES/7434.bugfix
@@ -1,0 +1,1 @@
+Added ``usedforsecurity=False`` to ``pulp_hashlib.new()`` so FIPS-disallowed algorithms used for content addressing no longer raise ``UnsupportedDigestmodError``.

--- a/pulpcore/app/pulp_hashlib.py
+++ b/pulpcore/app/pulp_hashlib.py
@@ -33,4 +33,5 @@ def new(name, *args, **kwargs):
                 "setting"
             ).format(name)
         )
+    kwargs.setdefault("usedforsecurity", False)
     return the_real_hashlib.new(name, *args, **kwargs)


### PR DESCRIPTION
## Summary

- Add `usedforsecurity=False` to `pulp_hashlib.new()` so FIPS-disallowed algorithms (e.g. md5, sha1) used for content addressing no longer raise `UnsupportedDigestmodError`.
- All hashes from this wrapper are for content addressing (storage paths, dedup, manifest IDs), never for cryptographic security. `setdefault` preserves any explicit `usedforsecurity=True` a caller might pass.
- Validated on a FIPS-enabled RHEL 9.7 VM running Satellite 6.18: manifest upload returned `UnsupportedDigestmodError` before the fix, HTTP 201 after.

### Checklist

- [x] Commits are squashed to one
- [x] A [changelog entry](https://pulpproject.org/pulpcore/docs/dev/guides/git/#changelog-update) has been added
- [x] Follows the [Pulp policy on AI Usage](https://pulpproject.org/help/more/governance/ai_policy/)

closes #7434

See also: pulp/pulp_container#2256

Made with [Cursor](https://cursor.com)