### PR TITLE
Add a data repair API for admins

### DIFF
--- a/CHANGES/7272.feature
+++ b/CHANGES/7272.feature
@@ -1,0 +1,1 @@
+Add a data repair API for admins - for more granular control and operations which are too long for migrations.

--- a/docs/admin/guides/_SUMMARY.md
+++ b/docs/admin/guides/_SUMMARY.md
@@ -8,4 +8,5 @@
     * [Introduction](configure-pulp/index.md)
     * [Database Encryption](configure-pulp/db-encryption.md)
     * [Configure Storage backends](configure-pulp/configure-storages.md)
+* [Data Repair](data-repair.md)
 * *.md

--- a/docs/admin/guides/data-repair.md
+++ b/docs/admin/guides/data-repair.md
@@ -1,0 +1,106 @@
+# Data Repair
+
+Pulp provides a data repair API for administrators to fix known data corruption issues, or
+operations which are too expensive to be changed via migration. It is intended to provide
+the admin with more control over how and when these operations are executed, and provide
+more feedback (e.g. `dry_run`) on the state of things before making changes to the database.
+
+These endpoints are available under `/pulp/api/v3/datarepair/` and each targets a specific
+known issue.
+
+## Repair #7272: Repository Version Cache and Count Mismatches
+
+[Issue #7272](https://github.com/pulp/pulpcore/issues/7272) describes a data corruption scenario
+where repository version metadata becomes inconsistent with the actual content relationships.
+This repair fixes two types of mismatches:
+
+1. **Content ID cache mismatch** — The cached `content_ids` on a `RepositoryVersion` no longer
+   matches the actual `RepositoryContent` relationships.
+2. **Content count mismatch** — The `RepositoryVersionContentDetails` count does not match the
+   actual number of `RepositoryContent` entries.
+
+### Dry run
+
+To check for issues without making any changes, set `dry_run` to `true`:
+
+=== "run"
+    ```bash
+    $ TASK=$(http POST :24817/pulp/api/v3/datarepair/7272/ dry_run=true | jq -r '.task')
+    $ http --body :24817$TASK
+    ```
+=== "output"
+    ```json
+    {
+        "progress_reports": [
+            {
+                "message": "Repositories checked",
+                "code": "repair.7272.repos_checked",
+                "state": "completed",
+                "done": 5,
+                "total": 5
+            },
+            {
+                "message": "Repository versions checked",
+                "code": "repair.7272.versions_checked",
+                "state": "completed",
+                "done": 12,
+                "total": 12
+            },
+            {
+                "message": "Repository versions fixed",
+                "code": "repair.7272.versions_fixed",
+                "state": "completed",
+                "done": 0,
+                "total": 2
+            }
+        ]
+    }
+    ```
+
+In dry run mode, the `versions_fixed` progress report will show `total` as the number of
+broken versions found, but `done` will remain at 0 since no changes are made.
+
+### Performing the repair
+
+To actually fix the detected issues, omit `dry_run` (defaults to `false`):
+
+=== "run"
+    ```bash
+    $ TASK=$(http POST :24817/pulp/api/v3/datarepair/7272/ | jq -r '.task')
+    $ http --body :24817$TASK
+    ```
+=== "output"
+    ```json
+    {
+        "progress_reports": [
+            {
+                "message": "Repositories checked",
+                "code": "repair.7272.repos_checked",
+                "state": "completed",
+                "done": 5,
+                "total": 5
+            },
+            {
+                "message": "Repository versions checked",
+                "code": "repair.7272.versions_checked",
+                "state": "completed",
+                "done": 12,
+                "total": 12
+            },
+            {
+                "message": "Repository versions fixed",
+                "code": "repair.7272.versions_fixed",
+                "state": "completed",
+                "done": 2,
+                "total": 2
+            }
+        ]
+    }
+    ```
+
+The task repairs each affected repository version by recalculating the `content_ids` cache
+and recomputing the content counts. The repair operates within the current domain only.
+
+!!! tip
+    It is recommended to run with `dry_run=true` first to understand the scope of the issue
+    before performing the actual repair.

--- a/pulpcore/app/serializers/__init__.py
+++ b/pulpcore/app/serializers/__init__.py
@@ -95,7 +95,7 @@ from .repository import (
     RepositoryAddRemoveContentSerializer,
     RepositoryVersionSerializer,
 )
-from .repair import RepairSerializer
+from .repair import RepairSerializer, DataRepair7272Serializer
 from .reclaim import ReclaimSpaceSerializer
 from .task import (
     MinimalTaskSerializer,

--- a/pulpcore/app/serializers/repair.py
+++ b/pulpcore/app/serializers/repair.py
@@ -15,3 +15,14 @@ class RepairSerializer(serializers.Serializer, ValidateFieldsMixin):
             "by default"
         ),
     )
+
+
+class DataRepair7272Serializer(serializers.Serializer, ValidateFieldsMixin):
+    dry_run = fields.BooleanField(
+        required=False,
+        default=False,
+        help_text=_(
+            "If true, only report issues without fixing them. If false (default), "
+            "repair the detected issues."
+        ),
+    )

--- a/pulpcore/app/tasks/__init__.py
+++ b/pulpcore/app/tasks/__init__.py
@@ -27,3 +27,5 @@ from .repository import repair_all_artifacts
 from .analytics import post_analytics
 
 from .vulnerability_report import check_content
+
+from .datarepair import repair_7272

--- a/pulpcore/app/tasks/datarepair.py
+++ b/pulpcore/app/tasks/datarepair.py
@@ -1,0 +1,107 @@
+from logging import getLogger
+
+from pulpcore.app import models
+from pulpcore.app.models import ProgressReport
+from pulpcore.app.util import get_domain_pk
+
+log = getLogger(__name__)
+
+
+def repair_7272(dry_run=False):
+    """
+    Repair repository version content_ids cache and content count mismatches (Issue #7272).
+
+    This task fixes two types of data corruption within the current domain:
+    1. Mismatch between RepositoryVersion.content_ids cache and actual RepositoryContent
+       relationships
+    2. Mismatch between RepositoryVersionContentDetails count and actual RepositoryContent count
+
+    Args:
+        dry_run (bool): If True, only report issues without fixing them. Defaults to False.
+    """
+    number_broken = 0
+
+    domain = models.Domain.objects.get(pk=get_domain_pk())
+
+    log.info(f'Performing datarepair for issue #7272 for domain "{domain.name}"')
+
+    repos = models.Repository.objects.filter(pulp_domain=domain)
+    total_versions = models.RepositoryVersion.objects.filter(repository__in=repos).count()
+
+    with ProgressReport(
+        message="Repositories checked",
+        code="repair.7272.repos_checked",
+        total=repos.count(),
+    ) as repos_progress, ProgressReport(
+        message="Repository versions checked",
+        code="repair.7272.versions_checked",
+        total=total_versions,
+    ) as versions_progress, ProgressReport(
+        message="Repository versions fixed",
+        code="repair.7272.versions_fixed",
+    ) as fixed_progress:
+        for repo in repos:
+            for rv in models.RepositoryVersion.objects.filter(repository=repo):
+                needs_fix = False
+                versions_progress.increment()
+
+                if rv.content_ids is not None:
+                    cached_id_set = set(rv.content_ids)
+                    repositorycontent_id_set = set(
+                        rv._content_relationships().values_list("content__pk", flat=True)
+                    )
+                    if cached_id_set != repositorycontent_id_set:
+                        log.warning(
+                            f'Repository "{repo.name}" (type "{repo.pulp_type}") version '
+                            f'{rv.number} in domain "{domain.name}" has a mismatch between the '
+                            "RepositoryContent and the cached ID set"
+                        )
+                        needs_fix = True
+
+                repositorycontent_id_count = rv._content_relationships().count()
+                if repositorycontent_id_count == 0:
+                    continue
+                rv_count_details = models.RepositoryVersionContentDetails.objects.filter(
+                    repository_version=rv,
+                    count_type=models.RepositoryVersionContentDetails.PRESENT,
+                )
+
+                # need to sum across all content types
+                total_count = sum(rvcd.count for rvcd in rv_count_details)
+
+                if total_count != repositorycontent_id_count:
+                    log.warning(
+                        f'Repository "{repo.name}" (type "{repo.pulp_type}") version {rv.number} '
+                        f'in domain "{domain.name}" has a mismatch between the RepositoryContent '
+                        "and RepositoryVersionContentDetails"
+                    )
+                    needs_fix = True
+
+                if needs_fix:
+                    number_broken += 1
+
+                    if not dry_run:
+                        rv.content_ids = list(
+                            rv._content_relationships().values_list("content__pk", flat=True)
+                        )
+                        rv.save()
+                        rv._compute_counts()
+                        fixed_progress.increment()
+
+            repos_progress.increment()
+
+        fixed_progress.total = number_broken
+
+    if not number_broken:
+        log.info(f'Data repair operation for issue #7272 for domain "{domain.name}" finished. (OK)')
+    else:
+        if dry_run:
+            log.info(
+                f"Data repair operation for issue #7272 dry run finished. ({number_broken} "
+                f'repository versions need fixing in domain "{domain.name}")'
+            )
+        else:
+            log.info(
+                f"Data repair operation for issue #7272 finished. ({number_broken} "
+                f'repository versions fixed in domain "{domain.name}")'
+            )

--- a/pulpcore/app/urls.py
+++ b/pulpcore/app/urls.py
@@ -18,6 +18,7 @@ from pulpcore.app.views import (
     LivezView,
     OrphansView,
     PulpImporterImportCheckView,
+    DataRepair7272View,
     RepairView,
     StatusView,
 )
@@ -156,6 +157,7 @@ for viewset in sorted_by_depth:
 special_views = [
     path("login/", LoginViewSet.as_view()),
     path("repair/", RepairView.as_view()),
+    path("datarepair/7272/", DataRepair7272View.as_view()),
     path(
         "orphans/cleanup/",
         OrphansCleanupViewset.as_view(actions={"post": "cleanup"}),

--- a/pulpcore/app/views/__init__.py
+++ b/pulpcore/app/views/__init__.py
@@ -1,3 +1,4 @@
+from .datarepair import DataRepair7272View
 from .orphans import OrphansView
 from .status import LivezView, StatusView
 from .repair import RepairView

--- a/pulpcore/app/views/datarepair.py
+++ b/pulpcore/app/views/datarepair.py
@@ -1,0 +1,35 @@
+from drf_spectacular.utils import extend_schema
+from rest_framework.views import APIView
+
+from pulpcore.app.response import OperationPostponedResponse
+from pulpcore.app.serializers import AsyncOperationResponseSerializer, DataRepair7272Serializer
+from pulpcore.app.tasks.datarepair import repair_7272
+from pulpcore.tasking.tasks import dispatch
+
+
+class DataRepair7272View(APIView):
+    @extend_schema(
+        description=(
+            "Trigger an asynchronous task that repairs repository version content_ids "
+            "cache and content count mismatches (Issue #7272). This task fixes two types "
+            "of data corruption: 1) Mismatch between RepositoryVersion.content_ids cache "
+            "and actual RepositoryContent relationships, and 2) Mismatch between "
+            "RepositoryVersionContentDetails count and actual RepositoryContent count."
+        ),
+        summary="Repair Repository Version Data (Issue #7272)",
+        request=DataRepair7272Serializer,
+        responses={202: AsyncOperationResponseSerializer},
+    )
+    def post(self, request):
+        """
+        Repair repository version data issues (Issue #7272).
+        """
+        serializer = DataRepair7272Serializer(data=request.data)
+        serializer.is_valid(raise_exception=True)
+
+        dry_run = serializer.validated_data["dry_run"]
+
+        exclusive_resources = [f"pdrn:{request.pulp_domain.pulp_id}:datarepair-7272"]
+        task = dispatch(repair_7272, exclusive_resources=exclusive_resources, args=[dry_run])
+
+        return OperationPostponedResponse(task, request)


### PR DESCRIPTION
Some operations take too long to put in a migration, or need to be done at a more granular level (e.g. per-domain), or are optional (e.g. backfilling information)

closes #7272
Assisted-By: claude-opus-4.6

### 📜 Checklist

- [x] Commits are cleanly separated with meaningful messages (simple features and bug fixes should be [squashed](https://pulpproject.org/pulpcore/docs/dev/guides/git/#rebasing-and-squashing) to one commit)
- [x] A [changelog entry](https://pulpproject.org/pulpcore/docs/dev/guides/git/#changelog-update) or entries has been added for any significant changes
- [x] Follows the [Pulp policy on AI Usage](https://pulpproject.org/help/more/governance/ai_policy/)
- [x] (For new features) - User documentation and test coverage has been added

See: [Pull Request Walkthrough](https://pulpproject.org/pulpcore/docs/dev/guides/pull-request-walkthrough/)
