### PR TITLE
Fix remove-signing-service handling, can now remove service without `--class` argument

### DIFF
--- a/CHANGES/7318.bugfix
+++ b/CHANGES/7318.bugfix
@@ -1,0 +1,1 @@
+Fix remove-signing-service handling, can now remove service without --class argument.

--- a/pulpcore/app/management/commands/remove-signing-service.py
+++ b/pulpcore/app/management/commands/remove-signing-service.py
@@ -24,40 +24,46 @@ class Command(BaseCommand):
         )
         parser.add_argument(
             "--class",
-            default="core:AsciiArmoredDetachedSigningService",
+            default=None,
             required=False,
             help=_("Signing service class prefixed by the app label separated by a colon."),
         )
 
     def handle(self, *args, **options):
         name = options["name"]
-        if ":" not in options["class"]:
-            raise CommandError(_("The signing service class was not provided in a proper format."))
-        app_label, service_class = options["class"].split(":")
-
-        try:
-            SigningService = apps.get_model(app_label, service_class)
-        except LookupError as e:
-            raise CommandError(str(e))
-        if not issubclass(SigningService, BaseSigningService):
-            raise CommandError(
-                _("Class '{}' is not a subclass of the base 'core:SigningService' class.").format(
-                    options["class"]
+        if options["class"] is not None:
+            if ":" not in options["class"]:
+                raise CommandError(
+                    _("The signing service class was not provided in a proper format.")
                 )
-            )
+            app_label, service_class = options["class"].split(":")
+
+            try:
+                signing_service_class = apps.get_model(app_label, service_class)
+            except LookupError as e:
+                raise CommandError(str(e))
+
+            if not issubclass(signing_service_class, BaseSigningService):
+                raise CommandError(
+                    _(
+                        "Class '{}' is not a subclass of the base 'core:SigningService' class."
+                    ).format(options["class"])
+                )
+        # If --class is not provided, query the base SigningService
+        else:
+            signing_service_class = BaseSigningService
 
         try:
-            SigningService.objects.get(name=name).delete()
+            signing_service = signing_service_class.objects.get(name=name)
+        except ObjectDoesNotExist:
+            raise CommandError(_("Signing service '{}' does not exist.").format(name))
+
+        try:
+            signing_service.delete()
         except IntegrityError:
             raise CommandError(
                 _("Signing service '{}' could not be removed because it's still in use.").format(
                     name
-                )
-            )
-        except ObjectDoesNotExist:
-            raise CommandError(
-                _("Signing service '{}' of class '{}' does not exists.").format(
-                    name, options["class"]
                 )
             )
         else:


### PR DESCRIPTION
Closes [7318](https://github.com/pulp/pulpcore/issues/7318)

### 📜 Checklist

- [x] Commits are cleanly separated with meaningful messages (simple features and bug fixes should be [squashed](https://pulpproject.org/pulpcore/docs/dev/guides/git/#rebasing-and-squashing) to one commit)
- [x] A [changelog entry](https://pulpproject.org/pulpcore/docs/dev/guides/git/#changelog-update) or entries has been added for any significant changes
- [x] Follows the [Pulp policy on AI Usage](https://pulpproject.org/help/more/governance/ai_policy/)
- [x] (For new features) - User documentation and test coverage has been added

