### PR TITLE
[3.73] Fix not cleaning up on-demand temp files after failed download

### DIFF
--- a/CHANGES/6975.bugfix
+++ b/CHANGES/6975.bugfix
@@ -1,0 +1,1 @@
+Clean up on-demand temporary file left over on an aborted download.

--- a/pulpcore/content/handler.py
+++ b/pulpcore/content/handler.py
@@ -1136,8 +1136,10 @@ class Handler:
                 await original_handle_data(data)
 
         async def finalize():
+            nonlocal failed_download
             if save_artifact and remote.policy != Remote.STREAMED:
                 await original_finalize()
+            failed_download = False
 
         downloader = remote.get_downloader(
             remote_artifact=remote_artifact,
@@ -1147,6 +1149,7 @@ class Handler:
         downloader.handle_data = handle_data
         original_finalize = downloader.finalize
         downloader.finalize = finalize
+        failed_download = True
         try:
             download_result = await downloader.run(
                 extra_data={"disable_retry_list": (DigestValidationError,)}
@@ -1169,6 +1172,17 @@ class Handler:
                 "Learn more on <https://pulpproject.org/pulpcore/docs/user/learn/"
                 "on-demand-downloading/#on-demand-and-streamed-limitations>"
             )
+        finally:
+            if failed_download:
+                if downloader.path:
+                    await sync_to_async(os.unlink)(downloader.path)
+
+            # manually close the DownloadFactory's (HTTP-)session, the next artifact-download will
+            # create a new DownloadFactory anyway because it will use a new remote-object.
+            # Leaving it open also left open file-descriptors to /dev/urandom. Most likely these FDs
+            # are held by the underlying SSL library.
+            if hasattr(downloader, "session"):
+                await downloader.session.close()
 
         if content_length := response.headers.get("Content-Length"):
             response.headers["X-PULP-ARTIFACT-SIZE"] = content_length
@@ -1176,12 +1190,6 @@ class Handler:
         else:
             response.headers["X-PULP-ARTIFACT-SIZE"] = str(size)
             artifacts_size_counter.add(size)
-
-        # manually close the DownloadFactory's (HTTP-)session, the next artifact-download will
-        # create a new DownloadFactory anyway because it will use a new remote-object.
-        # Leaving it open also left open file-descriptors to /dev/urandom. Most likely these FDs are
-        # held by the underlying SSL library.
-        await downloader.session.close()
 
         if save_artifact and remote.policy != Remote.STREAMED:
             await asyncio.shield(


### PR DESCRIPTION
Backport of #7429 to 3.73.

fixes: #6975

(cherry picked from commit 0e52cd78b474b1be6e2844babcc1a0d90578ae93)

Made with [Cursor](https://cursor.com)