### PR TITLE
Added REDACT_UNSAFE_EXCEPTIONS setting for strict error handling

### DIFF
--- a/CHANGES/+exceptions-handling-setting.feature
+++ b/CHANGES/+exceptions-handling-setting.feature
@@ -1,0 +1,1 @@
+Add REDACT_UNSAFE_EXCEPTIONS setting for strict exception handling.

--- a/docs/admin/reference/settings.md
+++ b/docs/admin/reference/settings.md
@@ -322,6 +322,14 @@ Toggles the activation of OpenTelemetry instrumentation for monitoring and traci
 
 Defaults to `False`.
 
+### REDACT\_UNSAFE\_EXCEPTIONS
+
+When enabled, task errors that are not `PulpException` subclasses are sanitized to prevent sensitive data leakage, such as credentials, tokens, or signed URLs.
+These exceptions appear as a generic error message in the task output, while full details remain logged for administrators.
+When disabled, all exception details are shown in task error messages with a deprecation warning.
+
+Defaults to `False`.
+
 ### REDIRECT\_TO\_OBJECT\_STORAGE
 
 When set to `True` access to artifacts is redirected to the corresponding Cloud storage

--- a/pulpcore/app/settings.py
+++ b/pulpcore/app/settings.py
@@ -426,6 +426,9 @@ VULN_REPORT_TASK_LIMITER = 10
 # Replaces asyncio event loop with uvloop
 UVLOOP_ENABLED = False
 
+# Replaces every non PulpException error msg with "An internal error occured"
+REDACT_UNSAFE_EXCEPTIONS = False
+
 # HERE STARTS DYNACONF EXTENSION LOAD (Keep at the very bottom of settings.py)
 # Read more at https://www.dynaconf.com/django/
 

--- a/pulpcore/tasking/tasks.py
+++ b/pulpcore/tasking/tasks.py
@@ -21,6 +21,7 @@ from pulpcore.app.util import (
     get_domain,
     get_prn,
 )
+from pulpcore.exceptions import PulpException, InternalErrorException
 from pulpcore.app.contexts import with_task_context, awith_task_context, x_task_diagnostics_var
 from pulpcore.constants import (
     TASK_FINAL_STATES,
@@ -31,6 +32,7 @@ from pulpcore.constants import (
     TASK_WAKEUP_UNBLOCK,
 )
 from pulpcore.tasking.kafka import send_task_notification
+from pulpcore.app.loggers import deprecation_logger
 
 _logger = logging.getLogger(__name__)
 
@@ -65,14 +67,25 @@ def _execute_task(task):
     with with_task_context(task):
         task.set_running()
         domain = get_domain()
-
         try:
             log_task_start(task, domain)
             task_function = get_task_function(task)
             result = task_function()
-        except Exception:
+        except Exception as e:
             exc_type, exc, tb = sys.exc_info()
-            task.set_failed(exc, tb)
+            task_exc = exc
+            if not isinstance(e, PulpException):
+                if settings.REDACT_UNSAFE_EXCEPTIONS:
+                    # Replace exception with generic error
+                    task_exc = InternalErrorException()
+                    tb = None
+                else:
+                    deprecation_logger.warning(
+                        "Exception ({exc_type}: {exc}) will be sanitized in pulpcore 3.115".format(
+                            exc_type=exc_type.__name__, exc=exc
+                        )
+                    )
+            task.set_failed(task_exc, tb)
             log_task_failed(task, exc_type, exc, tb, domain)
             send_task_notification(task)
         else:
@@ -95,9 +108,21 @@ async def _aexecute_task(task):
         try:
             task_coroutine_fn = await aget_task_function(task)
             result = await task_coroutine_fn()
-        except Exception:
+        except Exception as e:
             exc_type, exc, tb = sys.exc_info()
-            await sync_to_async(task.set_failed)(exc, tb)
+            task_exc = exc
+            if not isinstance(e, PulpException):
+                if settings.REDACT_UNSAFE_EXCEPTIONS:
+                    # Replace exception with generic error
+                    task_exc = InternalErrorException()
+                    tb = None
+                else:
+                    deprecation_logger.warning(
+                        "Exception ({exc_type}: {exc}) will be sanitized in pulpcore 3.115".format(
+                            exc_type=exc_type.__name__, exc=exc
+                        )
+                    )
+            await sync_to_async(task.set_failed)(task_exc, tb)
             log_task_failed(task, exc_type, exc, tb, domain)
             send_task_notification(task)
         else:
@@ -144,7 +169,8 @@ def log_task_failed(task, exc_type, exc, tb, domain):
             domain=domain.name,
         )
     )
-    _logger.info("\n".join(traceback.format_list(traceback.extract_tb(tb))))
+    if tb is not None:
+        _logger.info("\n".join(traceback.format_list(traceback.extract_tb(tb))))
 
 
 async def aget_task_function(task):


### PR DESCRIPTION

Added REDACT_UNSAFE_EXCEPTIONS setting (defaults to False) for strict error handling, returning "Internal error" for every non PulpException if set to True.  
Added deprecation warning for every non PulpException error message.

### 📜 Checklist

- [x] Commits are cleanly separated with meaningful messages (simple features and bug fixes should be [squashed](https://pulpproject.org/pulpcore/docs/dev/guides/git/#rebasing-and-squashing) to one commit)
- [x] A [changelog entry](https://pulpproject.org/pulpcore/docs/dev/guides/git/#changelog-update) or entries has been added for any significant changes
- [x] Follows the [Pulp policy on AI Usage](https://pulpproject.org/help/more/governance/ai_policy/)
- [x] (For new features) - User documentation and test coverage has been added

See: [Pull Request Walkthrough](https://pulpproject.org/pulpcore/docs/dev/guides/pull-request-walkthrough/)
