### PR TITLE
Add periodic malloc_trim to prevent unbounded RSS growth in API workers

### DIFF
--- a/CHANGES/7482.bugfix
+++ b/CHANGES/7482.bugfix
@@ -1,0 +1,2 @@
+Added periodic ``gc.collect()`` and ``malloc_trim(0)`` calls in API workers to prevent
+unbounded RSS growth caused by glibc heap fragmentation.

--- a/docs/admin/reference/settings.md
+++ b/docs/admin/reference/settings.md
@@ -250,6 +250,14 @@ The number of seconds before a content app should be considered lost.
 
 Defaults to `30` seconds.
 
+### MEMORY\_TRIM\_INTERVAL
+
+Number of API worker requests between periodic `gc.collect()` + `malloc_trim(0)` calls.
+This compacts the glibc heap to prevent unbounded RSS growth from memory fragmentation.
+Set to `0` to disable.
+
+Defaults to `1024`.
+
 ### CONTENT\_ORIGIN
 
 A string containing the `protocol`, `fqdn`, and optionally `port` where the content app is reachable by users.

--- a/pulpcore/app/entrypoint.py
+++ b/pulpcore/app/entrypoint.py
@@ -1,6 +1,10 @@
 from contextvars import ContextVar
 from logging import getLogger
+import ctypes
+import ctypes.util
+import gc
 import os
+import platform
 import sys
 import threading
 import time
@@ -18,15 +22,41 @@ from pulpcore.app.pulpcore_gunicorn_application import PulpcoreGunicornApplicati
 
 logger = getLogger(__name__)
 
+_malloc_trim = None
+if platform.system() == "Linux":
+    try:
+        _libc = ctypes.CDLL(ctypes.util.find_library("c"))
+        _malloc_trim = _libc.malloc_trim
+        _malloc_trim.argtypes = [ctypes.c_int]
+        _malloc_trim.restype = ctypes.c_int
+    except (OSError, AttributeError):
+        pass
+
 
 name_template_var = ContextVar("name_template_var", default=None)
 using_pulp_api_worker = ContextVar("using_pulp_api_worker", default=False)
 
 
 class PulpApiWorker(SyncWorker):
+    _request_counter = 0
+    _memory_trim_interval = 0
+
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.heartbeat_thread = None
+
+    def handle_request(self, listener, req, client, addr):
+        super().handle_request(listener, req, client, addr)
+        self._trim_memory_if_needed()
+
+    def _trim_memory_if_needed(self):
+        if not _malloc_trim or self._memory_trim_interval <= 0:
+            return
+        self._request_counter += 1
+        if self._request_counter >= self._memory_trim_interval:
+            self._request_counter = 0
+            gc.collect()
+            _malloc_trim(0)
 
     def _heartbeat_loop(self):
         """Run heartbeat in a loop. Exit process if heartbeat fails."""
@@ -104,6 +134,13 @@ class PulpApiWorker(SyncWorker):
             target=self._heartbeat_loop, daemon=True, name=f"heartbeat-{self.name}"
         )
         self.heartbeat_thread.start()
+
+        self._memory_trim_interval = settings.MEMORY_TRIM_INTERVAL
+        if _malloc_trim and self._memory_trim_interval > 0:
+            logger.info(
+                "Memory trim enabled: gc.collect + malloc_trim(0) every %d requests",
+                self._memory_trim_interval,
+            )
 
         super().init_process()
 

--- a/pulpcore/app/settings.py
+++ b/pulpcore/app/settings.py
@@ -292,6 +292,7 @@ CONTENT_PATH_PREFIX = "/pulp/content/"
 API_APP_TTL = 120  # The heartbeat is called from gunicorn notify (defaulting to 45 sec).
 CONTENT_APP_TTL = 30
 WORKER_TTL = 30
+MEMORY_TRIM_INTERVAL = 1024
 
 # Seconds for a task to finish on semi graceful worker shutdown (approx)
 # On SIGHUP, SIGTERM the currently running task will be awaited forever.


### PR DESCRIPTION
## Summary

PulpApiWorker (gunicorn SyncWorker) exhibits unbounded RSS growth over time due to glibc heap fragmentation. Django's per-request allocation pattern creates and destroys many small C-level objects (ORM compilers, SQL strings, psycopg cursor state), causing glibc's malloc to retain freed pages rather than returning them to the OS.

This PR adds periodic `gc.collect()` + `malloc_trim(0)` calls in `PulpApiWorker.handle_request()` every N requests (default 1024, configurable via `PULP_MEMORY_TRIM_INTERVAL` env var, set to 0 to disable).

The fix is Linux-only (glibc `malloc_trim`), graceful no-op on other platforms. No new dependencies.

## Problem

Observed in Ansible Automation Platform 2.6 deployments running pulpcore 3.49 on OpenShift: hub-api worker RSS grows ~1 kB/request even with zero user activity (liveness/readiness probes alone drive growth). Over hours this leads to OOM kills and pod restarts.

Profiling on a live cluster confirmed:
- Python object counts are completely stable (`gc.get_objects()` delta ~0)
- `gc.collect()` recovers 0 bytes (no reference cycles)
- `malloc_trim(0)` recovers ~2 MB immediately (heap fragmentation confirmed)
- RSS grows linearly without trimming, stabilizes completely with trimming

The root cause is glibc's default `malloc` behavior: small allocations spread across many arenas cause heap fragmentation, and freed blocks are not returned to the OS until `malloc_trim` is explicitly called.

## Changes

`pulpcore/app/entrypoint.py`:
- At module load: detect Linux, load `libc.malloc_trim` via `ctypes`
- `PulpApiWorker.handle_request()`: after each request, increment counter; every `PULP_MEMORY_TRIM_INTERVAL` requests (default 1024), call `gc.collect()` then `malloc_trim(0)`
- Log at worker init when trimming is enabled

## Configuration

| Env var | Default | Description |
|---------|---------|-------------|
| `PULP_MEMORY_TRIM_INTERVAL` | `1024` | Run trim every N requests. Set to `0` to disable. |

## Test plan

- [ ] Verify workers start normally with default settings (trim enabled)
- [ ] Verify `PULP_MEMORY_TRIM_INTERVAL=0` disables trimming (no log message)
- [ ] Verify RSS growth stabilizes under sustained probe/request load
- [ ] Verify no functional regression on macOS (trim is a no-op, no errors)
- [ ] Run existing unit/functional test suite

### 📜 Checklist

- [x] Commits are cleanly separated with meaningful messages (simple features and bug fixes should be [squashed](https://pulpproject.org/pulpcore/docs/dev/guides/git/#rebasing-and-squashing) to one commit)
- [x] A [changelog entry](https://pulpproject.org/pulpcore/docs/dev/guides/git/#changelog-update) or entries has been added for any significant changes
- [x] Follows the [Pulp policy on AI Usage](https://pulpproject.org/help/more/governance/ai_policy/)
- [ ] (For new features) - User documentation and test coverage has been added

See: [Pull Request Walkthrough](https://pulpproject.org/pulpcore/docs/dev/guides/pull-request-walkthrough/)