### PR TITLE
[3.49] Update pyopenssl requirement from <26.0 to <27.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -24,7 +24,7 @@ json_stream>=2.3.2,<2.4
 jq>=1.6.0,<1.7.0
 # pycares is only a transitive dependency, but there is a combination of versions that expresses a bug.
 pycares<4.9;python_version<'3.12'  # pycares==4.9 + aiodns==3.2.0 + python<3.12 = trouble
-PyOpenSSL<26.0
+PyOpenSSL<27.0
 opentelemetry-distro[otlp]>=0.38b0,<=0.49b0
 opentelemetry-exporter-otlp-proto-http>=1.17.0,<1.29
 opentelemetry-instrumentation-django>=0.38b0,<=0.49b0


### PR DESCRIPTION
Backport of #7476.

(cherry picked from commit 3ba3e89c539d5b3cac536ecf3323a47f87603a7b)

Made with [Cursor](https://cursor.com)