### PR TITLE
[3.73] Update pyopenssl requirement from <26.0 to <27.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,7 +53,7 @@ dependencies = [
   "jq>=1.6.0,<1.9.0",
   # pycares is only a transitive dependency, but there is a combination of versions that expresses a bug.
   "pycares<4.9;python_version<'3.12'",  # pycares==4.9 + aiodns==3.2.0 + python<3.12 = trouble
-  "PyOpenSSL<26.0",
+  "PyOpenSSL<27.0",
   "opentelemetry-api>=1.27.0,<1.31",
   "opentelemetry-sdk>=1.27.0,<1.31",
   "opentelemetry-exporter-otlp-proto-http>=1.27.0,<1.31",


### PR DESCRIPTION
Backport of #7476.

(cherry picked from commit 3ba3e89c539d5b3cac536ecf3323a47f87603a7b)

Made with [Cursor](https://cursor.com)