### PR TITLE
[3.85] Update pyopenssl requirement from <26.0 to <27.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,7 +47,7 @@ dependencies = [
   "jinja2>=3.1,<=3.1.6",
   "json_stream>=2.3.2,<2.4",
   "jq>=1.6.0,<1.11.0",
-  "PyOpenSSL<26.0",
+  "PyOpenSSL<27.0",
   "opentelemetry-api>=1.27.0,<1.37",
   "opentelemetry-sdk>=1.27.0,<1.37",
   "opentelemetry-exporter-otlp-proto-http>=1.27.0,<1.37",


### PR DESCRIPTION
Backport of #7476.

(cherry picked from commit 3ba3e89c539d5b3cac536ecf3323a47f87603a7b)

Made with [Cursor](https://cursor.com)