### PR TITLE
Support DRF responses in SyncCache

### DIFF
--- a/CHANGES/plugin_api/+sync-cache-response.bugfix
+++ b/CHANGES/plugin_api/+sync-cache-response.bugfix
@@ -1,0 +1,1 @@
+Properly support DRF responses in Synchronous Content Cache.

--- a/pulpcore/cache/cache.py
+++ b/pulpcore/cache/cache.py
@@ -7,6 +7,7 @@ from functools import wraps
 from django.http import HttpResponseRedirect, HttpResponse, FileResponse as ApiFileResponse
 
 from rest_framework.request import Request as ApiRequest
+from rest_framework.response import Response as ApiResponse
 
 from aiohttp.web import FileResponse, Response, HTTPSuccessful, Request, StreamResponse
 from aiohttp.web_exceptions import HTTPFound
@@ -127,6 +128,7 @@ class SyncContentCache(Cache):
 
     RESPONSE_TYPES = {
         "FileResponse": ApiFileResponse,
+        "APIResponse": ApiResponse,
         "Response": HttpResponse,
         "Redirect": HttpResponseRedirect,
     }
@@ -218,6 +220,9 @@ class SyncContentCache(Cache):
         elif isinstance(response, ApiFileResponse):
             entry["path"] = str(response.filename)
             entry["type"] = "FileResponse"
+        elif isinstance(response, ApiResponse):
+            entry["data"] = response.data
+            entry["type"] = "APIResponse"
         elif isinstance(response, HttpResponse):
             entry["content"] = response.content.decode("utf-8")
             entry["type"] = "Response"


### PR DESCRIPTION
This was an oversight on the sync cache. 

### 📜 Checklist

- [ ] Commits are cleanly separated with meaningful messages (simple features and bug fixes should be [squashed](https://pulpproject.org/pulpcore/docs/dev/guides/git/#rebasing-and-squashing) to one commit)
- [ ] A [changelog entry](https://pulpproject.org/pulpcore/docs/dev/guides/git/#changelog-update) or entries has been added for any significant changes
- [ ] Follows the [Pulp policy on AI Usage](https://pulpproject.org/help/more/governance/ai_policy/)
- [ ] (For new features) - User documentation and test coverage has been added

See: [Pull Request Walkthrough](https://pulpproject.org/pulpcore/docs/dev/guides/pull-request-walkthrough/)
