### PR TITLE
Fix duplicate migration number 0146

### DIFF
--- a/pulpcore/app/migrations/0147_content_pulp_labels_gin.py
+++ b/pulpcore/app/migrations/0147_content_pulp_labels_gin.py
@@ -9,7 +9,7 @@ class Migration(migrations.Migration):
     atomic = False  # required for CONCURRENTLY
 
     dependencies = [
-        ("core", "0145_domainize_import_export"),
+        ("core", "0146_repository_retain_checkpoints"),
     ]
 
     operations = [

--- a/pulpcore/app/migrations/0148_artifact_artifact_domain_size_index.py
+++ b/pulpcore/app/migrations/0148_artifact_artifact_domain_size_index.py
@@ -8,7 +8,7 @@ class Migration(migrations.Migration):
     atomic = False # required for CONCURRENTLY
 
     dependencies = [
-        ("core", "0146_content_pulp_labels_gin"),
+        ("core", "0147_content_pulp_labels_gin"),
     ]
 
     operations = [


### PR DESCRIPTION
Two migrations shared the number 0146. Rename:
- 0146_content_pulp_labels_gin → 0147_content_pulp_labels_gin (update dependency to 0146_repository_retain_checkpoints)
- 0147_artifact_artifact_domain_size_index → 0148_artifact_artifact_domain_size_index (update dependency to 0147_content_pulp_labels_gin)

<!---
Thank you for submitting a PR to the Pulp Project!

If this is your first time contributing, please read the Pull Request Walkthrough documentation
(https://pulpproject.org/pulpcore/docs/dev/guides/pull-request-walkthrough/).
-->

### 📜 Checklist

- [ ] Commits are cleanly separated with meaningful messages (simple features and bug fixes should be [squashed](https://pulpproject.org/pulpcore/docs/dev/guides/git/#rebasing-and-squashing) to one commit)
- [ ] A [changelog entry](https://pulpproject.org/pulpcore/docs/dev/guides/git/#changelog-update) or entries has been added for any significant changes
- [ ] Follows the [Pulp policy on AI Usage](https://pulpproject.org/help/more/governance/ai_policy/)
- [ ] (For new features) - User documentation and test coverage has been added

See: [Pull Request Walkthrough](https://pulpproject.org/pulpcore/docs/dev/guides/pull-request-walkthrough/)
