### PR TITLE
[PULP-1487] Fix slow extract_pk for HREFs

### DIFF
--- a/CHANGES/6237.bugfix
+++ b/CHANGES/6237.bugfix
@@ -1,0 +1,1 @@
+Fixed a performance issue causing operations that process large numbers of HREFs to be ~1000x slower than equivalent PRN-based operations.

--- a/pulpcore/app/util.py
+++ b/pulpcore/app/util.py
@@ -21,7 +21,7 @@ from django.apps import apps
 from django.conf import settings
 from django.db import connection
 from django.db.models import Model, UUIDField
-from django.urls import Resolver404, resolve
+
 
 from rest_framework.serializers import ValidationError
 from rest_framework.reverse import reverse as drf_reverse
@@ -195,15 +195,13 @@ def extract_pk(uri, only_prn=False):
         return prn[2]
     elif only_prn:
         raise ValidationError(_("Not a valid PRN: {p}, must start with 'prn:'").format(p=uri))
+    path = urlparse(uri).path
+    pk = path.rstrip("/").rsplit("/", 1)[-1]
     try:
-        match = resolve(urlparse(uri).path)
-    except Resolver404:
+        UUID(pk)
+    except ValueError:
         raise ValidationError(detail=_("URI not valid: {u}").format(u=uri))
-
-    try:
-        return match.kwargs["pk"]
-    except KeyError:
-        raise ValidationError("URI does not contain an unqualified resource PK")
+    return pk
 
 
 def raise_for_unknown_content_units(

--- a/pulpcore/tests/unit/conftest.py
+++ b/pulpcore/tests/unit/conftest.py
@@ -1,11 +1,11 @@
 import pytest
 from uuid import uuid4
 
-from pulpcore.app.models import Domain
-from pulpcore.app.util import set_domain
-
 
 @pytest.fixture
 def fake_domain():
     """A fixture to prevent `get_domain` to call out to the database."""
+    from pulpcore.app.models import Domain
+    from pulpcore.app.util import set_domain
+
     set_domain(Domain(pk=uuid4(), name=uuid4()))

--- a/pulpcore/tests/unit/test_util.py
+++ b/pulpcore/tests/unit/test_util.py
@@ -1,15 +1,72 @@
 import hashlib
 import tempfile
 import unittest
+from contextlib import nullcontext
 from pathlib import Path
 
 import pytest
 from unittest import mock
+from rest_framework.exceptions import ValidationError
 
 from pulpcore.app import models, util
-from pulpcore.app.util import HashingFileWriter
+from pulpcore.app.util import HashingFileWriter, extract_pk
 
 pytestmark = pytest.mark.usefixtures("fake_domain")
+
+
+TEST_UUID = "019c8cae-cc5f-7148-a3de-456d0a9f39a1"
+
+EXTRACT_PK_CASES = [
+    # happy cases
+    pytest.param(
+        f"/pulp/api/v3/repositories/file/file/{TEST_UUID}/",
+        nullcontext(TEST_UUID),
+        id="valid_href",
+    ),
+    pytest.param(
+        f"prn:file.filerepository:{TEST_UUID}",
+        nullcontext(TEST_UUID),
+        id="valid_prn",
+    ),
+    # validation errors
+    pytest.param(
+        "/pulp/api/v3/repositories/file/file/not-a-uuid/",
+        pytest.raises(ValidationError),
+        id="href_non_uuid_segment",
+    ),
+    pytest.param(
+        "not-a-valid-uri",
+        pytest.raises(ValidationError),
+        id="invalid_uri",
+    ),
+    pytest.param(
+        "prn:file.filerepository",
+        pytest.raises(ValidationError),
+        id="prn_missing_pk",
+    ),
+    pytest.param(
+        f"prn:file.filerepository:{TEST_UUID}:extra",
+        pytest.raises(ValidationError),
+        id="prn_too_many_parts",
+    ),
+    # nested URL can't be used with extract_pk
+    pytest.param(
+        f"/pulp/api/v3/repositories/file/file/{TEST_UUID}/versions/3/",
+        pytest.raises(ValidationError),
+        id="nested_href_version_number",
+    ),
+]
+
+
+@pytest.mark.parametrize("uri,ctx", EXTRACT_PK_CASES)
+def test_extract_pk(uri, ctx):
+    with ctx as expected:
+        assert extract_pk(uri) == expected
+
+
+def test_extract_pk_only_prn_rejects_href():
+    with pytest.raises(ValidationError):
+        extract_pk(f"/pulp/api/v3/repositories/file/file/{TEST_UUID}/", only_prn=True)
 
 
 def test_get_view_name_for_model_with_object():


### PR DESCRIPTION
extract_pk() was ~1000x slower for HREFs than PRNs (22.5s vs 0.024s for 10k items) because it called Django's URL resolver on every invocation. Replace it with a direct UUID extraction from the path, which matches the function's documented intent of not validating resource existence.

Add unit tests for extract_pk covering valid HREFs, PRNs, and various invalid inputs including nested URLs (e.g. RepositoryVersion).

Closes #6237

<!---
Thank you for submitting a PR to the Pulp Project!

If this is your first time contributing, please read the Pull Request Walkthrough documentation
(https://pulpproject.org/pulpcore/docs/dev/guides/pull-request-walkthrough/).
-->

### 📜 Checklist

- [ ] Commits are cleanly separated with meaningful messages (simple features and bug fixes should be [squashed](https://pulpproject.org/pulpcore/docs/dev/guides/git/#rebasing-and-squashing) to one commit)
- [ ] A [changelog entry](https://pulpproject.org/pulpcore/docs/dev/guides/git/#changelog-update) or entries has been added for any significant changes
- [ ] Follows the [Pulp policy on AI Usage](https://pulpproject.org/help/more/governance/ai_policy/)
- [ ] (For new features) - User documentation and test coverage has been added

See: [Pull Request Walkthrough](https://pulpproject.org/pulpcore/docs/dev/guides/pull-request-walkthrough/)
