### PR TITLE
Make PgpKeyFingerprintField prefix optional, default to v4

### DIFF
--- a/CHANGES/plugin_api/+pgp-fingerprint-optional-prefix.feature
+++ b/CHANGES/plugin_api/+pgp-fingerprint-optional-prefix.feature
@@ -1,0 +1,1 @@
+Made the prefix on `PgpKeyFingerprintField` optional, defaulting to `v4:` when omitted.

--- a/pulpcore/app/serializers/fields.py
+++ b/pulpcore/app/serializers/fields.py
@@ -448,15 +448,21 @@ class PgpKeyFingerprintField(serializers.CharField):
     A DRF field for type-prefixed OpenPGP key identifiers.
 
     Accepts formats like 'v4:<40-hex>', 'v6:<64-hex>', or 'keyid:<16-hex>'.
+    If no prefix is provided, 'v4:' is assumed.
     Normalizes hex to uppercase on input and validates the format.
     """
+
+    DEFAULT_PREFIX = "v4"
 
     # Matches versioned fingerprints (v3/v4/v5/v6) and legacy 16-char key IDs.
     FINGERPRINT_RE = re.compile(r"^(v\d:[0-9A-F]{32,64}|keyid:[0-9A-F]{16})$")
 
+    # Matches a bare hex string (no prefix).
+    BARE_HEX_RE = re.compile(r"^[0-9a-fA-F]+$")
+
     default_error_messages = {
         "invalid_format": _(
-            "Invalid fingerprint format. Expected 'v<N>:<hex-fingerprint>' or 'keyid:<16-hex>'."
+            "Invalid fingerprint format. Expected '[v<N>:]<hex-fingerprint>' or 'keyid:<16-hex>'."
         ),
     }
 
@@ -472,6 +478,8 @@ class PgpKeyFingerprintField(serializers.CharField):
 
     def to_internal_value(self, data):
         value = super().to_internal_value(data)
+        if self.BARE_HEX_RE.match(value):
+            value = f"{self.DEFAULT_PREFIX}:{value}"
         value = self.normalize(value)
         if not self.FINGERPRINT_RE.match(value):
             self.fail("invalid_format")

--- a/pulpcore/tests/unit/serializers/test_fields.py
+++ b/pulpcore/tests/unit/serializers/test_fields.py
@@ -126,6 +126,16 @@ def test_custom_json_dict_field_raises(field_and_data, binary_arg):
             "v3:AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
             id="v3-32hex",
         ),
+        pytest.param(
+            "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+            "v4:AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+            id="bare-hex-defaults-to-v4",
+        ),
+        pytest.param(
+            "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+            "v4:AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+            id="bare-hex-lowercase-defaults-to-v4",
+        ),
     ],
 )
 def test_pgp_key_fingerprint_field_valid(value, expected):
@@ -140,7 +150,7 @@ def test_pgp_key_fingerprint_field_valid(value, expected):
         pytest.param("not-a-fingerprint", id="garbage"),
         pytest.param("v4:ZZZZ", id="non-hex-chars"),
         pytest.param("v4:AAAA", id="too-short-hex"),
-        pytest.param("AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA", id="no-prefix"),
+        pytest.param("AAAA", id="bare-hex-too-short"),
         pytest.param("v4:", id="empty-hex"),
         pytest.param("", id="empty-string"),
         pytest.param("keyid:AAAAAAAAAAAAAAA", id="keyid-15hex-too-short"),


### PR DESCRIPTION
When a bare hex string is provided without a version prefix, PgpKeyFingerprintField now assumes 'v4:' as the default prefix. This makes the field backwards compatible.