### PR TITLE
[PULP-939] Add created_resource_prns field to Task

### DIFF
--- a/CHANGES/7003.feature
+++ b/CHANGES/7003.feature
@@ -1,0 +1,1 @@
+Added the `created_resource_prns` field to Task, returning the PRN of each created resource.

--- a/pulpcore/app/serializers/task.py
+++ b/pulpcore/app/serializers/task.py
@@ -17,10 +17,29 @@ from pulpcore.app.serializers import (
     fields,
 )
 from pulpcore.constants import TASK_STATES
-from pulpcore.app.util import reverse
+from pulpcore.app.util import get_prn, reverse
 
 
 class CreatedResourceField(RelatedResourceField):
+    class Meta:
+        model = models.CreatedResource
+        fields = []
+
+
+class CreatedResourcePrnField(RelatedResourceField):
+    """
+    A field that returns PRNs for created resources instead of HREFs.
+    """
+
+    def to_representation(self, data):
+        # If content_type is already cached, build PRN without a DB hit
+        if models.GenericRelationModel.content_type.is_cached(data):
+            model = data.content_type.model_class()
+            return f"prn:{model._meta.label_lower}:{data.object_id}"
+        if data.content_object is None:
+            return "<unavailable>"
+        return get_prn(instance=data.content_object)
+
     class Meta:
         model = models.CreatedResource
         fields = []
@@ -82,6 +101,13 @@ class TaskSerializer(ModelSerializer):
         read_only=True,
         view_name="None",  # This is a polymorphic field. The serializer does not need a view name.
     )
+    created_resource_prns = CreatedResourcePrnField(
+        help_text=_("Resources created by this task as PRNs."),
+        many=True,
+        read_only=True,
+        view_name="None",  # This is a polymorphic field. The serializer does not need a view name.
+        source="created_resources",
+    )
     reserved_resources_record = serializers.ListField(
         child=serializers.CharField(),
         help_text=_("A list of resources required by that task."),
@@ -120,6 +146,7 @@ class TaskSerializer(ModelSerializer):
             "task_group",
             "progress_reports",
             "created_resources",
+            "created_resource_prns",
             "reserved_resources_record",
             "result",
         )

--- a/pulpcore/tests/functional/api/using_plugin/test_tasks.py
+++ b/pulpcore/tests/functional/api/using_plugin/test_tasks.py
@@ -189,3 +189,26 @@ def test_task_result(add_to_cleanup, file_bindings, monitor_task):
     assert task_2.result["base_path"] == updated_body["base_path"]
 
     add_to_cleanup(file_bindings.DistributionsFileApi, dist_href)
+
+
+@pytest.mark.parallel
+def test_created_resource_prns(
+    basic_manifest_path,
+    file_bindings,
+    file_remote_factory,
+    file_repo,
+    monitor_task,
+):
+    """
+    Test that created_resource_prns returns PRNs matching the created resources.
+    """
+    remote = file_remote_factory(basic_manifest_path)
+    task = monitor_task(
+        file_bindings.RepositoriesFileApi.sync(file_repo.pulp_href, {"remote": remote.prn}).task
+    )
+    assert len(task.created_resources) == 1
+    assert len(task.created_resource_prns) == 1
+
+    # The PRN should correspond to the repository version that was created
+    repo_ver = file_bindings.RepositoriesFileVersionsApi.read(task.created_resources[0])
+    assert repo_ver.prn == task.created_resource_prns[0] == task.result["prn"]


### PR DESCRIPTION
closes #7003

<!---
Thank you for submitting a PR to the Pulp Project!

If this is your first time contributing, please read the Pull Request Walkthrough documentation
(https://pulpproject.org/pulpcore/docs/dev/guides/pull-request-walkthrough/).
-->

### 📜 Checklist

- [ ] Commits are cleanly separated with meaningful messages (simple features and bug fixes should be [squashed](https://pulpproject.org/pulpcore/docs/dev/guides/git/#rebasing-and-squashing) to one commit)
- [ ] A [changelog entry](https://pulpproject.org/pulpcore/docs/dev/guides/git/#changelog-update) or entries has been added for any significant changes
- [ ] Follows the [Pulp policy on AI Usage](https://pulpproject.org/help/more/governance/ai_policy/)
- [ ] (For new features) - User documentation and test coverage has been added

See: [Pull Request Walkthrough](https://pulpproject.org/pulpcore/docs/dev/guides/pull-request-walkthrough/)
