### PR TITLE
Fixed double publish bug after file syncing

### DIFF
--- a/CHANGES/pulp_file/7557.bugfix
+++ b/CHANGES/pulp_file/7557.bugfix
@@ -1,0 +1,1 @@
+Fixed double publish when performing file replication.

--- a/pulp_file/app/replica.py
+++ b/pulp_file/app/replica.py
@@ -44,7 +44,7 @@ class FileReplicator(Replicator):
         return f"{upstream_distribution['base_url']}{manifest}"
 
     def repository_extra_fields(self, remote):
-        return dict(manifest=remote.url.split("/")[-1], autopublish=True)
+        return dict(manifest=remote.url.split("/")[-1], autopublish=False)
 
     def sync_params(self, repository, remote):
         return dict(

--- a/pulp_file/app/viewsets.py
+++ b/pulp_file/app/viewsets.py
@@ -7,6 +7,7 @@ from rest_framework.decorators import action
 from rest_framework import status
 from rest_framework.generics import get_object_or_404
 from rest_framework.response import Response
+from rest_framework.exceptions import ValidationError
 
 from pulpcore.plugin.actions import ModifyRepositoryActionMixin
 from pulpcore.plugin.models import (
@@ -268,6 +269,8 @@ class FileRepositoryViewSet(RepositoryViewSet, ModifyRepositoryActionMixin, Role
         remote = serializer.validated_data.get("remote", repository.remote)
 
         mirror = serializer.validated_data.get("mirror", False)
+        if mirror and repository.autopublish:
+            raise ValidationError("Cannot use mirror mode with autopublished repository.")
         result = dispatch(
             tasks.synchronize,
             shared_resources=[remote],

--- a/pulp_file/tests/functional/api/test_auto_publish.py
+++ b/pulp_file/tests/functional/api/test_auto_publish.py
@@ -73,6 +73,13 @@ def test_auto_publish_and_distribution(
     )
     assert files_in_first_publication == expected_files
 
+    # Assert that mirror=True is not allowed when autopublish=True
+    body = RepositorySyncURL(remote=remote.pulp_href, mirror=True)
+    with pytest.raises(file_bindings.ApiException) as exc:
+        file_bindings.RepositoriesFileApi.sync(repo.pulp_href, body)
+    assert exc.value.status == 400
+    assert "Cannot use mirror mode with autopublished repository." in exc.value.body
+
     # Add a new content unit to the repository and assert that a publication gets created and the
     # new content unit is in it
     monitor_task(

--- a/pulpcore/tests/functional/api/test_replication.py
+++ b/pulpcore/tests/functional/api/test_replication.py
@@ -108,12 +108,13 @@ def test_replication_idempotence(
         file_bindings.RemotesFileApi,
         file_bindings.RepositoriesFileApi,
         file_bindings.ContentFilesApi,
+        file_bindings.PublicationsFileApi,
     ):
         result = api_client.list(pulp_domain=replica_domain.name)
         assert result.count == 1
         obj = result.results[0]
-        # Test that each new object (besides Content) has a source UpstreamPulp label
-        if api_client != file_bindings.ContentFilesApi:
+        # Test that each new object (besides Content/Publication) has a source UpstreamPulp label
+        if api_client not in (file_bindings.ContentFilesApi, file_bindings.PublicationsFileApi):
             assert "UpstreamPulp" in obj.pulp_labels
             assert upstream_pulp.prn.split(":")[-1] == obj.pulp_labels["UpstreamPulp"]
 
@@ -167,6 +168,11 @@ def test_replication_idempotence(
     assert "UpstreamPulp" in new_remote.pulp_labels
     assert upstream_pulp2.prn.split(":")[-1] == new_remote.pulp_labels["UpstreamPulp"]
 
+    result = file_bindings.PublicationsFileApi.list(pulp_domain=source_domain.name)
+    assert result.count == 1  # old publication got deleted when repository was deleted
+    new_publication = result.results[0]
+    assert new_publication.pulp_href != publication.pulp_href
+
 
 @pytest.mark.parallel
 def test_replication_with_repo_based_distribution(
@@ -188,11 +194,11 @@ def test_replication_with_repo_based_distribution(
     source_domain = domain_factory()
     add_domain_objects_to_cleanup(source_domain)
 
-    # Create a repo with autopublish, sync it, and distribute via repository (not publication)
+    # Create a repo, sync it w/ mirror=True, and distribute via repository (not publication)
     remote = file_remote_factory(
         pulp_domain=source_domain.name, manifest_path=basic_manifest_path, policy="immediate"
     )
-    repo = file_repository_factory(pulp_domain=source_domain.name, autopublish=True)
+    repo = file_repository_factory(pulp_domain=source_domain.name)
     sync_data = file_bindings.module.RepositorySyncURL(remote=remote.pulp_href, mirror=True)
     monitor_task(file_bindings.RepositoriesFileApi.sync(repo.pulp_href, sync_data).task)
     _ = file_distribution_factory(pulp_domain=source_domain.name, repository=repo.pulp_href)


### PR DESCRIPTION
`Repository.on_new_version` does a publish if `autopublish=True`, don't think we need to do a publish when `mirror=True` after syncs. 

### 📜 Checklist

- [ ] Commits are cleanly separated with meaningful messages (simple features and bug fixes should be [squashed](https://pulpproject.org/pulpcore/docs/dev/guides/git/#rebasing-and-squashing) to one commit)
- [ ] A [changelog entry](https://pulpproject.org/pulpcore/docs/dev/guides/git/#changelog-update) or entries has been added for any significant changes
- [ ] Follows the [Pulp policy on AI Usage](https://pulpproject.org/help/more/governance/ai_policy/)
- [ ] (For new features) - User documentation and test coverage has been added

See: [Pull Request Walkthrough](https://pulpproject.org/pulpcore/docs/dev/guides/pull-request-walkthrough/)
