### PR TITLE
Add support for allow_blank=True to PgpKeyFingerprintField

### DIFF
--- a/CHANGES/plugin_api/+pgp-fingerprint-allow-blank.feature
+++ b/CHANGES/plugin_api/+pgp-fingerprint-allow-blank.feature
@@ -1,0 +1,2 @@
+`PgpKeyFingerprintField` now supports `allow_blank=True`, enabling plugin writers to accept
+blank string values — useful for signaling deletion or resetting an override entry.

--- a/pulpcore/app/serializers/fields.py
+++ b/pulpcore/app/serializers/fields.py
@@ -478,6 +478,9 @@ class PgpKeyFingerprintField(serializers.CharField):
 
     def to_internal_value(self, data):
         value = super().to_internal_value(data)
+        # Allow blank strings through when allow_blank=True (e.g. for override deletion).
+        if self.allow_blank and not value:
+            return value
         if self.BARE_HEX_RE.match(value):
             value = f"{self.DEFAULT_PREFIX}:{value}"
         value = self.normalize(value)

--- a/pulpcore/tests/unit/serializers/test_fields.py
+++ b/pulpcore/tests/unit/serializers/test_fields.py
@@ -207,3 +207,27 @@ def test_pgp_key_fingerprint_field_custom_max_length():
 def test_pgp_key_fingerprint_field_normalize(value, expected):
     """PgpKeyFingerprintField.normalize should uppercase hex after the colon."""
     assert PgpKeyFingerprintField.normalize(value) == expected
+
+
+def test_pgp_key_fingerprint_field_rejects_blank_by_default():
+    """With the default allow_blank=False, empty strings should raise ValidationError."""
+    field = PgpKeyFingerprintField()
+    with pytest.raises(serializers.ValidationError):
+        field.to_internal_value("")
+
+
+def test_pgp_key_fingerprint_field_allow_blank():
+    """With allow_blank=True, empty strings should pass through without format validation."""
+    field = PgpKeyFingerprintField(allow_blank=True)
+    assert field.to_internal_value("") == ""
+
+
+def test_pgp_key_fingerprint_field_allow_blank_still_validates_non_empty():
+    """With allow_blank=True, non-empty values should still be validated as fingerprints."""
+    field = PgpKeyFingerprintField(allow_blank=True)
+    assert (
+        field.to_internal_value("AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA")
+        == "v4:AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+    )
+    with pytest.raises(serializers.ValidationError):
+        field.to_internal_value("not-a-fingerprint")


### PR DESCRIPTION
PgpKeyFingerprintField.to_internal_value() now respects allow_blank=True, enabling plugin writers to accept blank string values. Previously, blank inputs were unconditionally rejected with an 'invalid_format' error regardless of the allow_blank setting.

This is useful in pulp_deb where PackageFingerprintOverrideField (a DictField for per-release fingerprint overrides) uses PgpKeyFingerprintField as its child. That field relies on empty string values to signal deletion of an override entry — e.g. {"bionic": ""} deletes the override for bionic.