### PR TITLE
Fix race condition in reverse-replication

### DIFF
--- a/CHANGES/+replication-race.bugfix
+++ b/CHANGES/+replication-race.bugfix
@@ -1,0 +1,1 @@
+Fixed a race condition that could sometimes occur when converting an existing non-replica Pulp instance into a replica ("reverse-replication"). Likely rare in real world use.

--- a/pulpcore/app/replica.py
+++ b/pulpcore/app/replica.py
@@ -282,11 +282,16 @@ class Replicator:
         ]
 
         if repository_ids or remote_ids:
+            # Lock distros_uris to prevent concurrent distribution create/update tasks
+            # from racing with this deletion. Deleting a repository CASCADE-deletes its
+            # publications (and RVs, etc.), which SET_NULLs any distribution FK pointing
+            # to them. A concurrent distribution update could then write back the stale FK,
+            # causing an IntegrityError.
             dispatch(
                 general_multi_delete,
                 task_group=self.task_group,
                 shared_resources=[self.server],
-                exclusive_resources=repositories + remotes,
+                exclusive_resources=self.distros_uris + repositories + remotes,
                 args=(repository_ids + remote_ids,),
             )
 


### PR DESCRIPTION
Resulted in flaky CI behavior and sporadic failures

<!---
Thank you for submitting a PR to the Pulp Project!

If this is your first time contributing, please read the Pull Request Walkthrough documentation
(https://pulpproject.org/pulpcore/docs/dev/guides/pull-request-walkthrough/).
-->

### 📜 Checklist

- [x] Commits are cleanly separated with meaningful messages (simple features and bug fixes should be [squashed](https://pulpproject.org/pulpcore/docs/dev/guides/git/#rebasing-and-squashing) to one commit)
- [x] A [changelog entry](https://pulpproject.org/pulpcore/docs/dev/guides/git/#changelog-update) or entries has been added for any significant changes
- [x] Follows the [Pulp policy on AI Usage](https://pulpproject.org/help/more/governance/ai_policy/)
- [ ] (For new features) - User documentation and test coverage has been added

See: [Pull Request Walkthrough](https://pulpproject.org/pulpcore/docs/dev/guides/pull-request-walkthrough/)
