### PR TITLE
[PULP-1299] Add setting to allow admins to avoid timeout issues with immediate tasks

### DIFF
--- a/CHANGES/+task_immediate_timeout.bugfix
+++ b/CHANGES/+task_immediate_timeout.bugfix
@@ -1,0 +1,1 @@
+Added new setting `TASK_PREFER_DEFER` to always defer immediate tasks to a task worker. Useful for systems with slow databases that frequently timeout immediate tasks.

--- a/docs/admin/reference/settings.md
+++ b/docs/admin/reference/settings.md
@@ -392,6 +392,16 @@ This time is only accurate to one worker heartbeat corresponding to `WORKER_TTL 
 
 Defaults to `600` seconds.
 
+### TASK\_PREFER\_DEFER
+
+For tasks that are designed to run immediately, but could be deferred to a task worker, always choose to defer to the worker.
+This is helpful for systems with slow databases that could cause the immediate task to timeout after its 5 second limit.
+
+!!! note
+    Setting this to `True` will slow your Pulp's task throughput, especially if you perform many immediate tasks frequently.
+
+Defaults to `False`.
+
 ### TASK\_PROTECTION\_TIME, TMPFILE\_PROTECTION\_TIME and UPLOAD\_PROTECTION\_TIME
 
 Pulp uses `tasks`, `pulp temporary files` and `uploads` to pass data from the api to worker tasks.

--- a/pulpcore/app/settings.py
+++ b/pulpcore/app/settings.py
@@ -391,6 +391,9 @@ DEFAULT_AUTO_FIELD = "django.db.models.AutoField"
 # NOTE: "memray" and "pyinstrument" require additional packages to be installed on the system.
 TASK_DIAGNOSTICS = []  # ["memory", "pyinstrument", "memray", "logs", "debug-logs"]
 
+# For immediate tasks that can be deferred, always defer them to a worker.
+TASK_PREFER_DEFER = False
+
 ANALYTICS = True
 
 HIDE_GUARDED_DISTRIBUTIONS = False

--- a/pulpcore/tasking/tasks.py
+++ b/pulpcore/tasking/tasks.py
@@ -289,6 +289,8 @@ def dispatch(
     Raises:
         ValueError: When `resources` is an unsupported type.
     """
+    if settings.TASK_PREFER_DEFER and deferred and immediate:
+        immediate = False
     # Check WORKER_TYPE setting and delegate to appropriate implementation
     if settings.WORKER_TYPE == "redis":
         from pulpcore.tasking.redis_tasks import dispatch as redis_dispatch
@@ -347,6 +349,8 @@ async def adispatch(
     versions=None,
 ):
     """Async version of dispatch."""
+    if settings.TASK_PREFER_DEFER and deferred and immediate:
+        immediate = False
     # Check WORKER_TYPE setting and delegate to appropriate implementation
     if settings.WORKER_TYPE == "redis":
         from pulpcore.tasking.redis_tasks import adispatch as redis_adispatch


### PR DESCRIPTION
We can backport new settings right?

I looked at the [JIRA](https://redhat.atlassian.net/browse/PULP-1299) and in this case there really isn't any expensive operation going on for RPM or Container distribution updates. There's two synchronous operations: 1. the database update call, 2. the cache invalidation hook. These should both be fairly fast and happen under a second, so not sure how satellite is hitting the 5 second timeout. The only conclusion I can draw is that their third party systems are really slow.

I really don't think we should update the RPM & Container tasks to be deferred since Services never runs into this problem and it would significantly slow down their system if we did so with the thousands of updates they handle daily. I also didn't think we should allow the immediate timeout to be configurable with a setting since the user would be unaware that it would affect the task worker's heartbeat if increased too large and could end up with more cancelled tasks. Open to suggestions, but I think this setting is the simplest solution that can satisfy everyone's needs. 

<!---
Thank you for submitting a PR to the Pulp Project!

If this is your first time contributing, please read the Pull Request Walkthrough documentation
(https://pulpproject.org/pulpcore/docs/dev/guides/pull-request-walkthrough/).
-->

### 📜 Checklist

- [ ] Commits are cleanly separated with meaningful messages (simple features and bug fixes should be [squashed](https://pulpproject.org/pulpcore/docs/dev/guides/git/#rebasing-and-squashing) to one commit)
- [ ] A [changelog entry](https://pulpproject.org/pulpcore/docs/dev/guides/git/#changelog-update) or entries has been added for any significant changes
- [ ] Follows the [Pulp policy on AI Usage](https://pulpproject.org/help/more/governance/ai_policy/)
- [ ] (For new features) - User documentation and test coverage has been added

See: [Pull Request Walkthrough](https://pulpproject.org/pulpcore/docs/dev/guides/pull-request-walkthrough/)
