### PR TITLE
[PULP-1639] Fix gunicorn "Control server error"

### DIFF
--- a/CHANGES/7574.bugfix
+++ b/CHANGES/7574.bugfix
@@ -1,0 +1,4 @@
+Added option to `pulpcore-content` and `pulpcore-api` to configure the gunicorn control socket path.
+The default path could cause permission errors on certain deployments setups.
+
+This feature was added in gunicorn>=25.1 and is ignored for lower version.

--- a/pulpcore/app/entrypoint.py
+++ b/pulpcore/app/entrypoint.py
@@ -14,7 +14,10 @@ from gunicorn.workers.sync import SyncWorker
 
 from pulpcore.app.apps import pulp_plugin_configs
 from pulpcore.app.netutil import has_ipv6
-from pulpcore.app.pulpcore_gunicorn_application import PulpcoreGunicornApplication
+from pulpcore.app.pulpcore_gunicorn_application import (
+    handle_control_interface_feature,
+    PulpcoreGunicornApplication,
+)
 
 logger = getLogger(__name__)
 
@@ -146,7 +149,7 @@ class PulpcoreApiApplication(PulpcoreGunicornApplication):
 
 
 @click.option(
-    "--bind", "-b", default=[f"{ '[::]' if has_ipv6() else '0.0.0.0' }:24817"], multiple=True
+    "--bind", "-b", default=[f"{'[::]' if has_ipv6() else '0.0.0.0'}:24817"], multiple=True
 )
 @click.option("--workers", "-w", type=int)
 # @click.option("--threads", "-w", type=int)  # We don't use a threaded worker...
@@ -181,6 +184,11 @@ class PulpcoreApiApplication(PulpcoreGunicornApplication):
 @click.option("--user", "-u")
 @click.option("--group", "-g")
 @click.option(
+    "--control-socket",
+    "control_socket",
+    help="Path to the gunicorn control socket (requires gunicorn>=25.1).",
+)
+@click.option(
     "--name-template",
     type=str,
     help="Format string to use for the status name. "
@@ -190,5 +198,6 @@ class PulpcoreApiApplication(PulpcoreGunicornApplication):
 def main(bind, name_template, **options):
     name_template_var.set(name_template)
     options["bind"] = list(bind)
+    handle_control_interface_feature(options)
     sys.argv = sys.argv[:1]
     PulpcoreApiApplication(options).run()

--- a/pulpcore/app/pulpcore_gunicorn_application.py
+++ b/pulpcore/app/pulpcore_gunicorn_application.py
@@ -1,6 +1,22 @@
 import sys
+from importlib.metadata import version as pkg_version
 
 from gunicorn.app.base import Application
+
+
+def handle_control_interface_feature(options):
+    """Drop control_socket from options if gunicorn<25.1, which introduced the feature."""
+    # TODO: remove this function when gunicorn lowerbound>=25.1
+    if options.get("control_socket") is None:
+        return
+
+    gunicorn_version = tuple(int(x) for x in pkg_version("gunicorn").split(".")[:2])
+    if gunicorn_version < (25, 1):
+        sys.stderr.write(
+            "Warning: --control-socket requires gunicorn>=25.1, ignoring "
+            f"(installed: {'.'.join(str(x) for x in gunicorn_version)}).\n"
+        )
+        options["control_socket"] = None
 
 
 class PulpcoreGunicornApplication(Application):

--- a/pulpcore/content/entrypoint.py
+++ b/pulpcore/content/entrypoint.py
@@ -2,7 +2,10 @@ import sys
 
 import click
 from pulpcore.app.netutil import has_ipv6
-from pulpcore.app.pulpcore_gunicorn_application import PulpcoreGunicornApplication
+from pulpcore.app.pulpcore_gunicorn_application import (
+    handle_control_interface_feature,
+    PulpcoreGunicornApplication,
+)
 from django.conf import settings
 
 
@@ -23,7 +26,7 @@ class PulpcoreContentApplication(PulpcoreGunicornApplication):
 
 
 @click.option(
-    "--bind", "-b", default=[f"{ '[::]' if has_ipv6() else '0.0.0.0' }:24816"], multiple=True
+    "--bind", "-b", default=[f"{'[::]' if has_ipv6() else '0.0.0.0'}:24816"], multiple=True
 )
 @click.option("--workers", "-w", type=int)
 # @click.option("--threads", "-w", type=int)  # We don't use a threaded worker...
@@ -51,6 +54,11 @@ class PulpcoreContentApplication(PulpcoreGunicornApplication):
 @click.option("--user", "-u")
 @click.option("--group", "-g")
 @click.option(
+    "--control-socket",
+    "control_socket",
+    help="Path to the gunicorn control socket (requires gunicorn>=25.1).",
+)
+@click.option(
     "--name-template",
     type=str,
     help="Format string to use for the status name. "
@@ -61,5 +69,6 @@ def main(bind, name_template, **options):
     if name_template:
         settings.set("WORKER_NAME_TEMPLATE", name_template)
     options["bind"] = list(bind)
+    handle_control_interface_feature(options)
     sys.argv = sys.argv[:1]
     PulpcoreContentApplication(options).run()


### PR DESCRIPTION
gunicorn [25.1.0](https://gunicorn.org/news/#2510-2026-02-13) introduced a control socket (gunicornc) that defaults to `gunicorn.ctl` relative to the working directory. Since pulpcore-content sets its CWD to WORKING_DIRECTORY (`/var/lib/pulp/tmp` by default), the socket lands on the shared PVC and persists across pod restarts, causing Permission denied when a new pod tries to recreate it during a rolling update.

Default to /tmp/pulpcore-content.ctl, which is pod-local ephemeral storage. Users who want a different path can override via gunicorn.conf.py.

fixes: #7574
Assisted-by: Claude Code

<!---
Thank you for submitting a PR to the Pulp Project!

If this is your first time contributing, please read the Pull Request Walkthrough documentation
(https://pulpproject.org/pulpcore/docs/dev/guides/pull-request-walkthrough/).
-->

### 📜 Checklist

- [ ] Commits are cleanly separated with meaningful messages (simple features and bug fixes should be [squashed](https://pulpproject.org/pulpcore/docs/dev/guides/git/#rebasing-and-squashing) to one commit)
- [ ] A [changelog entry](https://pulpproject.org/pulpcore/docs/dev/guides/git/#changelog-update) or entries has been added for any significant changes
- [ ] Follows the [Pulp policy on AI Usage](https://pulpproject.org/help/more/governance/ai_policy/)
- [ ] (For new features) - User documentation and test coverage has been added

See: [Pull Request Walkthrough](https://pulpproject.org/pulpcore/docs/dev/guides/pull-request-walkthrough/)
