### PR TITLE
[3.85] [PULP-1299] Add setting to allow admins to avoid timeout issues with immediate tasks

### DIFF
--- a/CHANGES/+task_immediate_timeout.bugfix
+++ b/CHANGES/+task_immediate_timeout.bugfix
@@ -1,0 +1,1 @@
+Added new setting `TASK_PREFER_DEFER` to always defer immediate tasks to a task worker. Useful for systems with slow databases that frequently timeout immediate tasks.

--- a/docs/admin/reference/settings.md
+++ b/docs/admin/reference/settings.md
@@ -376,6 +376,16 @@ This time is only accurate to one worker heartbeat corresponding to `WORKER_TTL 
 
 Defaults to `600` seconds.
 
+### TASK\_PREFER\_DEFER
+
+For tasks that are designed to run immediately, but could be deferred to a task worker, always choose to defer to the worker.
+This is helpful for systems with slow databases that could cause the immediate task to timeout after its 5 second limit.
+
+!!! note
+    Setting this to `True` will slow your Pulp's task throughput, especially if you perform many immediate tasks frequently.
+
+Defaults to `False`.
+
 ### TASK\_PROTECTION\_TIME, TMPFILE\_PROTECTION\_TIME and UPLOAD\_PROTECTION\_TIME
 
 Pulp uses `tasks`, `pulp temporary files` and `uploads` to pass data from the api to worker tasks.

--- a/pulpcore/app/settings.py
+++ b/pulpcore/app/settings.py
@@ -377,6 +377,9 @@ DEFAULT_AUTO_FIELD = "django.db.models.AutoField"
 # NOTE: "memray" and "pyinstrument" require additional packages to be installed on the system.
 TASK_DIAGNOSTICS = []  # ["memory", "pyinstrument", "memray"]
 
+# For immediate tasks that can be deferred, always defer them to a worker.
+TASK_PREFER_DEFER = False
+
 ANALYTICS = True
 
 HIDE_GUARDED_DISTRIBUTIONS = False

--- a/pulpcore/tasking/tasks.py
+++ b/pulpcore/tasking/tasks.py
@@ -193,6 +193,8 @@ def dispatch(
     Raises:
         ValueError: When `resources` is an unsupported type.
     """
+    if settings.TASK_PREFER_DEFER and deferred and immediate:
+        immediate = False
 
     # Can't run short tasks immediately if running from thread pool
     immediate = immediate and not running_from_thread_pool()


### PR DESCRIPTION
Manual backport of https://github.com/pulp/pulpcore/pull/7587 (cherry-picked from 71c6e2c0cb5d79db06e1e4cfdc634d9c15246afa).

Patchback failed on \`3.85\` because \`main\`'s patch did not apply cleanly to \`pulpcore/tasking/tasks.py\`. The branch uses the older tasking layout (no \`adispatch\` / redis worker delegation here), so only the \`TASK_PREFER_DEFER\` guard was added at the start of \`dispatch()\`, matching the intent of the original change.