### PR TITLE
[3.105] [PULP-1299] Add setting to allow admins to avoid timeout issues with immediate tasks

### DIFF
--- a/CHANGES/+task_immediate_timeout.bugfix
+++ b/CHANGES/+task_immediate_timeout.bugfix
@@ -1,0 +1,1 @@
+Added new setting `TASK_PREFER_DEFER` to always defer immediate tasks to a task worker. Useful for systems with slow databases that frequently timeout immediate tasks.

--- a/docs/admin/reference/settings.md
+++ b/docs/admin/reference/settings.md
@@ -377,6 +377,16 @@ This time is only accurate to one worker heartbeat corresponding to `WORKER_TTL 
 
 Defaults to `600` seconds.
 
+### TASK\_PREFER\_DEFER
+
+For tasks that are designed to run immediately, but could be deferred to a task worker, always choose to defer to the worker.
+This is helpful for systems with slow databases that could cause the immediate task to timeout after its 5 second limit.
+
+!!! note
+    Setting this to `True` will slow your Pulp's task throughput, especially if you perform many immediate tasks frequently.
+
+Defaults to `False`.
+
 ### TASK\_PROTECTION\_TIME, TMPFILE\_PROTECTION\_TIME and UPLOAD\_PROTECTION\_TIME
 
 Pulp uses `tasks`, `pulp temporary files` and `uploads` to pass data from the api to worker tasks.

--- a/pulpcore/app/settings.py
+++ b/pulpcore/app/settings.py
@@ -387,6 +387,9 @@ DEFAULT_AUTO_FIELD = "django.db.models.AutoField"
 # NOTE: "memray" and "pyinstrument" require additional packages to be installed on the system.
 TASK_DIAGNOSTICS = []  # ["memory", "pyinstrument", "memray", "logs", "debug-logs"]
 
+# For immediate tasks that can be deferred, always defer them to a worker.
+TASK_PREFER_DEFER = False
+
 ANALYTICS = True
 
 HIDE_GUARDED_DISTRIBUTIONS = False

--- a/pulpcore/tasking/tasks.py
+++ b/pulpcore/tasking/tasks.py
@@ -261,6 +261,8 @@ def dispatch(
     Raises:
         ValueError: When `resources` is an unsupported type.
     """
+    if settings.TASK_PREFER_DEFER and deferred and immediate:
+        immediate = False
 
     execute_now = immediate and not called_from_content_app()
     assert deferred or immediate, "A task must be at least `deferred` or `immediate`."
@@ -303,6 +305,9 @@ async def adispatch(
     versions=None,
 ):
     """Async version of dispatch."""
+    if settings.TASK_PREFER_DEFER and deferred and immediate:
+        immediate = False
+
     execute_now = immediate and not called_from_content_app()
     assert deferred or immediate, "A task must be at least `deferred` or `immediate`."
     function_name = get_function_name(func)


### PR DESCRIPTION
Manual backport of https://github.com/pulp/pulpcore/pull/7587 (cherry-picked from 71c6e2c0cb5d79db06e1e4cfdc634d9c15246afa).

Patchback failed on \`3.105\` due to conflicts in \`pulpcore/tasking/tasks.py\`. Resolved by keeping the branch's \`dispatch\` / \`adispatch\` structure and inserting only the \`TASK_PREFER_DEFER\` adjustment before the existing worker-type and execution logic (same placement as the automated backport to \`3.108\`, https://github.com/pulp/pulpcore/pull/7596).