### PR TITLE
Optimize protected_versions() to avoid expensive JOINs

### DIFF
--- a/CHANGES/7594.bugfix
+++ b/CHANGES/7594.bugfix
@@ -1,0 +1,2 @@
+Optimized cleanup_old_versions() by rewriting protected_versions() to avoid expensive JOINs
+on large databases and deferring the content_ids field during version deletion.

--- a/pulpcore/app/models/repository.py
+++ b/pulpcore/app/models/repository.py
@@ -323,20 +323,31 @@ class Repository(MasterModel):
         """
         from .publication import Distribution, Publication
 
+        protected_pks = set()
+
         # find all repo versions set on a distribution
-        qs = self.versions.filter(pk__in=Distribution.objects.values_list("repository_version_id"))
+        protected_pks.update(
+            Distribution.objects.filter(
+                repository_version__repository=self,
+            ).values_list("repository_version_id", flat=True)
+        )
 
         # find all repo versions with publications set on a distribution
-        qs |= self.versions.filter(
-            publication__pk__in=Distribution.objects.values_list("publication_id")
+        dist_pub_ids = Distribution.objects.values_list("publication_id", flat=True)
+        protected_pks.update(
+            Publication.objects.filter(
+                pk__in=dist_pub_ids,
+                repository_version__repository=self,
+            ).values_list("repository_version_id", flat=True)
         )
 
         # Protect repo versions of distributed checkpoint publications.
         if Distribution.objects.filter(repository=self.pk, checkpoint=True).exists():
-            qs |= self.versions.filter(
-                publication__pk__in=Publication.objects.filter(checkpoint=True).values_list(
-                    "pulp_id"
-                )
+            protected_pks.update(
+                Publication.objects.filter(
+                    checkpoint=True,
+                    repository_version__repository=self,
+                ).values_list("repository_version_id", flat=True)
             )
 
         if distro := Distribution.objects.filter(repository=self.pk, checkpoint=False).first():
@@ -352,9 +363,12 @@ class Repository(MasterModel):
                 version = self.latest_version()
 
             if version:
-                qs |= self.versions.filter(pk=version.pk)
+                protected_pks.add(version.pk)
 
-        return qs.distinct()
+        # Discard None values from distributions with no repository_version set
+        protected_pks.discard(None)
+
+        return self.versions.filter(pk__in=protected_pks)
 
     def pull_through_add_content(self, content_artifact):
         """
@@ -416,7 +430,9 @@ class Repository(MasterModel):
         if self.retain_repo_versions:
             # Consider only completed versions that aren't protected for cleanup
             versions = self.versions.complete().exclude(pk__in=self.protected_versions())
-            for version in versions.order_by("-number")[self.retain_repo_versions :]:
+            for version in versions.defer("content_ids").order_by("-number")[
+                self.retain_repo_versions :
+            ]:
                 _logger.info(
                     "Deleting repository version {} due to version retention limit.".format(version)
                 )


### PR DESCRIPTION
The protected_versions() method was building a single queryset using |= (OR) operations that caused Django to generate a LEFT OUTER JOIN on core_publication across all repository versions (10,000+ rows), resulting in queries taking minutes in large databases.

Rewritten to collect protected version PKs from separate simple queries against Distribution and Publication tables, then return a simple filter(pk__in=...).

Also defer the content_ids ArrayField in cleanup_old_versions since it can contain hundreds of thousands of UUIDs per version and is not needed by version.delete().

fixes: #7594

Assisted By: claude-opus-4.6

<!---
Thank you for submitting a PR to the Pulp Project!

If this is your first time contributing, please read the Pull Request Walkthrough documentation
(https://pulpproject.org/pulpcore/docs/dev/guides/pull-request-walkthrough/).
-->

### 📜 Checklist

- [ ] Commits are cleanly separated with meaningful messages (simple features and bug fixes should be [squashed](https://pulpproject.org/pulpcore/docs/dev/guides/git/#rebasing-and-squashing) to one commit)
- [ ] A [changelog entry](https://pulpproject.org/pulpcore/docs/dev/guides/git/#changelog-update) or entries has been added for any significant changes
- [ ] Follows the [Pulp policy on AI Usage](https://pulpproject.org/help/more/governance/ai_policy/)
- [ ] (For new features) - User documentation and test coverage has been added

See: [Pull Request Walkthrough](https://pulpproject.org/pulpcore/docs/dev/guides/pull-request-walkthrough/)
