### PR TITLE
Investigate azure flaky failures

### DIFF
--- a/pulpcore/app/tasks/test.py
+++ b/pulpcore/app/tasks/test.py
@@ -4,7 +4,9 @@ import os
 import signal
 import time
 from pulpcore.app.models import TaskGroup
+from pulpcore.app.models import Task
 from pulpcore.tasking.tasks import dispatch
+from pulpcore.constants import TASK_STATES
 
 
 def dummy_task():
@@ -34,6 +36,32 @@ def dummy_group_task(inbetween=3, intervals=None):
     for interval in intervals:
         dispatch(sleep, args=(interval,), task_group=task_group)
         time.sleep(inbetween)
+
+
+def group_finalizer_task():
+    """Raise if any sibling task in the group has not yet completed."""
+    task = Task.current()
+    task_group = TaskGroup.current()
+    if task_group.tasks.exclude(pk=task.pk).exclude(state=TASK_STATES.COMPLETED).exists():
+        raise Exception("Not all sibling tasks have completed.")
+
+
+def group_task_with_finalizer(resource):
+    """Dispatch one sibling (shared on resource) then a finalizer (exclusive on resource)."""
+    task_group = TaskGroup.current()
+    unique = f"{resource}:0"
+    # This first task will hold some lock
+    dispatch(sleep, args=(0.5,), exclusive_resources=[unique])
+    # Which will force the non-finalizer group task to wait for it
+    dispatch(
+        sleep,
+        args=(0,),
+        task_group=task_group,
+        shared_resources=[resource],
+        exclusive_resources=[unique],
+    )
+    # The finalizer is trigerred very closely, but should not start before
+    dispatch(group_finalizer_task, task_group=task_group, exclusive_resources=[resource])
 
 
 def missing_worker():

--- a/pulpcore/tests/functional/api/test_tasking.py
+++ b/pulpcore/tests/functional/api/test_tasking.py
@@ -462,6 +462,18 @@ def test_scope_task_groups(pulpcore_bindings, task_group, gen_user):
 
 
 @pytest.mark.parallel
+def test_finalizer_task_runs_after_all_siblings(dispatch_task_group, monitor_task_group):
+    """
+    A finalizer task that holds an exclusive resource lock should not start before all
+    sibling tasks holding shared locks on that resource have completed.
+    """
+    resource = str(uuid4())
+    group_task = "pulpcore.app.tasks.test.group_task_with_finalizer"
+    tgroup_href = dispatch_task_group(group_task, args=(resource,))
+    monitor_task_group(tgroup_href)
+
+
+@pytest.mark.parallel
 def test_cancel_task_group(pulpcore_bindings, dispatch_task_group, gen_user):
     """Test that task groups can be canceled."""
     kwargs = {"inbetween": 1, "intervals": [10, 10, 10, 10, 10]}


### PR DESCRIPTION
For now, this adds a minimum reproducer to the flaky azure replicate task.
It's seems like a redis worker bug on keeping the ordering (azure runs with the redis worker)

The newly added test failed every time on my machine.

---
:robot: 
A finalizer task (exclusive resource lock) can start before sibling tasks (shared resource lock) have completed if they are blocked on a separate exclusive resource. In the Redis worker, this bypasses FIFO ordering because the sibling's shared resource is never added to blocked_shared when the blocking reason is its exclusive resource.

<!---
Thank you for submitting a PR to the Pulp Project!

If this is your first time contributing, please read the Pull Request Walkthrough documentation
(https://pulpproject.org/pulpcore/docs/dev/guides/pull-request-walkthrough/).
-->

### 📜 Checklist

- [ ] Commits are cleanly separated with meaningful messages (simple features and bug fixes should be [squashed](https://pulpproject.org/pulpcore/docs/dev/guides/git/#rebasing-and-squashing) to one commit)
- [ ] A [changelog entry](https://pulpproject.org/pulpcore/docs/dev/guides/git/#changelog-update) or entries has been added for any significant changes
- [ ] Follows the [Pulp policy on AI Usage](https://pulpproject.org/help/more/governance/ai_policy/)
- [ ] (For new features) - User documentation and test coverage has been added

See: [Pull Request Walkthrough](https://pulpproject.org/pulpcore/docs/dev/guides/pull-request-walkthrough/)
