### PR TITLE
Move gnupg import inside signing script fixture

### DIFF
--- a/pulpcore/pytest_plugin.py
+++ b/pulpcore/pytest_plugin.py
@@ -1,6 +1,5 @@
 import aiohttp
 import asyncio
-import gnupg
 import json
 import os
 import pathlib
@@ -1153,6 +1152,10 @@ def signing_gpg_metadata(signing_gpg_homedir_path):
     """A fixture that returns a GPG instance and related metadata (i.e., fingerprint, keyid)."""
     PRIVATE_KEY_URL = "https://raw.githubusercontent.com/pulp/pulp-fixtures/master/common/GPG-PRIVATE-KEY-fixture-signing"  # noqa: E501
 
+    try:
+        import gnupg
+    except ImportError:
+        pytest.fail("python-gnupg is not installed, add to your functest_requirements.txt")
     key_file = pathlib.Path(__file__).parent / "GPG-PRIVATE-KEY-fixture-signing"
     if key_file.exists():
         private_key_data = key_file.read_text()


### PR DESCRIPTION
This should resolve the CI failures for plugins that don't require gnupg for their tests.

### 📜 Checklist

- [ ] Commits are cleanly separated with meaningful messages (simple features and bug fixes should be [squashed](https://pulpproject.org/pulpcore/docs/dev/guides/git/#rebasing-and-squashing) to one commit)
- [ ] A [changelog entry](https://pulpproject.org/pulpcore/docs/dev/guides/git/#changelog-update) or entries has been added for any significant changes
- [ ] Follows the [Pulp policy on AI Usage](https://pulpproject.org/help/more/governance/ai_policy/)
- [ ] (For new features) - User documentation and test coverage has been added

See: [Pull Request Walkthrough](https://pulpproject.org/pulpcore/docs/dev/guides/pull-request-walkthrough/)
