### PR TITLE
Change redis worker task pickup algo to respect FIFO shared resources

### DIFF
--- a/CHANGES/7616.bugfix
+++ b/CHANGES/7616.bugfix
@@ -1,0 +1,1 @@
+Fixed RedisWorker not always respecting FIFO order of tasks with shared resources.

--- a/pulpcore/app/tasks/test.py
+++ b/pulpcore/app/tasks/test.py
@@ -4,7 +4,9 @@ import os
 import signal
 import time
 from pulpcore.app.models import TaskGroup
+from pulpcore.app.models import Task
 from pulpcore.tasking.tasks import dispatch
+from pulpcore.constants import TASK_STATES
 
 
 def dummy_task():
@@ -34,6 +36,32 @@ def dummy_group_task(inbetween=3, intervals=None):
     for interval in intervals:
         dispatch(sleep, args=(interval,), task_group=task_group)
         time.sleep(inbetween)
+
+
+def group_finalizer_task():
+    """Raise if any sibling task in the group has not yet completed."""
+    task = Task.current()
+    task_group = TaskGroup.current()
+    if task_group.tasks.exclude(pk=task.pk).exclude(state=TASK_STATES.COMPLETED).exists():
+        raise Exception("Not all sibling tasks have completed.")
+
+
+def group_task_with_finalizer(resource):
+    """Dispatch one sibling (shared on resource) then a finalizer (exclusive on resource)."""
+    task_group = TaskGroup.current()
+    unique = f"{resource}:0"
+    # This first task will hold some lock
+    dispatch(sleep, args=(0.5,), exclusive_resources=[unique])
+    # Which will force the non-finalizer group task to wait for it
+    dispatch(
+        sleep,
+        args=(0,),
+        task_group=task_group,
+        shared_resources=[resource],
+        exclusive_resources=[unique],
+    )
+    # The finalizer is trigerred very closely, but should not start before
+    dispatch(group_finalizer_task, task_group=task_group, exclusive_resources=[resource])
 
 
 def missing_worker():

--- a/pulpcore/tasking/redis_worker.py
+++ b/pulpcore/tasking/redis_worker.py
@@ -439,8 +439,8 @@ class RedisWorker:
         fetch_limit = FETCH_TASK_LIMIT
 
         while True:
-            blocked_exclusive = set()
-            blocked_shared = set()
+            taken_exclusive = set()
+            taken_shared = set()
 
             waiting_tasks = list(
                 Task.objects.filter(state=TASK_STATES.WAITING, app_lock=None)
@@ -455,25 +455,25 @@ class RedisWorker:
             for task in waiting_tasks:
                 try:
                     exclusive_resources, shared_resources = extract_task_resources(task)
-
                     should_skip = False
 
                     for resource in exclusive_resources:
-                        if resource in blocked_exclusive or resource in blocked_shared:
+                        if resource in taken_exclusive or resource in taken_shared:
                             should_skip = True
                             break
 
                     if not should_skip:
                         for resource in shared_resources:
-                            if resource in blocked_shared:
+                            if resource in taken_exclusive:
                                 should_skip = True
                                 break
 
+                    taken_exclusive.update(exclusive_resources)
+                    taken_shared.update(shared_resources)
                     if should_skip:
                         continue
 
                     task_lock_key = get_task_lock_key(task.pk)
-
                     blocked_resource_list = acquire_locks(
                         self.redis_conn,
                         self.name,
@@ -481,13 +481,7 @@ class RedisWorker:
                         exclusive_resources,
                         shared_resources,
                     )
-
                     if blocked_resource_list:
-                        if "__task_lock__" not in blocked_resource_list:
-                            blocked_exclusive.update(exclusive_resources)
-                            for resource in shared_resources:
-                                if resource in blocked_resource_list:
-                                    blocked_shared.add(resource)
                         continue
 
                     rows = Task.objects.filter(

--- a/pulpcore/tests/functional/api/test_tasking.py
+++ b/pulpcore/tests/functional/api/test_tasking.py
@@ -463,6 +463,18 @@ def test_scope_task_groups(pulpcore_bindings, task_group, gen_user):
 
 
 @pytest.mark.parallel
+def test_finalizer_task_runs_after_all_siblings(dispatch_task_group, monitor_task_group):
+    """
+    A finalizer task that holds an exclusive resource lock should not start before all
+    sibling tasks holding shared locks on that resource have completed.
+    """
+    resource = str(uuid4())
+    group_task = "pulpcore.app.tasks.test.group_task_with_finalizer"
+    tgroup_href = dispatch_task_group(group_task, args=(resource,))
+    monitor_task_group(tgroup_href)
+
+
+@pytest.mark.parallel
 def test_cancel_task_group(pulpcore_bindings, dispatch_task_group, gen_user):
     """Test that task groups can be canceled."""
     kwargs = {"inbetween": 1, "intervals": [10, 10, 10, 10, 10]}


### PR DESCRIPTION
When the redis task worker is fetching tasks, it is checking waiting tasks in creation order that have `app_lock=null`. Then for each task it tries to acquire the resource (and task) locks on the task from redis. If it succeeds then it proceeds to switch the the task's `app_lock=self.app_status` and return the task, with the goal being that the redis checks will make this final update call only happen on one worker, reducing database row contention. Now the redis check only sees currently taken resource locks from running tasks, it has no idea about tasks that are waiting ahead of the task we are checking. So the redis worker needs to create a list of taken resources ahead of the current checked task to prevent out of order execution.

Another thing to note is that the `block_resource_list` that redis returns is opportunistic so it will return as soon as it finds a blocked resource. It doesn't always check every resource that was blocked.

### 📜 Checklist

- [ ] Commits are cleanly separated with meaningful messages (simple features and bug fixes should be [squashed](https://pulpproject.org/pulpcore/docs/dev/guides/git/#rebasing-and-squashing) to one commit)
- [ ] A [changelog entry](https://pulpproject.org/pulpcore/docs/dev/guides/git/#changelog-update) or entries has been added for any significant changes
- [ ] Follows the [Pulp policy on AI Usage](https://pulpproject.org/help/more/governance/ai_policy/)
- [ ] (For new features) - User documentation and test coverage has been added

See: [Pull Request Walkthrough](https://pulpproject.org/pulpcore/docs/dev/guides/pull-request-walkthrough/)
