### PR TITLE
[3.109] Fix RedisWorker stalling when there are more than 20 tasks waiting on the same resource

### DIFF
--- a/CHANGES/7612.bugfix
+++ b/CHANGES/7612.bugfix
@@ -1,0 +1,3 @@
+Fixed RedisWorker stalling when more than 20 tasks are waiting on the same resource.
+The worker now doubles its fetch limit and retries until a runnable task is found or the
+entire queue has been examined.

--- a/pulpcore/tasking/redis_worker.py
+++ b/pulpcore/tasking/redis_worker.py
@@ -431,89 +431,88 @@ class RedisWorker:
         3. If resource locks acquired, attempts to claim the task
            with a Redis task lock (24h expiration)
         4. Returns the first task for which both locks can be acquired
+        5. If no task found in the batch, doubles the fetch limit and retries from the oldest
 
         Returns:
             Task: A task object if one was successfully locked, None otherwise
         """
-        # Query waiting tasks, sorted by creation time, limited
-        # Filter for app_lock__isnull=True to avoid tasks being executed immediately by API
-        waiting_tasks = (
-            Task.objects.filter(state=TASK_STATES.WAITING, app_lock=None)
-            .exclude(pk__in=self.ignored_task_ids)
-            .order_by("pulp_created")
-            .select_related("pulp_domain")[:FETCH_TASK_LIMIT]
-        )
+        fetch_limit = FETCH_TASK_LIMIT
 
-        # Track resources that are blocked to preserve FIFO ordering
-        # blocked_exclusive: resources where an earlier task wanted exclusive access and failed
-        # blocked_shared: resources where an earlier task wanted shared access and failed
-        blocked_exclusive = set()
-        blocked_shared = set()
+        while True:
+            blocked_exclusive = set()
+            blocked_shared = set()
 
-        # Try to acquire locks for each task
-        for task in waiting_tasks:
-            try:
-                # Extract resources from task
-                exclusive_resources, shared_resources = extract_task_resources(task)
+            waiting_tasks = list(
+                Task.objects.filter(state=TASK_STATES.WAITING, app_lock=None)
+                .exclude(pk__in=self.ignored_task_ids)
+                .order_by("pulp_created")
+                .select_related("pulp_domain")[:fetch_limit]
+            )
 
-                # Check if this task should skip to preserve FIFO ordering
-                should_skip = False
+            if not waiting_tasks:
+                break
 
-                # Skip if we need exclusive access but an earlier task already tried and failed
-                for resource in exclusive_resources:
-                    if resource in blocked_exclusive or resource in blocked_shared:
-                        should_skip = True
-                        break
+            for task in waiting_tasks:
+                try:
+                    exclusive_resources, shared_resources = extract_task_resources(task)
 
-                # Skip if we need shared access but earlier task wanted it and exclusive lock exists
-                if not should_skip:
-                    for resource in shared_resources:
-                        if resource in blocked_shared:
+                    should_skip = False
+
+                    for resource in exclusive_resources:
+                        if resource in blocked_exclusive or resource in blocked_shared:
                             should_skip = True
                             break
 
-                if should_skip:
-                    continue
-
-                # Acquire Redis locks first — avoids wasted DB writes for blocked tasks
-                task_lock_key = get_task_lock_key(task.pk)
-
-                blocked_resource_list = acquire_locks(
-                    self.redis_conn, self.name, task_lock_key, exclusive_resources, shared_resources
-                )
-
-                if blocked_resource_list:
-                    # Failed to acquire locks — no DB writes needed
-                    if "__task_lock__" not in blocked_resource_list:
-                        # Block ALL exclusive resources this task needed to preserve FIFO ordering.
-                        # A later task must not acquire a resource that an earlier task also needs,
-                        # even if the earlier task failed due to a different resource being blocked.
-                        blocked_exclusive.update(exclusive_resources)
-                        # Block shared resources that were explicitly blocked by an exclusive lock.
+                    if not should_skip:
                         for resource in shared_resources:
-                            if resource in blocked_resource_list:
-                                blocked_shared.add(resource)
+                            if resource in blocked_shared:
+                                should_skip = True
+                                break
+
+                    if should_skip:
+                        continue
+
+                    task_lock_key = get_task_lock_key(task.pk)
+
+                    blocked_resource_list = acquire_locks(
+                        self.redis_conn,
+                        self.name,
+                        task_lock_key,
+                        exclusive_resources,
+                        shared_resources,
+                    )
+
+                    if blocked_resource_list:
+                        if "__task_lock__" not in blocked_resource_list:
+                            blocked_exclusive.update(exclusive_resources)
+                            for resource in shared_resources:
+                                if resource in blocked_resource_list:
+                                    blocked_shared.add(resource)
+                        continue
+
+                    rows = Task.objects.filter(
+                        pk=task.pk, state=TASK_STATES.WAITING, app_lock__isnull=True
+                    ).update(app_lock=self.app_status)
+
+                    if rows == 0:
+                        safe_release_task_locks(task, lock_owner=self.name)
+                        _logger.debug(
+                            "WORKER: Task %s no longer claimable, releasing locks", task.pk
+                        )
+                        continue
+
+                    task.app_lock = self.app_status
+                    return task
+
+                except Exception as e:
+                    _logger.error("Error processing task %s: %s", task.pk, e)
                     continue
 
-                # Redis locks acquired — now claim the task in the DB
-                rows = Task.objects.filter(
-                    pk=task.pk, state=TASK_STATES.WAITING, app_lock__isnull=True
-                ).update(app_lock=self.app_status)
+            if len(waiting_tasks) < fetch_limit:
+                break
 
-                if rows == 0:
-                    # Task was canceled or state changed between SELECT and lock attempt
-                    safe_release_task_locks(task, lock_owner=self.name)
-                    _logger.debug("WORKER: Task %s no longer claimable, releasing locks", task.pk)
-                    continue
+            fetch_limit *= 2
 
-                task.app_lock = self.app_status
-                return task
-
-            except Exception as e:
-                _logger.error("Error processing task %s: %s", task.pk, e)
-                continue
-
-        # No task could be locked
         return None
 
     def supervise_immediate_task(self, task):

--- a/pulpcore/tests/functional/api/test_tasking.py
+++ b/pulpcore/tests/functional/api/test_tasking.py
@@ -9,6 +9,7 @@ from datetime import datetime
 from urllib.parse import urljoin
 from uuid import uuid4
 
+from pulpcore.app import settings
 from pulpcore.client.pulpcore import ApiException
 from contextlib import contextmanager
 
@@ -720,3 +721,54 @@ class TestImmediateTaskWithBlockedResource:
                 )
             monitor_task(task_href)
         assert "timed out after" in ctx.value.task.error["description"]
+
+
+@pytest.mark.parallel
+@pytest.mark.skipif(
+    settings.WORKER_TYPE != "redis",
+    reason="Only runs with WORKER_TYPE=redis",
+)
+def test_fetch_task_beyond_initial_batch(dispatch_task, monitor_task, pulpcore_bindings):
+    """Test that tasks beyond the initial fetch batch are still processed.
+
+    When more than FETCH_TASK_LIMIT tasks are blocked on the same exclusive resource,
+    the RedisWorker should double the fetch limit and find runnable tasks further
+    down the queue.
+    """
+    blocker_resource = str(uuid4())
+    other_resource = str(uuid4())
+
+    # Dispatch a long-running task that holds the blocker resource
+    blocker_href = dispatch_task(
+        "pulpcore.app.tasks.test.sleep",
+        args=(60,),
+        exclusive_resources=[blocker_resource],
+    )
+    time.sleep(2)
+
+    # Dispatch 25 tasks that all need the same blocked resource
+    blocked_hrefs = []
+    for _ in range(25):
+        href = dispatch_task(
+            "pulpcore.app.tasks.test.sleep",
+            args=(0,),
+            exclusive_resources=[blocker_resource],
+        )
+        blocked_hrefs.append(href)
+
+    # Dispatch a task that uses a completely different resource (position 27 in the queue)
+    unblocked_href = dispatch_task(
+        "pulpcore.app.tasks.test.sleep",
+        args=(0,),
+        exclusive_resources=[other_resource],
+    )
+
+    # The unblocked task should complete even though 25 tasks ahead of it are blocked
+    unblocked_task = monitor_task(unblocked_href)
+    assert unblocked_task.state == "completed"
+
+    # Cancel the blocker so blocked tasks can drain
+    try:
+        pulpcore_bindings.TasksApi.tasks_cancel(blocker_href, {"state": "canceled"})
+    except ApiException:
+        pass


### PR DESCRIPTION
<!---
Thank you for submitting a PR to the Pulp Project!

If this is your first time contributing, please read the Pull Request Walkthrough documentation
(https://pulpproject.org/pulpcore/docs/dev/guides/pull-request-walkthrough/).
-->

### 📜 Checklist

- [ ] Commits are cleanly separated with meaningful messages (simple features and bug fixes should be [squashed](https://pulpproject.org/pulpcore/docs/dev/guides/git/#rebasing-and-squashing) to one commit)
- [ ] A [changelog entry](https://pulpproject.org/pulpcore/docs/dev/guides/git/#changelog-update) or entries has been added for any significant changes
- [ ] Follows the [Pulp policy on AI Usage](https://pulpproject.org/help/more/governance/ai_policy/)
- [ ] (For new features) - User documentation and test coverage has been added

See: [Pull Request Walkthrough](https://pulpproject.org/pulpcore/docs/dev/guides/pull-request-walkthrough/)
