### PR TITLE
Replace use of distulils.util.strtobool

### DIFF
--- a/CHANGES/7571.bugfix
+++ b/CHANGES/7571.bugfix
@@ -1,0 +1,1 @@
+Replace use of the deprecated distutils. The module has been removed in Python 3.12 .

--- a/pulpcore/app/tasks/export.py
+++ b/pulpcore/app/tasks/export.py
@@ -3,7 +3,6 @@ import logging
 import os
 import os.path
 import tarfile
-from distutils.util import strtobool
 from gettext import gettext as _
 from glob import glob
 from pathlib import Path
@@ -41,6 +40,21 @@ class UnexportableArtifactException(RuntimeError):
 
     def __init__(self):
         super().__init__(_("Cannot export artifacts that haven't been downloaded."))
+
+
+def _ensure_bool(value):
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, str):
+        if value.tolower() in ["yes", "y", "true", "t", "on", "1"]:
+            return True
+        if value.tolower() in ["no", "n", "false", "f", "off", "0"]:
+            return False
+    if value == 1:
+        return True
+    if value == 0:
+        return False
+    raise ValueError("Value {value:r} does not describe a boolean.")
 
 
 def _validate_fs_export(content_artifacts):
@@ -346,9 +360,7 @@ def _version_match(curr_versions, prev_versions):
 def _incremental_requested(the_export):
     """Figure out that a) an incremental is requested, and b) it's possible."""
     the_exporter = the_export.exporter
-    full = the_export.params.get("full", True)
-    if isinstance(full, str):
-        full = bool(strtobool(full))
+    full = _ensure_bool(the_export.params.get("full", True))
     starting_versions_provided = len(the_export.params.get("start_versions", [])) > 0
     last_exists = the_exporter.last_export
     return (starting_versions_provided or last_exists) and not full

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -290,3 +290,7 @@ extend-select = [
 # This section is managed by the plugin template. Do not edit manually.
 sections = { second-party = ["pulpcore"] }
 section-order = ["future", "standard-library", "third-party", "second-party", "first-party", "local-folder"]
+
+[tool.ruff.lint.flake8-tidy-imports.banned-api]
+# TODO Add this to the plugin template
+"distutils".msg = "The 'distutils' module has been deprecated since Python 3.9."


### PR DESCRIPTION
This module has been deprecated since python 3.9 and removed in 3.12.

<!---
Thank you for submitting a PR to the Pulp Project!

If this is your first time contributing, please read the Pull Request Walkthrough documentation
(https://pulpproject.org/pulpcore/docs/dev/guides/pull-request-walkthrough/).
-->

### 📜 Checklist

- [ ] Commits are cleanly separated with meaningful messages (simple features and bug fixes should be [squashed](https://pulpproject.org/pulpcore/docs/dev/guides/git/#rebasing-and-squashing) to one commit)
- [ ] A [changelog entry](https://pulpproject.org/pulpcore/docs/dev/guides/git/#changelog-update) or entries has been added for any significant changes
- [ ] Follows the [Pulp policy on AI Usage](https://pulpproject.org/help/more/governance/ai_policy/)
- [ ] (For new features) - User documentation and test coverage has been added

See: [Pull Request Walkthrough](https://pulpproject.org/pulpcore/docs/dev/guides/pull-request-walkthrough/)
