### PR TITLE
Allow plugins to access pulp_plugin_configs and get_plugin_config

### DIFF
--- a/CHANGES/plugin_api/7650.feature
+++ b/CHANGES/plugin_api/7650.feature
@@ -1,0 +1,1 @@
+Allow plugins to access `pulp_plugin_configs` and `get_plugin_config` from `pulpcore.app.apps` via `pulpcore.plugin.apps`

--- a/pulpcore/plugin/apps.py
+++ b/pulpcore/plugin/apps.py
@@ -1,1 +1,1 @@
-from pulpcore.app.apps import adjust_roles  # noqa: F401
+from pulpcore.app.apps import adjust_roles, get_plugin_config, pulp_plugin_configs  # noqa: F401


### PR DESCRIPTION
Fixes: #7650

<!---
Thank you for submitting a PR to the Pulp Project!

If this is your first time contributing, please read the Pull Request Walkthrough documentation
(https://pulpproject.org/pulpcore/docs/dev/guides/pull-request-walkthrough/).
-->

### 📜 Checklist

- [x] Commits are cleanly separated with meaningful messages (simple features and bug fixes should be [squashed](https://pulpproject.org/pulpcore/docs/dev/guides/git/#rebasing-and-squashing) to one commit)
- [x] A [changelog entry](https://pulpproject.org/pulpcore/docs/dev/guides/git/#changelog-update) or entries has been added for any significant changes
- [x] Follows the [Pulp policy on AI Usage](https://pulpproject.org/help/more/governance/ai_policy/)
- [ ] (For new features) - User documentation and test coverage has been added

See: [Pull Request Walkthrough](https://pulpproject.org/pulpcore/docs/dev/guides/pull-request-walkthrough/)
