### PR TITLE
[backport/3.105/#7591] Add --control-socket option to pulpcore-content

### DIFF
--- a/CHANGES/7574.bugfix
+++ b/CHANGES/7574.bugfix
@@ -1,0 +1,4 @@
+Added option to `pulpcore-content` and `pulpcore-api` to configure the gunicorn control socket path.
+The default path could cause permission errors on certain deployments setups.
+
+This feature was added in gunicorn>=25.1 and is ignored for lower version.

--- a/pulpcore/app/entrypoint.py
+++ b/pulpcore/app/entrypoint.py
@@ -12,7 +12,10 @@ from gunicorn.workers.sync import SyncWorker
 
 from pulpcore.app.apps import pulp_plugin_configs
 from pulpcore.app.netutil import has_ipv6
-from pulpcore.app.pulpcore_gunicorn_application import PulpcoreGunicornApplication
+from pulpcore.app.pulpcore_gunicorn_application import (
+    PulpcoreGunicornApplication,
+    handle_control_interface_feature,
+)
 
 logger = getLogger(__name__)
 
@@ -145,6 +148,11 @@ class PulpcoreApiApplication(PulpcoreGunicornApplication):
 @click.option("--user", "-u")
 @click.option("--group", "-g")
 @click.option(
+    "--control-socket",
+    "control_socket",
+    help="Path to the gunicorn control socket (requires gunicorn>=25.1).",
+)
+@click.option(
     "--name-template",
     type=str,
     help="Format string to use for the status name. "
@@ -154,5 +162,6 @@ class PulpcoreApiApplication(PulpcoreGunicornApplication):
 def main(bind, name_template, **options):
     name_template_var.set(name_template)
     options["bind"] = list(bind)
+    handle_control_interface_feature(options)
     sys.argv = sys.argv[:1]
     PulpcoreApiApplication(options).run()

--- a/pulpcore/app/pulpcore_gunicorn_application.py
+++ b/pulpcore/app/pulpcore_gunicorn_application.py
@@ -1,6 +1,22 @@
 import sys
+from importlib.metadata import version as pkg_version
 
 from gunicorn.app.base import Application
+
+
+def handle_control_interface_feature(options):
+    """Drop control_socket from options if gunicorn<25.1, which introduced the feature."""
+    # TODO: remove this function when gunicorn lowerbound>=25.1
+    if options.get("control_socket") is None:
+        return
+
+    gunicorn_version = tuple(int(x) for x in pkg_version("gunicorn").split(".")[:2])
+    if gunicorn_version < (25, 1):
+        sys.stderr.write(
+            "Warning: --control-socket requires gunicorn>=25.1, ignoring "
+            f"(installed: {'.'.join(str(x) for x in gunicorn_version)}).\n"
+        )
+        options["control_socket"] = None
 
 
 class PulpcoreGunicornApplication(Application):

--- a/pulpcore/content/entrypoint.py
+++ b/pulpcore/content/entrypoint.py
@@ -4,7 +4,10 @@ import click
 from django.conf import settings
 
 from pulpcore.app.netutil import has_ipv6
-from pulpcore.app.pulpcore_gunicorn_application import PulpcoreGunicornApplication
+from pulpcore.app.pulpcore_gunicorn_application import (
+    PulpcoreGunicornApplication,
+    handle_control_interface_feature,
+)
 
 
 class PulpcoreContentApplication(PulpcoreGunicornApplication):
@@ -52,6 +55,11 @@ class PulpcoreContentApplication(PulpcoreGunicornApplication):
 @click.option("--user", "-u")
 @click.option("--group", "-g")
 @click.option(
+    "--control-socket",
+    "control_socket",
+    help="Path to the gunicorn control socket (requires gunicorn>=25.1).",
+)
+@click.option(
     "--name-template",
     type=str,
     help="Format string to use for the status name. "
@@ -62,5 +70,6 @@ def main(bind, name_template, **options):
     if name_template:
         settings.set("WORKER_NAME_TEMPLATE", name_template)
     options["bind"] = list(bind)
+    handle_control_interface_feature(options)
     sys.argv = sys.argv[:1]
     PulpcoreContentApplication(options).run()


### PR DESCRIPTION
Exposes gunicorn's control socket path as a CLI option so operators can redirect it away from locations that cause permission errors on certain deployments (e.g. shared PVCs on k8s rolling updates).

Silently ignored on gunicorn<25.1, which introduced the feature.

fixes: #7574
Assisted-by: Claude Sonnet 4.6 <noreply@anthropic.com>
(cherry picked from commit f24cb2440326af2c14151442b4bd51f7df2f6385)

<!---
Thank you for submitting a PR to the Pulp Project!

If this is your first time contributing, please read the Pull Request Walkthrough documentation
(https://pulpproject.org/pulpcore/docs/dev/guides/pull-request-walkthrough/).
-->

### 📜 Checklist

- [ ] Commits are cleanly separated with meaningful messages (simple features and bug fixes should be [squashed](https://pulpproject.org/pulpcore/docs/dev/guides/git/#rebasing-and-squashing) to one commit)
- [ ] A [changelog entry](https://pulpproject.org/pulpcore/docs/dev/guides/git/#changelog-update) or entries has been added for any significant changes
- [ ] Follows the [Pulp policy on AI Usage](https://pulpproject.org/help/more/governance/ai_policy/)
- [ ] (For new features) - User documentation and test coverage has been added

See: [Pull Request Walkthrough](https://pulpproject.org/pulpcore/docs/dev/guides/pull-request-walkthrough/)
