### PR TITLE
Fix TypeError in _ensure_bool: str has no attribute 'tolower'

### DIFF
--- a/CHANGES/7678.bugfix
+++ b/CHANGES/7678.bugfix
@@ -1,0 +1,1 @@
+Fixed `TypeError: 'str' object has no attribute 'tolower'` in `_ensure_bool` during incremental content exports. Changed `.tolower()` to `.lower()`.

--- a/pulpcore/app/tasks/export.py
+++ b/pulpcore/app/tasks/export.py
@@ -46,9 +46,9 @@ def _ensure_bool(value):
     if isinstance(value, bool):
         return value
     if isinstance(value, str):
-        if value.tolower() in ["yes", "y", "true", "t", "on", "1"]:
+        if value.lower() in ["yes", "y", "true", "t", "on", "1"]:
             return True
-        if value.tolower() in ["no", "n", "false", "f", "off", "0"]:
+        if value.lower() in ["no", "n", "false", "f", "off", "0"]:
             return False
     if value == 1:
         return True


### PR DESCRIPTION
## Summary

`_ensure_bool` in `pulpcore/app/tasks/export.py` (introduced in 438bdc8e) calls `value.tolower()` which does not exist on Python strings. This causes incremental content exports to fail with:

```
Error: 'str' object has no attribute 'tolower'
```

Fix changes both occurrences to `value.lower()`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)