### PR TITLE
Expose EncryptedJSONField via the plugin API

### DIFF
--- a/CHANGES/plugin_api/7690.feature
+++ b/CHANGES/plugin_api/7690.feature
@@ -1,0 +1,1 @@
+Exposed `EncryptedJSONField` via the plugin API.

--- a/pulpcore/plugin/models/__init__.py
+++ b/pulpcore/plugin/models/__init__.py
@@ -47,7 +47,7 @@ from pulpcore.app.models import (
 )
 
 
-from pulpcore.app.models.fields import EncryptedTextField
+from pulpcore.app.models.fields import EncryptedJSONField, EncryptedTextField
 from pulpcore.app.models.analytics import system_id
 
 __all__ = [
@@ -90,6 +90,7 @@ __all__ = [
     "TaskSchedule",
     "Upload",
     "UploadChunk",
+    "EncryptedJSONField",
     "EncryptedTextField",
     "system_id",
     "VulnerabilityReport",


### PR DESCRIPTION
`pulpcore.app.models.fields.EncryptedTextField` is already exported via `pulpcore.plugin.models`, but its sibling `EncryptedJSONField` is not. This PR exposes `EncryptedJSONField` through the plugin API so plugins that need to encrypt structured (JSON) data at rest can use it on equal footing with `EncryptedTextField`.

fixes #7690

Assisted-By: GitHub Copilot (Claude)