### PR TITLE
Fix Content-Type header for cached APIResponse

### DIFF
--- a/CHANGES/+cache_api_response_content_type.bugfix
+++ b/CHANGES/+cache_api_response_content_type.bugfix
@@ -1,0 +1,1 @@
+Fixed cache forgetting the Content-Type header of ApiResponses

--- a/pulpcore/cache/cache.py
+++ b/pulpcore/cache/cache.py
@@ -218,6 +218,7 @@ class SyncContentCache(Cache):
             entry["type"] = "FileResponse"
         elif isinstance(response, ApiResponse):
             entry["data"] = response.data
+            entry["content_type"] = response.content_type
             entry["type"] = "APIResponse"
         elif isinstance(response, HttpResponse):
             entry["content"] = response.content.decode("utf-8")


### PR DESCRIPTION
ApiResponse overwrites the Content-Type header with the passed in `content_type` argument on initialization, so we need to save it to the cache to ensure the cached response still has the original header.

### 📜 Checklist

- [ ] Commits are cleanly separated with meaningful messages (simple features and bug fixes should be [squashed](https://pulpproject.org/pulpcore/docs/dev/guides/git/#rebasing-and-squashing) to one commit)
- [ ] A [changelog entry](https://pulpproject.org/pulpcore/docs/dev/guides/git/#changelog-update) or entries has been added for any significant changes
- [ ] Follows the [Pulp policy on AI Usage](https://pulpproject.org/help/more/governance/ai_policy/)
- [ ] (For new features) - User documentation and test coverage has been added

See: [Pull Request Walkthrough](https://pulpproject.org/pulpcore/docs/dev/guides/pull-request-walkthrough/)
