### PR TITLE
Treat aiohttp.ClientError exceptions as safe.

### DIFF
--- a/CHANGES/+treat-aiohttp-exceptions-as-safe.bugfix
+++ b/CHANGES/+treat-aiohttp-exceptions-as-safe.bugfix
@@ -1,0 +1,1 @@
+Treat aiohttp.ClientError exceptions as safe in the task runner to preserve download error details when REDACT_UNSAFE_EXCEPTIONS is enabled.

--- a/pulpcore/tasking/tasks.py
+++ b/pulpcore/tasking/tasks.py
@@ -10,6 +10,7 @@ from contextlib import contextmanager
 from functools import partial
 from gettext import gettext as _
 
+import aiohttp
 from asgiref.sync import async_to_sync, sync_to_async
 from django.conf import settings
 from django.db import connection
@@ -81,14 +82,14 @@ def _execute_task(task):
         except Exception as e:
             exc_type, exc, tb = sys.exc_info()
             task_exc = exc
-            if not isinstance(e, (PulpException, APIException)):
+            if not isinstance(e, (PulpException, APIException, aiohttp.ClientError)):
                 if settings.REDACT_UNSAFE_EXCEPTIONS:
                     # Replace exception with generic error
                     task_exc = InternalErrorException()
                     tb = None
                 else:
                     deprecation_logger.warning(
-                        "Exception ({exc_type}: {exc}) will be sanitized in pulpcore 3.115".format(
+                        "Exception ({exc_type}: {exc}) will be sanitized in pulpcore 3.130".format(
                             exc_type=exc_type.__name__, exc=exc
                         )
                     )
@@ -118,14 +119,14 @@ async def _aexecute_task(task):
         except Exception as e:
             exc_type, exc, tb = sys.exc_info()
             task_exc = exc
-            if not isinstance(e, (PulpException, APIException)):
+            if not isinstance(e, (PulpException, APIException, aiohttp.ClientError)):
                 if settings.REDACT_UNSAFE_EXCEPTIONS:
                     # Replace exception with generic error
                     task_exc = InternalErrorException()
                     tb = None
                 else:
                     deprecation_logger.warning(
-                        "Exception ({exc_type}: {exc}) will be sanitized in pulpcore 3.115".format(
+                        "Exception ({exc_type}: {exc}) will be sanitized in pulpcore 3.130".format(
                             exc_type=exc_type.__name__, exc=exc
                         )
                     )


### PR DESCRIPTION
Bump pulpcore version in deprecation warning to 3.130 

### 📜 Checklist

- [ ] Commits are cleanly separated with meaningful messages (simple features and bug fixes should be [squashed](https://pulpproject.org/pulpcore/docs/dev/guides/git/#rebasing-and-squashing) to one commit)
- [ ] A [changelog entry](https://pulpproject.org/pulpcore/docs/dev/guides/git/#changelog-update) or entries has been added for any significant changes
- [ ] Follows the [Pulp policy on AI Usage](https://pulpproject.org/help/more/governance/ai_policy/)
- [ ] (For new features) - User documentation and test coverage has been added

See: [Pull Request Walkthrough](https://pulpproject.org/pulpcore/docs/dev/guides/pull-request-walkthrough/)
