### PR TITLE
Skip overwrite check when re-adding existing content

### DIFF
--- a/pulp_file/tests/functional/api/test_overwrite_content.py
+++ b/pulp_file/tests/functional/api/test_overwrite_content.py
@@ -223,3 +223,38 @@ def test_content_upload_overwrite_false_allows_non_conflicting(
     )
     repo = file_bindings.RepositoriesFileApi.read(file_repo.pulp_href)
     assert repo.latest_version_href.endswith("/versions/2/")
+
+
+@pytest.mark.parallel
+def test_modify_overwrite_false_allows_readding_same_content(
+    file_bindings,
+    file_repo,
+    file_content_unit_with_name_factory,
+    monitor_task,
+):
+    """Re-adding the same content unit with overwrite=False is a no-op, not a conflict.
+
+    A content unit already present in the repository version shares its repo_key_fields with
+    itself, but since the pk is identical there is no overwrite. The check should not raise.
+    """
+    content_a = file_content_unit_with_name_factory(str(uuid.uuid4()))
+
+    # Seed the repo with content_a
+    monitor_task(
+        file_bindings.RepositoriesFileApi.modify(
+            file_repo.pulp_href,
+            {"add_content_units": [content_a.pulp_href]},
+        ).task
+    )
+    repo = file_bindings.RepositoriesFileApi.read(file_repo.pulp_href)
+    assert repo.latest_version_href.endswith("/versions/1/")
+
+    # Re-add the same content unit with overwrite=False — should not raise; no new version
+    monitor_task(
+        file_bindings.RepositoriesFileApi.modify(
+            file_repo.pulp_href,
+            {"add_content_units": [content_a.pulp_href], "overwrite": False},
+        ).task
+    )
+    repo = file_bindings.RepositoriesFileApi.read(file_repo.pulp_href)
+    assert repo.latest_version_href.endswith("/versions/1/")

--- a/pulpcore/app/models/repository.py
+++ b/pulpcore/app/models/repository.py
@@ -270,11 +270,11 @@ class Repository(MasterModel):
                 type_obj.objects.filter(pk__in=add_content_pks).values("pk", *repo_key_fields)
             ):
                 find_dup_qs = Q()
-                incoming_by_key = {}
+                incoming_by_key = defaultdict(list)
                 for content_dict in batch:
                     pk = content_dict.pop("pk")
                     key = tuple(content_dict[f] for f in repo_key_fields)
-                    incoming_by_key[key] = pk
+                    incoming_by_key[key].append(pk)
                     find_dup_qs |= Q(**content_dict)
 
                 existing_by_key = {
@@ -283,10 +283,14 @@ class Repository(MasterModel):
                     .filter(find_dup_qs)
                     .values("pk", *repo_key_fields)
                 }
+                # A match on the same pk is the same content unit being re-added, not a
+                # conflict. add_content() already deduplicates this case.
                 conflict_map = {
-                    incoming_by_key[key]: existing_by_key[key]
-                    for key in incoming_by_key
+                    pk: existing_by_key[key]
+                    for key, pks in incoming_by_key.items()
                     if key in existing_by_key
+                    for pk in pks
+                    if pk != existing_by_key[key]
                 }
                 if conflict_map:
                     pulp_type = type_obj.get_pulp_type()


### PR DESCRIPTION
While working on adding the overwrite check to pulp_rpm, I noticed that re-adding the same content raised an `ContentOverwriteError`. I think that re-adding existing content shouldn't trigger this error.

Assisted-By: GitHub Copilot (Claude)