### PR TITLE
Fix additional issues with atomic replication

### DIFF
--- a/CHANGES/7614.bugfix
+++ b/CHANGES/7614.bugfix
@@ -1,0 +1,3 @@
+Replication now removes stale distributions before creating new ones, preventing
+base_path uniqueness conflicts that caused entire replications to fail. Improved
+error reporting in finalize_replication to include details about which subtasks failed.

--- a/CHANGES/7614.bugfix
+++ b/CHANGES/7614.bugfix
@@ -1,3 +1,5 @@
-Replication now removes stale distributions before creating new ones, preventing
-base_path uniqueness conflicts that caused entire replications to fail. Improved
-error reporting in finalize_replication to include details about which subtasks failed.
+Replication now reuses existing distributions matched by base_path when a name
+lookup misses (e.g. upstream rename), preventing base_path uniqueness conflicts
+and preserving content continuity. Stale distributions are also cleaned up
+before new distributions are created as an additional safeguard. Improved error
+reporting in finalize_replication to include details about which subtasks failed.

--- a/docs/user/guides/replication.md
+++ b/docs/user/guides/replication.md
@@ -189,6 +189,38 @@ A sync will still be triggered if:
 - The Upstream Pulp configuration was modified after the last replication.
 - The upstream distribution's content has changed since the last replication.
 
+## Failure Behavior and Content Safety
+
+Replication is designed so that existing distributions continue serving content even when errors
+occur.
+
+### Atomic content updates
+
+Distributions are not updated to point to new repository versions until **all** sync subtasks have
+completed successfully. If any subtask fails, no distributions are updated — the local instance
+continues serving the content from the previous successful replication. A subsequent successful
+replication will apply all pending updates atomically.
+
+### Safe failure states
+
+A failed replication leaves the system in a consistent state:
+
+- **Existing distributions** continue serving the content they had before the failed replication
+  started. Their repository version references are never partially updated.
+- **New distributions** (for upstream distributions that did not previously exist locally) may be
+  created but will not serve any content until a subsequent successful replication sets their
+  repository version.
+- **Remotes and repositories** are created or updated independently of the distribution content
+  update, so they may reflect the latest upstream state even after a failed replication. This is
+  harmless — the next replication will pick up where it left off.
+
+### Upstream renames
+
+When a distribution is renamed upstream but keeps the same `base_path`, replication reuses the
+existing local distribution rather than deleting and recreating it. This preserves content
+continuity — the distribution continues serving content at its `base_path` throughout the
+replication process, even while the name is updated to match the upstream.
+
 ## Roles and Permissions
 
 Replication uses Pulp's RBAC system. The following built-in roles are available for Upstream Pulp

--- a/pulpcore/app/replica.py
+++ b/pulpcore/app/replica.py
@@ -187,13 +187,6 @@ class Replicator:
         }
 
     def create_or_update_distribution(self, repository, upstream_distribution):
-        """Create or update a local distribution to match the upstream distribution.
-
-        Returns the old name of the distribution if it was found by base_path instead of
-        by name (i.e. a rename occurred upstream). The caller must add this old name to
-        the distro_names list so that remove_missing does not race with the rename.
-        Returns None otherwise.
-        """
         distribution_data = self.distribution_extra_fields(repository, upstream_distribution)
         distribution_data["pulp_labels"] = self.labels(upstream_distribution)
         try:
@@ -201,7 +194,7 @@ class Replicator:
                 name=upstream_distribution["name"], pulp_domain=self.domain
             )
             if not self._is_managed(distro):
-                return None
+                return
             needs_update = self.needs_update(distribution_data, distro)
             if needs_update:
                 dispatch(
@@ -215,13 +208,15 @@ class Replicator:
                         "partial": True,
                     },
                 )
-            return None
+            return
         except self.distribution_model_cls.DoesNotExist:
             pass
 
         # Not found by name — check if a managed distribution with the same base_path
-        # already exists (e.g. the distribution was renamed upstream). If so, update it
-        # in-place including the name, preserving content continuity at that base_path.
+        # already exists (e.g. the distribution was renamed upstream). If so, rename it
+        # synchronously and then dispatch an update for the remaining fields (labels, etc.).
+        # The synchronous rename ensures remove_missing sees the new name in the DB and
+        # won't try to delete the distribution we're reusing.
         base_path = distribution_data.get("base_path")
         if base_path:
             try:
@@ -229,20 +224,26 @@ class Replicator:
                     base_path=base_path, pulp_domain=self.domain
                 )
                 if self._is_managed(distro):
-                    old_name = distro.name
-                    distribution_data["name"] = upstream_distribution["name"]
-                    dispatch(
-                        ageneral_update,
-                        task_group=self.task_group,
-                        shared_resources=[repository, self.server],
-                        exclusive_resources=self.distros_uris,
-                        args=(distro.pk, self.app_label, self.distribution_serializer_name),
-                        kwargs={
-                            "data": distribution_data,
-                            "partial": True,
-                        },
-                    )
-                    return old_name
+                    distro.name = upstream_distribution["name"]
+                    distro.save(update_fields=["name"])
+                    needs_update = self.needs_update(distribution_data, distro)
+                    if needs_update:
+                        dispatch(
+                            ageneral_update,
+                            task_group=self.task_group,
+                            shared_resources=[repository, self.server],
+                            exclusive_resources=self.distros_uris,
+                            args=(
+                                distro.pk,
+                                self.app_label,
+                                self.distribution_serializer_name,
+                            ),
+                            kwargs={
+                                "data": distribution_data,
+                                "partial": True,
+                            },
+                        )
+                    return
             except self.distribution_model_cls.DoesNotExist:
                 pass
 
@@ -256,7 +257,6 @@ class Replicator:
             args=(self.app_label, self.distribution_serializer_name),
             kwargs={"data": create_data},
         )
-        return None
 
     def sync_params(self, repository, remote):
         """This method returns a dict that will be passed as kwargs to the sync task."""

--- a/pulpcore/app/replica.py
+++ b/pulpcore/app/replica.py
@@ -187,6 +187,13 @@ class Replicator:
         }
 
     def create_or_update_distribution(self, repository, upstream_distribution):
+        """Create or update a local distribution to match the upstream distribution.
+
+        Returns the old name of the distribution if it was found by base_path instead of
+        by name (i.e. a rename occurred upstream). The caller must add this old name to
+        the distro_names list so that remove_missing does not race with the rename.
+        Returns None otherwise.
+        """
         distribution_data = self.distribution_extra_fields(repository, upstream_distribution)
         distribution_data["pulp_labels"] = self.labels(upstream_distribution)
         try:
@@ -208,17 +215,48 @@ class Replicator:
                         "partial": True,
                     },
                 )
+            return None
         except self.distribution_model_cls.DoesNotExist:
-            create_data = dict(distribution_data)
-            create_data["name"] = upstream_distribution["name"]
-            dispatch(
-                general_create,
-                task_group=self.task_group,
-                shared_resources=[repository, self.server],
-                exclusive_resources=self.distros_uris,
-                args=(self.app_label, self.distribution_serializer_name),
-                kwargs={"data": create_data},
-            )
+            pass
+
+        # Not found by name — check if a managed distribution with the same base_path
+        # already exists (e.g. the distribution was renamed upstream). If so, update it
+        # in-place including the name, preserving content continuity at that base_path.
+        base_path = distribution_data.get("base_path")
+        if base_path:
+            try:
+                distro = self.distribution_model_cls.objects.get(
+                    base_path=base_path, pulp_domain=self.domain
+                )
+                if self._is_managed(distro):
+                    old_name = distro.name
+                    distribution_data["name"] = upstream_distribution["name"]
+                    dispatch(
+                        ageneral_update,
+                        task_group=self.task_group,
+                        shared_resources=[repository, self.server],
+                        exclusive_resources=self.distros_uris,
+                        args=(distro.pk, self.app_label, self.distribution_serializer_name),
+                        kwargs={
+                            "data": distribution_data,
+                            "partial": True,
+                        },
+                    )
+                    return old_name
+            except self.distribution_model_cls.DoesNotExist:
+                pass
+
+        create_data = dict(distribution_data)
+        create_data["name"] = upstream_distribution["name"]
+        dispatch(
+            general_create,
+            task_group=self.task_group,
+            shared_resources=[repository, self.server],
+            exclusive_resources=self.distros_uris,
+            args=(self.app_label, self.distribution_serializer_name),
+            kwargs={"data": create_data},
+        )
+        return None
 
     def sync_params(self, repository, remote):
         """This method returns a dict that will be passed as kwargs to the sync task."""

--- a/pulpcore/app/tasks/replica.py
+++ b/pulpcore/app/tasks/replica.py
@@ -92,13 +92,14 @@ def replicate_distributions(server_pk, q_select=None):
         distro_repo_pairs = []
         for replicator in supported_replicators:
             distro_names = []
+            pending_distributions = []
             distros = replicator.upstream_distributions(q=effective_q_select)
             for distro in distros:
                 # Create remote
                 remote = replicator.create_or_update_remote(upstream_distribution=distro)
                 if not remote:
                     # The upstream distribution is not serving any content,
-                    # let if fall through the cracks and be cleanup below.
+                    # let it fall through the cracks and be cleaned up below.
                     continue
                 # Check if there is already a repository
                 repository = replicator.create_or_update_repository(remote=remote)
@@ -111,13 +112,13 @@ def replicate_distributions(server_pk, q_select=None):
                 if replicator.requires_syncing(distro):
                     replicator.sync(repository, remote)
 
-                # Get or create a distribution
-                replicator.create_or_update_distribution(repository, distro)
-
                 # Add name to the list of known distribution names
                 distro_names.append(distro["name"])
                 distro_repo_pairs.append((distro["name"], str(repository.pk)))
+                pending_distributions.append((repository, distro))
 
+            # Clean up stale distributions BEFORE creating new ones so that
+            # base_path conflicts from old distributions are resolved first.
             # When a per-request q_select override is used, this is a selective sync
             # of a subset of distributions.  Skipping remove_missing avoids deleting
             # distributions that simply weren't included in the filter — but it also
@@ -125,6 +126,10 @@ def replicate_distributions(server_pk, q_select=None):
             # a full (non-overridden) replication runs.
             if q_select is None:
                 replicator.remove_missing(distro_names)
+
+            # Get or create distributions
+            for repository, distro in pending_distributions:
+                replicator.create_or_update_distribution(repository, distro)
     except GluePulpException as e:
         raise ExternalServiceError(service_name=server.base_url, details=str(e))
 
@@ -140,8 +145,17 @@ def finalize_replication(server_pk, distro_repo_pairs):
     task = Task.current()
     task_group = TaskGroup.current()
     server = UpstreamPulp.objects.get(pk=server_pk)
-    if task_group.tasks.exclude(pk=task.pk).exclude(state=TASK_STATES.COMPLETED).exists():
-        raise Exception("Replication failed.")
+    failed_tasks = task_group.tasks.exclude(pk=task.pk).exclude(state=TASK_STATES.COMPLETED)
+    if failed_tasks.exists():
+        details = []
+        for t in failed_tasks:
+            error_desc = t.error.get("description", "unknown error") if t.error else t.state
+            details.append(f"  {t.name}: {error_desc}")
+        raise Exception(
+            "Replication failed. {} subtask(s) did not complete successfully:\n{}".format(
+                failed_tasks.count(), "\n".join(details)
+            )
+        )
 
     # Atomically update all managed distributions to point to their repo's latest version,
     # clearing any previous repository or publication references.

--- a/pulpcore/app/tasks/replica.py
+++ b/pulpcore/app/tasks/replica.py
@@ -117,14 +117,12 @@ def replicate_distributions(server_pk, q_select=None):
                 distro_repo_pairs.append((distro["name"], str(repository.pk)))
                 pending_distributions.append((repository, distro))
 
-            # Get or create distributions BEFORE remove_missing. If a
-            # distribution was found by base_path rather than by name (upstream
-            # rename), add the old name to distro_names so that remove_missing
-            # does not delete the distribution we just dispatched a rename for.
+            # Get or create distributions BEFORE remove_missing so that
+            # create_or_update_distribution can synchronously rename any existing
+            # distribution matched by base_path.  remove_missing then sees the
+            # updated name in the DB and won't schedule it for deletion.
             for repository, distro in pending_distributions:
-                old_name = replicator.create_or_update_distribution(repository, distro)
-                if old_name:
-                    distro_names.append(old_name)
+                replicator.create_or_update_distribution(repository, distro)
 
             # When a per-request q_select override is used, this is a selective sync
             # of a subset of distributions.  Skipping remove_missing avoids deleting

--- a/pulpcore/app/tasks/replica.py
+++ b/pulpcore/app/tasks/replica.py
@@ -117,8 +117,15 @@ def replicate_distributions(server_pk, q_select=None):
                 distro_repo_pairs.append((distro["name"], str(repository.pk)))
                 pending_distributions.append((repository, distro))
 
-            # Clean up stale distributions BEFORE creating new ones so that
-            # base_path conflicts from old distributions are resolved first.
+            # Get or create distributions BEFORE remove_missing. If a
+            # distribution was found by base_path rather than by name (upstream
+            # rename), add the old name to distro_names so that remove_missing
+            # does not delete the distribution we just dispatched a rename for.
+            for repository, distro in pending_distributions:
+                old_name = replicator.create_or_update_distribution(repository, distro)
+                if old_name:
+                    distro_names.append(old_name)
+
             # When a per-request q_select override is used, this is a selective sync
             # of a subset of distributions.  Skipping remove_missing avoids deleting
             # distributions that simply weren't included in the filter — but it also
@@ -126,10 +133,6 @@ def replicate_distributions(server_pk, q_select=None):
             # a full (non-overridden) replication runs.
             if q_select is None:
                 replicator.remove_missing(distro_names)
-
-            # Get or create distributions
-            for repository, distro in pending_distributions:
-                replicator.create_or_update_distribution(repository, distro)
     except GluePulpException as e:
         raise ExternalServiceError(service_name=server.base_url, details=str(e))
 

--- a/pulpcore/tests/functional/api/test_replication.py
+++ b/pulpcore/tests/functional/api/test_replication.py
@@ -1011,7 +1011,9 @@ def test_replication_partial_failure_recovery(
     ).results[0]
     assert replica_distro_a.repository_version is None
 
-    # Fix upstream B: add content and a publication so the sync will succeed
+    # Fix upstream B: add content and create a publication. The distribution already
+    # points to repository=repo_b, so it will automatically serve the latest
+    # publication from the latest version — no distribution update needed.
     file_path_b = tmp_path / "file_b.txt"
     file_path_b.write_text("content_b")
     monitor_task(
@@ -1022,12 +1024,7 @@ def test_replication_partial_failure_recovery(
             pulp_domain=source_domain.name,
         ).task
     )
-    pub_b = file_publication_factory(pulp_domain=source_domain.name, repository=repo_b.pulp_href)
-    monitor_task(
-        file_bindings.DistributionsFileApi.partial_update(
-            distro_b.pulp_href, {"publication": pub_b.pulp_href}
-        ).task
-    )
+    file_publication_factory(pulp_domain=source_domain.name, repository=repo_b.pulp_href)
 
     # Second replication — should now succeed
     response = pulpcore_bindings.UpstreamPulpsApi.replicate(

--- a/pulpcore/tests/functional/api/test_replication.py
+++ b/pulpcore/tests/functional/api/test_replication.py
@@ -831,6 +831,92 @@ def test_replicate_rbac(
     )
 
 
+@pytest.mark.parallel
+def test_replication_base_path_conflict(
+    domain_factory,
+    bindings_cfg,
+    pulpcore_bindings,
+    file_bindings,
+    monitor_task,
+    monitor_task_group,
+    pulp_settings,
+    gen_object_with_cleanup,
+    file_distribution_factory,
+    file_publication_factory,
+    file_repository_factory,
+    tmp_path,
+    add_domain_objects_to_cleanup,
+):
+    """Test that replication succeeds when a stale distribution in the replica domain has a
+    base_path that conflicts with an upstream distribution. The stale distribution should be
+    removed before the new one is created."""
+
+    source_domain = domain_factory()
+    add_domain_objects_to_cleanup(source_domain)
+
+    # Create content in the upstream domain
+    repository = file_repository_factory(pulp_domain=source_domain.name)
+    file_path = tmp_path / "file.txt"
+    file_path.write_text("DEADBEEF")
+    monitor_task(
+        file_bindings.ContentFilesApi.create(
+            file=str(file_path),
+            relative_path="file.txt",
+            repository=repository.pulp_href,
+            pulp_domain=source_domain.name,
+        ).task
+    )
+    publication = file_publication_factory(
+        pulp_domain=source_domain.name, repository=repository.pulp_href
+    )
+    # Create upstream distribution with a known base_path
+    conflicting_base_path = str(uuid.uuid4())
+    upstream_distro = file_distribution_factory(
+        pulp_domain=source_domain.name,
+        publication=publication.pulp_href,
+        base_path=conflicting_base_path,
+    )
+
+    # Create the replica domain and a "blocker" distribution with the same base_path
+    replica_domain = domain_factory()
+    add_domain_objects_to_cleanup(replica_domain)
+    blocker_distro = file_distribution_factory(
+        pulp_domain=replica_domain.name,
+        base_path=conflicting_base_path,
+    )
+    assert blocker_distro.base_path == conflicting_base_path
+    assert blocker_distro.name != upstream_distro.name
+
+    # Create UpstreamPulp and run replication — should succeed because remove_missing
+    # deletes the blocker before the upstream distribution is created
+    upstream_pulp = gen_object_with_cleanup(
+        pulpcore_bindings.UpstreamPulpsApi,
+        {
+            "name": str(uuid.uuid4()),
+            "base_url": bindings_cfg.host,
+            "api_root": pulp_settings.API_ROOT,
+            "domain": source_domain.name,
+            "username": bindings_cfg.username,
+            "password": bindings_cfg.password,
+        },
+        pulp_domain=replica_domain.name,
+    )
+    response = pulpcore_bindings.UpstreamPulpsApi.replicate(
+        upstream_pulp.pulp_href, pulpcore_bindings.module.UpstreamPulpReplicate()
+    )
+    task_group = monitor_task_group(response.task_group)
+    for task in task_group.tasks:
+        assert task.state == "completed"
+
+    # Verify the blocker was removed and the upstream distribution was created
+    result = file_bindings.DistributionsFileApi.list(pulp_domain=replica_domain.name)
+    assert result.count == 1
+    replica_distro = result.results[0]
+    assert replica_distro.name == upstream_distro.name
+    assert replica_distro.base_path == conflicting_base_path
+    assert replica_distro.repository_version is not None
+
+
 @pytest.fixture
 def populate_upstream(
     domain_factory,

--- a/pulpcore/tests/functional/api/test_replication.py
+++ b/pulpcore/tests/functional/api/test_replication.py
@@ -920,6 +920,141 @@ def test_replication_base_path_conflict(
     assert replica_distro.repository_version is not None
 
 
+@pytest.mark.parallel
+def test_replication_partial_failure_recovery(
+    domain_factory,
+    bindings_cfg,
+    pulpcore_bindings,
+    file_bindings,
+    monitor_task,
+    monitor_task_group,
+    pulp_settings,
+    gen_object_with_cleanup,
+    file_distribution_factory,
+    file_publication_factory,
+    file_repository_factory,
+    tmp_path,
+    add_domain_objects_to_cleanup,
+):
+    """Test that after a partially failed replication (some syncs succeed, some fail),
+    a subsequent successful replication correctly updates all distributions to their
+    latest repository versions — including versions created by the failed run's
+    successful syncs."""
+
+    source_domain = domain_factory()
+    add_domain_objects_to_cleanup(source_domain)
+
+    # Distribution A: has valid content, will sync successfully
+    repo_a = file_repository_factory(pulp_domain=source_domain.name)
+    file_path_a = tmp_path / "file_a.txt"
+    file_path_a.write_text("content_a")
+    monitor_task(
+        file_bindings.ContentFilesApi.create(
+            file=str(file_path_a),
+            relative_path="file_a.txt",
+            repository=repo_a.pulp_href,
+            pulp_domain=source_domain.name,
+        ).task
+    )
+    pub_a = file_publication_factory(pulp_domain=source_domain.name, repository=repo_a.pulp_href)
+    distro_a = file_distribution_factory(
+        pulp_domain=source_domain.name, publication=pub_a.pulp_href
+    )
+
+    # Distribution B: points to a repository with no content or publication.
+    # The distribution has a base_url but serves no PULP_MANIFEST, so the
+    # file sync task will fail trying to download it.
+    repo_b = file_repository_factory(pulp_domain=source_domain.name)
+    distro_b = file_distribution_factory(
+        pulp_domain=source_domain.name, repository=repo_b.pulp_href
+    )
+
+    # Set up replica
+    replica_domain = domain_factory()
+    add_domain_objects_to_cleanup(replica_domain)
+    upstream_pulp = gen_object_with_cleanup(
+        pulpcore_bindings.UpstreamPulpsApi,
+        {
+            "name": str(uuid.uuid4()),
+            "base_url": bindings_cfg.host,
+            "api_root": pulp_settings.API_ROOT,
+            "domain": source_domain.name,
+            "username": bindings_cfg.username,
+            "password": bindings_cfg.password,
+        },
+        pulp_domain=replica_domain.name,
+    )
+
+    # First replication — should fail because sync for B fails (no content to serve)
+    response = pulpcore_bindings.UpstreamPulpsApi.replicate(
+        upstream_pulp.pulp_href, pulpcore_bindings.module.UpstreamPulpReplicate()
+    )
+    with pytest.raises(PulpTaskGroupError):
+        monitor_task_group(response.task_group)
+
+    # last_replication should NOT be updated after a failed run
+    upstream_pulp = pulpcore_bindings.UpstreamPulpsApi.read(upstream_pulp.pulp_href)
+    assert upstream_pulp.last_replication is None
+
+    # Verify that repo A's sync succeeded on the replica — it has a version with content
+    replica_repo_a = file_bindings.RepositoriesFileApi.list(
+        name=distro_a.name, pulp_domain=replica_domain.name
+    ).results[0]
+    version_from_failed_run = replica_repo_a.latest_version_href
+    assert version_from_failed_run is not None
+    version_detail = file_bindings.RepositoriesFileVersionsApi.read(version_from_failed_run)
+    assert version_detail.content_summary.present["file.file"]["count"] == 1
+
+    # But distribution A was NOT updated — finalize never ran
+    replica_distro_a = file_bindings.DistributionsFileApi.list(
+        name=distro_a.name, pulp_domain=replica_domain.name
+    ).results[0]
+    assert replica_distro_a.repository_version is None
+
+    # Fix upstream B: add content and a publication so the sync will succeed
+    file_path_b = tmp_path / "file_b.txt"
+    file_path_b.write_text("content_b")
+    monitor_task(
+        file_bindings.ContentFilesApi.create(
+            file=str(file_path_b),
+            relative_path="file_b.txt",
+            repository=repo_b.pulp_href,
+            pulp_domain=source_domain.name,
+        ).task
+    )
+    pub_b = file_publication_factory(pulp_domain=source_domain.name, repository=repo_b.pulp_href)
+    monitor_task(
+        file_bindings.DistributionsFileApi.partial_update(
+            distro_b.pulp_href, {"publication": pub_b.pulp_href}
+        ).task
+    )
+
+    # Second replication — should now succeed
+    response = pulpcore_bindings.UpstreamPulpsApi.replicate(
+        upstream_pulp.pulp_href, pulpcore_bindings.module.UpstreamPulpReplicate()
+    )
+    task_group = monitor_task_group(response.task_group)
+    for task in task_group.tasks:
+        assert task.state == "completed"
+
+    # Verify BOTH distributions now have repository_versions with correct content
+    for distro_name in (distro_a.name, distro_b.name):
+        replica_distro = file_bindings.DistributionsFileApi.list(
+            name=distro_name, pulp_domain=replica_domain.name
+        ).results[0]
+        assert replica_distro.repository_version is not None
+        version = file_bindings.RepositoriesFileVersionsApi.read(replica_distro.repository_version)
+        assert version.content_summary.present["file.file"]["count"] == 1
+
+    # Verify that repo A's latest version is still the one created during the failed run.
+    # The second run's sync found no content changes and didn't create a new version,
+    # so finalize picked up the version from the first (failed) run's successful sync.
+    replica_repo_a = file_bindings.RepositoriesFileApi.list(
+        name=distro_a.name, pulp_domain=replica_domain.name
+    ).results[0]
+    assert replica_repo_a.latest_version_href == version_from_failed_run
+
+
 @pytest.fixture
 def populate_upstream(
     domain_factory,

--- a/pulpcore/tests/functional/api/test_replication.py
+++ b/pulpcore/tests/functional/api/test_replication.py
@@ -847,9 +847,10 @@ def test_replication_base_path_conflict(
     tmp_path,
     add_domain_objects_to_cleanup,
 ):
-    """Test that replication succeeds when a stale distribution in the replica domain has a
-    base_path that conflicts with an upstream distribution. The stale distribution should be
-    removed before the new one is created."""
+    """Test that replication succeeds when a distribution in the replica domain has a
+    base_path that conflicts with an upstream distribution. The existing distribution
+    should be reused (updated in-place) rather than deleted and recreated, preserving
+    content continuity at that base_path."""
 
     source_domain = domain_factory()
     add_domain_objects_to_cleanup(source_domain)
@@ -878,6 +879,7 @@ def test_replication_base_path_conflict(
     )
 
     # Create the replica domain and a "blocker" distribution with the same base_path
+    # but a different name — simulating a rename or a locally-created distribution
     replica_domain = domain_factory()
     add_domain_objects_to_cleanup(replica_domain)
     blocker_distro = file_distribution_factory(
@@ -887,8 +889,8 @@ def test_replication_base_path_conflict(
     assert blocker_distro.base_path == conflicting_base_path
     assert blocker_distro.name != upstream_distro.name
 
-    # Create UpstreamPulp and run replication — should succeed because remove_missing
-    # deletes the blocker before the upstream distribution is created
+    # Create UpstreamPulp and run replication — should succeed because the existing
+    # distribution is found by base_path and updated in-place (renamed)
     upstream_pulp = gen_object_with_cleanup(
         pulpcore_bindings.UpstreamPulpsApi,
         {
@@ -908,10 +910,11 @@ def test_replication_base_path_conflict(
     for task in task_group.tasks:
         assert task.state == "completed"
 
-    # Verify the blocker was removed and the upstream distribution was created
+    # Verify the distribution was reused — same pulp_href, renamed to match upstream
     result = file_bindings.DistributionsFileApi.list(pulp_domain=replica_domain.name)
     assert result.count == 1
     replica_distro = result.results[0]
+    assert replica_distro.pulp_href == blocker_distro.pulp_href
     assert replica_distro.name == upstream_distro.name
     assert replica_distro.base_path == conflicting_base_path
     assert replica_distro.repository_version is not None


### PR DESCRIPTION
In situations where an installation was replicating >1 external Pulp servers, the result was cascading failures as the replications would race and conflict with each other.


### 📜 Checklist

- [ ] Commits are cleanly separated with meaningful messages (simple features and bug fixes should be [squashed](https://pulpproject.org/pulpcore/docs/dev/guides/git/#rebasing-and-squashing) to one commit)
- [ ] A [changelog entry](https://pulpproject.org/pulpcore/docs/dev/guides/git/#changelog-update) or entries has been added for any significant changes
- [ ] Follows the [Pulp policy on AI Usage](https://pulpproject.org/help/more/governance/ai_policy/)
- [ ] (For new features) - User documentation and test coverage has been added

See: [Pull Request Walkthrough](https://pulpproject.org/pulpcore/docs/dev/guides/pull-request-walkthrough/)
