### PR TITLE
Added additional locking during replication

### DIFF
--- a/CHANGES/7614.bugfix
+++ b/CHANGES/7614.bugfix
@@ -1,0 +1,1 @@
+Added a distributions lock to `finalize_replication` to prevent concurrent finalize tasks from different upstream servers from racing on the same distribution objects.

--- a/pulpcore/app/replica.py
+++ b/pulpcore/app/replica.py
@@ -17,6 +17,10 @@ from pulpcore.tasking.tasks import dispatch
 _logger = logging.getLogger(__name__)
 
 
+def distros_lock_uri(domain_id):
+    return f"pdrn:{domain_id}:distributions"
+
+
 class ReplicaContext(PulpContext):
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
@@ -61,7 +65,7 @@ class Replicator:
         self.tls_settings = tls_settings
         self.server = server
         self.domain = get_domain()
-        self.distros_uris = [f"pdrn:{self.domain.pulp_id}:distributions"]
+        self.distros_uris = [distros_lock_uri(self.domain.pulp_id)]
 
     @staticmethod
     def needs_update(fields_dict, model_instance):

--- a/pulpcore/app/tasks/replica.py
+++ b/pulpcore/app/tasks/replica.py
@@ -11,7 +11,7 @@ from pulp_glue.common.exceptions import PulpException as GluePulpException
 
 from pulpcore.app.apps import PulpAppConfig, pulp_plugin_configs
 from pulpcore.app.models import Distribution, Repository, Task, TaskGroup, UpstreamPulp
-from pulpcore.app.replica import ReplicaContext
+from pulpcore.app.replica import ReplicaContext, distros_lock_uri
 from pulpcore.constants import TASK_STATES
 from pulpcore.exceptions import ExternalServiceError
 from pulpcore.tasking.tasks import dispatch
@@ -118,7 +118,7 @@ def replicate_distributions(server_pk):
     dispatch(
         finalize_replication,
         task_group=task_group,
-        exclusive_resources=[server],
+        exclusive_resources=[server, distros_lock_uri(server.pulp_domain_id)],
         args=[server.pk, distro_repo_pairs],
     )
 


### PR DESCRIPTION
Locking didn't prevent two UpstreamPulps with overlapping Distributions from racing and clobbering each other.

Assisted-By: claude-opus-4.6
re #7614

<!---
Thank you for submitting a PR to the Pulp Project!

If this is your first time contributing, please read the Pull Request Walkthrough documentation
(https://pulpproject.org/pulpcore/docs/dev/guides/pull-request-walkthrough/).
-->

### 📜 Checklist

- [ ] Commits are cleanly separated with meaningful messages (simple features and bug fixes should be [squashed](https://pulpproject.org/pulpcore/docs/dev/guides/git/#rebasing-and-squashing) to one commit)
- [ ] A [changelog entry](https://pulpproject.org/pulpcore/docs/dev/guides/git/#changelog-update) or entries has been added for any significant changes
- [ ] Follows the [Pulp policy on AI Usage](https://pulpproject.org/help/more/governance/ai_policy/)
- [ ] (For new features) - User documentation and test coverage has been added

See: [Pull Request Walkthrough](https://pulpproject.org/pulpcore/docs/dev/guides/pull-request-walkthrough/)
