### PR TITLE
Don't leak overwrite kwarg into plugin validated_data

### DIFF
--- a/CHANGES/plugin_api/+overwrite-default-leak.bugfix
+++ b/CHANGES/plugin_api/+overwrite-default-leak.bugfix
@@ -1,0 +1,3 @@
+Removed the `default=True` from the `overwrite` field on `NoArtifactContentSerializer` so it no
+longer leaks into `validated_data`. This fixes plugins that splat content serializer data
+(`**serializer.validated_data`).

--- a/pulpcore/app/serializers/content.py
+++ b/pulpcore/app/serializers/content.py
@@ -35,7 +35,6 @@ class NoArtifactContentSerializer(base.ModelSerializer):
     )
     overwrite = serializers.BooleanField(
         required=False,
-        default=True,
         write_only=True,
         help_text=_(
             "When set to true, existing content in the repository with the same unique key "


### PR DESCRIPTION
## Problem

The `overwrite` field added in #7550 (commit f6dc7b93f) on `NoArtifactContentSerializer` was declared with `default=True`. DRF auto-injects any field with a `default=...` into `validated_data` even when the caller does not supply it, so plugins that splat `**serializer.validated_data` into a content model constructor were broken by the unexpected `overwrite=True` kwarg.

For example, in pulp_deb's sync stage (`pulp_deb/app/tasks/synchronizing.py:1057`):

```python
serializer = serializer_class.from822(data=package_paragraph)
serializer.is_valid(raise_exception=True)
package_content_unit = package_class(
    relative_path=package_relpath,
    sha256=package_sha256,
    **serializer.validated_data,   # <-- now contains overwrite=True
)
```

The Django `Package` model has no `overwrite` field, so:

```
TypeError: Package() got unexpected keyword arguments: 'overwrite'
```

This caused 10 functional `test_sync` tests in pulp_deb to fail.

The other inherited control fields on `NoArtifactContentSerializer` (`repository`, `pulp_labels`) don't trigger the same issue because none of them declare a `default=`, so DRF only puts them into `validated_data` when explicitly supplied. `overwrite` was the only one that leaked unconditionally.

## Fix

Remove the `default=True` from the field declaration. The existing `validated_data.pop("overwrite", True)` in `NoArtifactContentSerializer.create()` already encodes the "absent ⇒ True" semantics, so there is no behavior change for REST API callers:

| Caller behavior | Before | After |
|---|---|---|
| Omits `overwrite` | `validated_data["overwrite"] = True`, `pop` returns `True` → silent overwrite | Field absent from `validated_data`, `pop("overwrite", True)` returns `True` → silent overwrite |
| Sends `overwrite: false` | Field validates → `False` in `validated_data` → check runs | Same |
| Sends `overwrite: true` | Field validates → `True` in `validated_data` → silent overwrite | Same |

## Verification

- All 7 existing tests in `pulp_file/tests/functional/api/test_overwrite_content.py` still pass.
- The 10 pulp_deb `test_sync` failures are resolved by this change alone.

## AI attribution

AI-Generated: github-copilot
