### PR TITLE
Add NAME_FILTER_OPTIONS to FileContent relative_path filter

### DIFF
--- a/CHANGES/pulp_file/7719.feature
+++ b/CHANGES/pulp_file/7719.feature
@@ -1,0 +1,1 @@
+Added `NAME_FILTER_OPTIONS` to the `relative_path` field in `FileContentFilter`, enabling contains, startswith, regex, and other lookup expressions.

--- a/pulp_file/app/viewsets.py
+++ b/pulp_file/app/viewsets.py
@@ -9,6 +9,7 @@ from rest_framework.exceptions import ValidationError
 from rest_framework.generics import get_object_or_404
 from rest_framework.response import Response
 
+from pulpcore.app.viewsets.base import NAME_FILTER_OPTIONS
 from pulpcore.plugin.actions import ModifyRepositoryActionMixin
 from pulpcore.plugin.models import (
     AlternateContentSource,
@@ -66,7 +67,10 @@ class FileContentFilter(ContentFilter):
 
     class Meta:
         model = FileContent
-        fields = ["relative_path", "sha256"]
+        fields = {
+            "relative_path": NAME_FILTER_OPTIONS,
+            "digest": ["exact"],
+        }
 
 
 class FileContentViewSet(SingleArtifactContentUploadViewSet):

--- a/pulp_file/tests/functional/api/test_crud_content_unit.py
+++ b/pulp_file/tests/functional/api/test_crud_content_unit.py
@@ -35,6 +35,36 @@ def test_crud_content_unit(file_bindings, random_artifact, gen_object_with_clean
 
 
 @pytest.mark.parallel
+def test_relative_path_filter_options(file_bindings, random_artifact, gen_object_with_cleanup):
+    """Test that relative_path supports contains, startswith, and regex filters."""
+    path = f"packages/python/{uuid.uuid4()}/my-package-1.0.tar.gz"
+    content_unit = gen_object_with_cleanup(
+        file_bindings.ContentFilesApi,
+        artifact=random_artifact.pulp_href,
+        relative_path=path,
+    )
+
+    # contains
+    response = file_bindings.ContentFilesApi.list(relative_path__contains="my-package")
+    assert response.count >= 1
+    assert any(c.pulp_href == content_unit.pulp_href for c in response.results)
+
+    # startswith
+    response = file_bindings.ContentFilesApi.list(relative_path__startswith="packages/python/")
+    assert response.count >= 1
+    assert any(c.pulp_href == content_unit.pulp_href for c in response.results)
+
+    # regex
+    response = file_bindings.ContentFilesApi.list(relative_path__regex=r".*\.tar\.gz$")
+    assert response.count >= 1
+    assert any(c.pulp_href == content_unit.pulp_href for c in response.results)
+
+    # negative case — no match
+    response = file_bindings.ContentFilesApi.list(relative_path__startswith="nonexistent-prefix/")
+    assert not any(c.pulp_href == content_unit.pulp_href for c in response.results)
+
+
+@pytest.mark.parallel
 def test_same_sha256_same_relative_path_no_repo(file_bindings, random_artifact, monitor_task):
     artifact_attrs = {"artifact": random_artifact.pulp_href, "relative_path": str(uuid.uuid4())}
 


### PR DESCRIPTION
## Summary
- Use `NAME_FILTER_OPTIONS` for `relative_path` in `FileContentFilter`, enabling contains, startswith, regex, and other lookup expressions
- Change `fields` from a list to a dict to specify per-field filter options
- `sha256` query parameter continues to work via the existing `CharFilter` alias

Fixes #7719

## Test plan
- [ ] Existing file content filter tests pass
- [ ] New filter lookups work: `?relative_path__contains=foo`, `?relative_path__startswith=packages/`, `?relative_path__regex=.*\.rpm$`