### PR TITLE
Decouple /livez endpoint from the database

### DIFF
--- a/CHANGES/7721.bugfix
+++ b/CHANGES/7721.bugfix
@@ -1,0 +1,1 @@
+Decoupled the `/livez` liveness probe from the database so it returns 200 even when the database is unavailable.

--- a/pulpcore/app/views/status.py
+++ b/pulpcore/app/views/status.py
@@ -145,6 +145,8 @@ class LivezView(APIView):
     # allow anyone to access the liveness api
     authentication_classes = []
     permission_classes = []
+    # Skip domain DB lookup so this probe stays independent of the database
+    skip_domain_middleware = True
 
     @extend_schema(
         summary="Inspect liveness of Pulp's REST API.",

--- a/pulpcore/middleware.py
+++ b/pulpcore/middleware.py
@@ -38,6 +38,10 @@ class DomainMiddleware:
 
     def process_view(self, request, view_func, view_args, view_kwargs):
         """Remove the domain name if present, called right before view_func is called."""
+        view_class = getattr(view_func, "view_class", None) or getattr(view_func, "cls", None)
+        if view_class and getattr(view_class, "skip_domain_middleware", False):
+            view_kwargs.pop("pulp_domain", None)
+            return None
         domain_name = view_kwargs.pop("pulp_domain", "default")
         try:
             domain = Domain.objects.get(name=domain_name)

--- a/pulpcore/tests/unit/test_middleware.py
+++ b/pulpcore/tests/unit/test_middleware.py
@@ -1,0 +1,35 @@
+from unittest.mock import MagicMock, patch
+
+from django.test import TestCase
+
+from pulpcore.middleware import DomainMiddleware
+from pulpcore.plugin.find_url import find_api_root
+
+
+class TestLivezNoDatabaseAccess(TestCase):
+    """Test that GET /livez/ makes zero database queries."""
+
+    def test_livez_makes_no_database_queries(self):
+        _, api_v3_path = find_api_root(set_domain=False, rewrite_header=False)
+        with self.assertNumQueries(0):
+            response = self.client.get(f"{api_v3_path}livez/")
+        self.assertEqual(response.status_code, 200)
+
+
+class TestDomainMiddlewareSkip(TestCase):
+    """Test that DomainMiddleware skips DB lookup for views with skip_domain_middleware=True."""
+
+    def setUp(self):
+        self.middleware = DomainMiddleware(get_response=MagicMock())
+        self.request = MagicMock()
+
+    @patch("pulpcore.middleware.Domain.objects")
+    @patch("pulpcore.middleware.set_domain")
+    def test_does_db_lookup_when_flag_not_set(self, mock_set_domain, mock_domain_objects):
+        view_class = type("NormalView", (), {})
+        view_func = MagicMock(view_class=view_class)
+        view_kwargs = {"pulp_domain": "default"}
+
+        self.middleware.process_view(self.request, view_func, [], view_kwargs)
+
+        mock_domain_objects.get.assert_called_once_with(name="default")


### PR DESCRIPTION
## Summary
- Add `skip_domain_middleware = True` flag to `LivezView`
- Teach `DomainMiddleware.process_view()` to skip `Domain.objects.get()` when the flag is set
- The `/livez` probe now returns 200 even when the database is unavailable

Other middleware (`SessionMiddleware`, `AuthenticationMiddleware`) are lazy and don't hit the DB for `/livez` since `authentication_classes` and `permission_classes` are both empty and `request.user`/`request.session` are never accessed. `DomainMiddleware` was the only eager DB dependency.

Fixes #7721

## Test plan
- [ ] Existing `/livez` test passes (`test_status.py`)
- [ ] `/livez` returns 200 when database is stopped (manual verification)