### PR TITLE
Fix serializing html formdata with nested representations

### DIFF
--- a/CHANGES/7677.bugfix
+++ b/CHANGES/7677.bugfix
@@ -1,0 +1,1 @@
+Allow nested downloader_config to be passed json stringified.

--- a/pulp_file/tests/functional/api/test_crud_content_unit.py
+++ b/pulp_file/tests/functional/api/test_crud_content_unit.py
@@ -296,7 +296,11 @@ def test_create_file_from_url(
 ):
     # Test create w/ url
     remote = file_remote_factory(manifest_path=basic_manifest_path)
-    body = {"file_url": remote.url, "relative_path": "PULP_MANIFEST"}
+    body = {
+        "file_url": remote.url,
+        "relative_path": "PULP_MANIFEST",
+        "downloader_config": {"total_timeout": 5},
+    }
     response = file_bindings.ContentFilesApi.create(**body)
     task = monitor_task(response.task)
     assert len(task.created_resources) == 1

--- a/pulpcore/app/serializers/base.py
+++ b/pulpcore/app/serializers/base.py
@@ -1,4 +1,5 @@
 import functools
+import json
 import re
 import traceback
 from collections import namedtuple
@@ -80,7 +81,7 @@ class HrefPrnFieldMixin:
         return super().to_internal_value(data)
 
 
-class _MatchingRegexViewName(object):
+class _MatchingRegexViewName:
     """This is a helper class to help defining object matching rules for master-detail.
 
     If you can be specific, please specify the `view_name`, but if you cannot, this allows
@@ -781,6 +782,17 @@ class RemoteNetworkConfigSerializer(serializers.Serializer):
                 raise serializers.ValidationError(
                     "Invalid {} specified, error '{}'".format(which_cert, e.args)
                 )
+
+    def to_internal_value(self, data):
+        if isinstance(data, str):
+            try:
+                # Nested Serializers in from-urlencoded bodies are stringified as json by default.
+                data = json.loads(data)
+            except json.DecodeError:
+                raise serializers.ValidationError(
+                    "Invalid json data for (nested) downloader config."
+                )
+        return super().to_internal_value(data)
 
     def validate(self, data):
         """

--- a/pulpcore/app/serializers/base.py
+++ b/pulpcore/app/serializers/base.py
@@ -306,7 +306,11 @@ def validate_unknown_fields(initial_data, defined_fields):
     The `csrfmiddlewaretoken` field is silently ignored.
     """
     ignored_fields = {"csrfmiddlewaretoken"}
-    unknown_fields = set(initial_data) - set(defined_fields) - ignored_fields
+    unknown_fields = (
+        {key.split(".", maxsplit=1)[0] for key in initial_data}
+        - set(defined_fields)
+        - ignored_fields
+    )
     if unknown_fields:
         unknown_fields = {field: _("Unexpected field") for field in unknown_fields}
         raise serializers.ValidationError(unknown_fields)
@@ -783,6 +787,7 @@ class RemoteNetworkConfigSerializer(serializers.Serializer):
         Check that proxy credentials are only provided completely and if a proxy is configured.
         Adapted to work for both ModelSerializers (Remotes) and standard Serializers (Uploads).
         """
+        data = super().validate(data)
         # Handle cases where we don't have an instance (e.g. Uploads)
         instance = getattr(self, "instance", None)
         partial = getattr(self, "partial", False)


### PR DESCRIPTION
Form data is treated differently by serializers.

<!---
Thank you for submitting a PR to the Pulp Project!

If this is your first time contributing, please read the Pull Request Walkthrough documentation
(https://pulpproject.org/pulpcore/docs/dev/guides/pull-request-walkthrough/).
-->

### 📜 Checklist

- [ ] Commits are cleanly separated with meaningful messages (simple features and bug fixes should be [squashed](https://pulpproject.org/pulpcore/docs/dev/guides/git/#rebasing-and-squashing) to one commit)
- [ ] A [changelog entry](https://pulpproject.org/pulpcore/docs/dev/guides/git/#changelog-update) or entries has been added for any significant changes
- [ ] Follows the [Pulp policy on AI Usage](https://pulpproject.org/help/more/governance/ai_policy/)
- [ ] (For new features) - User documentation and test coverage has been added

See: [Pull Request Walkthrough](https://pulpproject.org/pulpcore/docs/dev/guides/pull-request-walkthrough/)
