### PR TITLE
Fix race condition in resource_blocker test fixture

### DIFF
--- a/pulpcore/tests/functional/api/test_tasking.py
+++ b/pulpcore/tests/functional/api/test_tasking.py
@@ -613,6 +613,13 @@ def resource_blocker(pulpcore_bindings, dispatch_task):
             args=(duration,),
             exclusive_resources=exclusive_resources,
         )
+        # Wait for the blocking task to start running so it holds the resource lock
+        for _ in range(100):
+            task = pulpcore_bindings.TasksApi.read(task_href)
+            if task.state == "running":
+                break
+            time.sleep(0.1)
+        assert task.state == "running", f"Blocker task never started: {task.state}"
         yield
         # Trying to cancel a finished task will return a 409 code.
         # We can ignore if that's the case, because all we want here is to cut time down.


### PR DESCRIPTION
## Summary

The `resource_blocker` fixture dispatched a blocking task but yielded immediately without waiting for it to start running. With RedisWorker (Azure runner), the blocking task may not have acquired the resource lock before the test dispatches an immediate task on the same resource, causing the immediate task to complete instead of waiting.

Now polls the blocking task until it reaches `"running"` state before yielding, ensuring the resource lock is held.

Fixes flaky `TestImmediateTaskWithBlockedResource.test_executes_in_task_worker` on Azure runner.

## Test plan
- [ ] Azure runner (RedisWorker) CI passes — the previously flaky test should now be stable
- [ ] GHA runner (PulpcoreWorker) CI passes — no behavior change for fast task pickup