### PR TITLE
Expose `StableOrderingFilter` in pulpcore.plugin API

### DIFF
--- a/CHANGES/plugin_api/+expose-stable-ordering-filter.feature
+++ b/CHANGES/plugin_api/+expose-stable-ordering-filter.feature
@@ -1,0 +1,1 @@
+Exposed ``StableOrderingFilter`` in the plugin API so pulp plugins can import it from ``pulpcore.plugin``.

--- a/pulpcore/plugin/viewsets/__init__.py
+++ b/pulpcore/plugin/viewsets/__init__.py
@@ -1,6 +1,6 @@
 # ruff: noqa: F401
 # isort: skip_file
-from pulpcore.filters import BaseFilterSet
+from pulpcore.filters import BaseFilterSet, StableOrderingFilter
 
 # Allow plugin viewsets to return 202s
 from pulpcore.app.response import OperationPostponedResponse, TaskGroupOperationResponse
@@ -55,6 +55,7 @@ from .content import (
 
 __all__ = [
     "BaseFilterSet",
+    "StableOrderingFilter",
     "OperationPostponedResponse",
     "TaskGroupOperationResponse",
     "AlternateContentSourceViewSet",


### PR DESCRIPTION
Expose `StableOrderingFilter` in `pulpcore.plugin.viewsets` so plugin repos can import it from the public API (`from pulpcore.plugin import StableOrderingFilter`) instead of reaching into the internal `pulpcore.filters` module directly.

Required for https://github.com/pulp/pulp_ansible/pull/2555

<!---
Thank you for submitting a PR to the Pulp Project!

If this is your first time contributing, please read the Pull Request Walkthrough documentation
(https://pulpproject.org/pulpcore/docs/dev/guides/pull-request-walkthrough/).
-->

### 📜 Checklist

- [x] Commits are cleanly separated with meaningful messages (simple features and bug fixes should be [squashed](https://pulpproject.org/pulpcore/docs/dev/guides/git/#rebasing-and-squashing) to one commit)
- [x] A [changelog entry](https://pulpproject.org/pulpcore/docs/dev/guides/git/#changelog-update) or entries has been added for any significant changes
- [x] Follows the [Pulp policy on AI Usage](https://pulpproject.org/help/more/governance/ai_policy/)
- [ ] (For new features) - User documentation and test coverage has been added

See: [Pull Request Walkthrough](https://pulpproject.org/pulpcore/docs/dev/guides/pull-request-walkthrough/)
