### PR TITLE
Fix reset-admin-password crashing when admin exists without superuser flag

### DIFF
--- a/pulpcore/app/management/commands/reset-admin-password.py
+++ b/pulpcore/app/management/commands/reset-admin-password.py
@@ -34,7 +34,10 @@ class Command(BaseCommand):
         )
 
     def handle(self, *args, **options):
-        user = User.objects.get_or_create(username="admin", is_superuser=True, is_staff=True)[0]
+        user, _ = User.objects.update_or_create(
+            username="admin",
+            defaults={"is_superuser": True, "is_staff": True},
+        )
         if options["random"]:
             alphabet = string.ascii_letters + string.digits
             password = "".join(secrets.choice(alphabet) for i in range(20))

--- a/pulpcore/tests/unit/test_reset_admin_password_command.py
+++ b/pulpcore/tests/unit/test_reset_admin_password_command.py
@@ -1,0 +1,54 @@
+from io import StringIO
+
+import pytest
+from django.contrib.auth import get_user_model
+from django.core.management import call_command
+
+User = get_user_model()
+
+
+@pytest.mark.django_db
+def test_creates_new_admin_with_password():
+    out = StringIO()
+    call_command("reset-admin-password", password="testpass123", stdout=out)
+    user = User.objects.get(username="admin")
+    assert user.is_superuser is True
+    assert user.is_staff is True
+    assert user.check_password("testpass123")
+    assert "Successfully set password" in out.getvalue()
+
+
+@pytest.mark.django_db
+def test_resets_password_on_existing_superuser():
+    User.objects.create_user(username="admin", password="old", is_superuser=True, is_staff=True)
+    out = StringIO()
+    call_command("reset-admin-password", password="newpass", stdout=out)
+    user = User.objects.get(username="admin")
+    assert user.is_superuser is True
+    assert user.is_staff is True
+    assert user.check_password("newpass")
+
+
+@pytest.mark.django_db
+def test_promotes_existing_non_superuser_admin():
+    User.objects.create_user(username="admin", password="old", is_superuser=False, is_staff=False)
+    out = StringIO()
+    call_command("reset-admin-password", password="newpass", stdout=out)
+    user = User.objects.get(username="admin")
+    assert user.is_superuser is True
+    assert user.is_staff is True
+    assert user.check_password("newpass")
+
+
+@pytest.mark.django_db
+def test_random_password():
+    out = StringIO()
+    call_command("reset-admin-password", random=True, stdout=out)
+    user = User.objects.get(username="admin")
+    assert user.is_superuser is True
+    assert user.is_staff is True
+    output = out.getvalue()
+    assert "Successfully set" in output
+    password = output.split('"')[-2]
+    assert len(password) == 20
+    assert user.check_password(password)


### PR DESCRIPTION
## Summary

- Fix `reset-admin-password` management command crashing with `UniqueViolation` when an `admin` user exists but has `is_superuser=False` and/or `is_staff=False`
- Switch from `get_or_create` to `update_or_create` so the lookup uses `username` only, and `is_superuser`/`is_staff` are set via `defaults` on both create and update paths
- Add unit tests covering: new admin creation, password reset on existing superuser, promotion of non-superuser admin (regression test), and random password generation

## Root Cause

Line 37 used `get_or_create` with all three fields as lookup criteria:

```python
user = User.objects.get_or_create(username="admin", is_superuser=True, is_staff=True)[0]
```

Django's `get_or_create` uses all kwargs (except `defaults`) for the WHERE clause. When an admin user exists with different flag values, the SELECT returns empty, then the INSERT fails on the unique constraint for `username`.

This affects the galaxy-operator's reconciliation loop, which calls `reset-admin-password` when it detects no superuser admin — causing continuous crash logs on every reconciliation.

## Fix

```python
user, _ = User.objects.update_or_create(
    username="admin",
    defaults={"is_superuser": True, "is_staff": True},
)
```

`update_or_create` looks up by `username` only and ensures `is_superuser=True, is_staff=True` on both create and update paths. This resolves both the crash and the operator's infinite reconciliation loop (the admin gets promoted to superuser, so the operator's check succeeds on the next pass).

Note: using `get_or_create` with `defaults` (instead of `update_or_create`) would prevent the crash but would NOT promote an existing non-superuser admin, leaving the operator in an infinite loop of unnecessary password resets.

Related: [AAP-76361](https://redhat.atlassian.net/browse/AAP-76361)

## Test plan

- [x] Add unit test: creates new admin with correct flags and password
- [x] Add unit test: resets password on existing superuser admin
- [x] Add unit test: promotes existing non-superuser admin (regression test for the bug)
- [x] Add unit test: random password generation works
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[AAP-76361]: https://redhat.atlassian.net/browse/AAP-76361?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ