### PR TITLE
Strip version info from status endpoint for unauthenticated requests

### DIFF
--- a/pulpcore/app/serializers/status.py
+++ b/pulpcore/app/serializers/status.py
@@ -96,7 +96,9 @@ class StatusSerializer(serializers.Serializer):
     Serializer for the status information of the app
     """
 
-    versions = VersionSerializer(help_text=_("Version information of Pulp components"), many=True)
+    versions = VersionSerializer(
+        help_text=_("Version information of Pulp components"), many=True, required=False
+    )
 
     online_workers = AppStatusSerializer(
         help_text=_(

--- a/pulpcore/app/views/status.py
+++ b/pulpcore/app/views/status.py
@@ -38,8 +38,6 @@ class StatusView(APIView):
     Returns status information about the application
     """
 
-    # allow anyone to access the status api
-    authentication_classes = []
     permission_classes = []
 
     @extend_schema(
@@ -98,6 +96,9 @@ class StatusView(APIView):
             "content_settings": content_settings,
             "domain_enabled": settings.DOMAIN_ENABLED,
         }
+
+        if not request.user or not request.user.is_authenticated:
+            data.pop("versions")
 
         context = {"request": request}
         serializer = StatusSerializer(data, context=context)

--- a/pulpcore/tests/functional/api/test_status.py
+++ b/pulpcore/tests/functional/api/test_status.py
@@ -49,7 +49,6 @@ STATUS = {
         "database_connection",
         "online_workers",
         "storage",
-        "versions",
     ],
 }
 
@@ -65,14 +64,18 @@ def test_get_authenticated(pulpcore_bindings, pulp_settings):
 
 
 @pytest.mark.parallel
-def test_get_unauthenticated(pulpcore_bindings, anonymous_user, pulp_settings):
+def test_get_unauthenticated(pulpcore_bindings, anonymous_user):
     """GET the status path with no credentials.
 
-    Verify the response with :meth:`verify_get_response`.
+    Verify that version information is not disclosed to unauthenticated users.
     """
     with anonymous_user:
         response = pulpcore_bindings.StatusApi.status_read()
-    verify_get_response(response.to_dict(), STATUS, pulp_settings)
+    status = response.to_dict()
+    validate(status, STATUS)
+    assert "versions" not in status or status["versions"] is None
+    assert status["database_connection"]["connected"]
+    assert status["online_workers"] != []
 
 
 @pytest.mark.parallel


### PR DESCRIPTION
## Summary

- Remove `authentication_classes = []` from `StatusView` so DRF runs its default authenticators while keeping `permission_classes = []` (endpoint stays accessible to everyone)
- Strip the `versions` field from the `/pulp/api/v3/status/` response for unauthenticated requests to prevent version disclosure
- Make `versions` optional in `StatusSerializer` and update functional tests accordingly

## Context

A penetration test found that the status endpoint discloses exact versions of every installed Pulp plugin to unauthenticated users. Attackers can use exact version numbers for targeted CVE lookups. Healthcheck probes (e.g. `readyz.py`) only need `database_connection` and `redis_connection`, so stripping `versions` for unauthenticated requests has no impact on them.

## Test plan

- [x] Verified unauthenticated requests to `/pulp/api/v3/status/` no longer contain `versions`
- [x] Verified authenticated requests still return full `versions` array
- [x] Verified all healthcheck fields (`database_connection`, `redis_connection`, `online_workers`, `storage`, etc.) remain present regardless of auth
- [ ] CI functional tests (require regenerated client bindings from updated OpenAPI spec)

🤖 Generated with [Claude Code](https://claude.com/claude-code)