### PR TITLE
Add OR alternatives to label select

### DIFF
--- a/CHANGES/7435.feature
+++ b/CHANGES/7435.feature
@@ -1,0 +1,1 @@
+Added OR alternatives to `pulp_label_select` using pipe-separated values within a comma-separated label term.

--- a/docs/user/guides/manage-labels.md
+++ b/docs/user/guides/manage-labels.md
@@ -117,6 +117,12 @@ Multiple terms can be combined with `,`:
 - `environment,reviewed=false` - returns resources with an environment label and where reviewed is
   false
 
+Multiple alternatives in a single term can be combined with `|`:
+
+- `build_id=123|456` - returns resources where build_id is 123 or 456
+- `environment=production|staging,reviewed=true` - returns resources where environment is
+  production or staging and reviewed is true
+
 To filter using the CLI use `--label-select`:
 
 ```bash

--- a/pulp_file/tests/functional/api/test_labels.py
+++ b/pulp_file/tests/functional/api/test_labels.py
@@ -159,6 +159,16 @@ def test_label_select(file_repository_factory, file_bindings):
     assert len(results) == 1
 
     results = file_bindings.RepositoriesFileApi.list(
+        pulp_label_select=f"{key1}=production|staging"
+    ).results
+    assert len(results) == 2
+
+    results = file_bindings.RepositoriesFileApi.list(
+        pulp_label_select=f"{key1}=production|staging,{key2}=true"
+    ).results
+    assert len(results) == 1
+
+    results = file_bindings.RepositoriesFileApi.list(
         pulp_label_select=f"{key1}=production,{key2}!=false"
     ).results
     assert len(results) == 1

--- a/pulpcore/app/viewsets/custom_filters.py
+++ b/pulpcore/app/viewsets/custom_filters.py
@@ -283,7 +283,13 @@ class LabelFilter(Filter):
     """Filter to get resources that match a label filter string."""
 
     def __init__(self, *args, **kwargs):
-        kwargs.setdefault("help_text", _("Filter labels by search string"))
+        kwargs.setdefault(
+            "help_text",
+            _(
+                "Filter labels by search string. Separate terms with ',' for AND and "
+                "'|' for OR alternatives within a term."
+            ),
+        )
         if "label_field_name" in kwargs:
             self.label_field_name = kwargs.pop("label_field_name")
         else:
@@ -312,30 +318,51 @@ class LabelFilter(Filter):
             return qs
 
         for term in value.split(","):
-            match = re.match(rf"(!?{LABEL_KEY_CHARS}+)(=|!=|~)?(.*)?", term)
-            if not match:
-                raise DRFValidationError(_("Invalid search term: '{}'.").format(term))
-            key, op, val = match.groups()
-
-            if key.startswith("!") and op:
-                raise DRFValidationError(_("Cannot use an operator with '{}'.").format(key))
-
-            if op == "=":
-                qs = qs.filter(**{f"{field_name}__contains": {key: val}})
-            elif op == "!=":
-                qs = qs.filter(**{f"{field_name}__has_key": key}).exclude(
-                    **{f"{field_name}__contains": {key: val}}
-                )
-            elif op == "~":
-                qs = qs.filter(**{f"{field_name}__{key}__icontains": val})
-            else:
-                # 'foo', '!foo'
-                if key.startswith("!"):
-                    qs = qs.exclude(**{f"{field_name}__has_key": key[1:]})
-                else:
-                    qs = qs.filter(**{f"{field_name}__has_key": key})
+            qs = qs.filter(self._term_to_q(field_name, term))
 
         return qs
+
+    def _term_to_q(self, field_name, term):
+        """Convert a comma-separated label term into a query expression."""
+
+        expression = Q()
+        key = op = None
+        for part in term.split("|"):
+            parsed_key, parsed_op, val = self._parse_term_part(part, term)
+            if parsed_op is None and op:
+                # Allow the compact form "key=value1|value2" by treating
+                # operator-free alternatives as additional values.
+                parsed_key, parsed_op, val = key, op, parsed_key
+
+            key, op = parsed_key, parsed_op
+            expression |= self._part_to_q(field_name, parsed_key, parsed_op, val)
+        return expression
+
+    def _parse_term_part(self, part, term):
+        match = re.fullmatch(rf"(!?{LABEL_KEY_CHARS}+)(=|!=|~)?(.*)?", part)
+        if not match:
+            raise DRFValidationError(_("Invalid search term: '{}'.").format(term))
+
+        key, op, val = match.groups()
+        if key.startswith("!") and op:
+            raise DRFValidationError(_("Cannot use an operator with '{}'.").format(key))
+        return key, op, val
+
+    def _part_to_q(self, field_name, key, op, val):
+        if op == "=":
+            return Q(**{f"{field_name}__contains": {key: val}})
+        elif op == "!=":
+            return Q(**{f"{field_name}__has_key": key}) & ~Q(
+                **{f"{field_name}__contains": {key: val}}
+            )
+        elif op == "~":
+            return Q(**{f"{field_name}__{key}__icontains": val})
+        else:
+            # 'foo', '!foo'
+            if key.startswith("!"):
+                return ~Q(**{f"{field_name}__has_key": key[1:]})
+            else:
+                return Q(**{f"{field_name}__has_key": key})
 
 
 class WithContentFilter(Filter):


### PR DESCRIPTION
## Summary
- add pipe-separated OR alternatives within `pulp_label_select` terms
- keep comma-separated terms as AND
- document the new label filter syntax and add functional coverage

Refs #7435

## Verification
- `uvx ruff check pulpcore/app/viewsets/custom_filters.py pulp_file/tests/functional/api/test_labels.py`
- `/Users/viraat/.local/share/uv/python/cpython-3.11-macos-aarch64-none/bin/python3.11 -m compileall pulpcore/app/viewsets/custom_filters.py`
- `git diff --check`

I also attempted `uv run --python 3.11 --with pytest --with pytest-django --with-editable . pytest pulp_file/tests/functional/api/test_labels.py -k test_label_select -q`, but this local checkout cannot collect functional tests because generated `pulpcore.client` bindings are not present.

## AI Usage
Generated by Libra Issues / Codex and reviewed before submission.