### PR TITLE
[AAP-73644 ] Fix `adjust_roles` to use `update_or_create` for LOCKED_ROLES

### DIFF
--- a/CHANGES/+fix-role-race-condition.bugfix
+++ b/CHANGES/+fix-role-race-condition.bugfix
@@ -1,0 +1,1 @@
+Fixed `adjust_roles` to use `update_or_create` instead of `get_or_create` when populating locked roles, so that a pre-existing role with `locked=False` is updated rather than causing a duplicate key error.

--- a/pulpcore/app/apps.py
+++ b/pulpcore/app/apps.py
@@ -396,11 +396,9 @@ def adjust_roles(apps, role_prefix, desired_roles, verbosity=1):
                 _("Locked role definition for {name} is incompatible.").format(name=name)
             )
         permissions = [_get_permission(perm) for perm in permissions]
-        role, created = Role.objects.get_or_create(
-            name=name, locked=True, defaults={"name": name, "locked": True}
+        role, created = Role.objects.update_or_create(
+            name=name, defaults={"name": name, "locked": True, "description": description}
         )
-        role.description = description
-        role.save()
         role.permissions.set(permissions)
 
 

--- a/pulpcore/tests/unit/roles/test_adjust_roles.py
+++ b/pulpcore/tests/unit/roles/test_adjust_roles.py
@@ -1,0 +1,102 @@
+import pytest
+from django.apps import apps
+
+from pulpcore.app.apps import adjust_roles
+from pulpcore.app.models.role import Role
+
+ROLE_PREFIX = "core."
+VIEW_REPO_PERM = "core.view_repository"
+CHANGE_REPO_PERM = "core.change_repository"
+
+
+@pytest.fixture(autouse=True)
+def _cleanup_test_roles(db):
+    yield
+    Role.objects.filter(name__startswith=ROLE_PREFIX + "test_").delete()
+
+
+def test_creates_new_locked_role(db):
+    desired = {
+        "core.test_viewer": {
+            "description": "Can view repositories",
+            "permissions": [VIEW_REPO_PERM],
+        }
+    }
+    adjust_roles(apps, ROLE_PREFIX, desired, verbosity=0)
+
+    role = Role.objects.get(name="core.test_viewer")
+    assert role.locked is True
+    assert role.description == "Can view repositories"
+    assert role.permissions.filter(codename="view_repository").exists()
+
+
+def test_updates_unlocked_role_to_locked(db):
+    """Core scenario from AAP-73644: a role pre-created with locked=False
+    must be updated to locked=True instead of raising UniqueViolation."""
+    Role.objects.create(name="core.test_viewer", locked=False)
+
+    desired = {
+        "core.test_viewer": {
+            "description": "Can view repositories",
+            "permissions": [VIEW_REPO_PERM],
+        }
+    }
+    adjust_roles(apps, ROLE_PREFIX, desired, verbosity=0)
+
+    role = Role.objects.get(name="core.test_viewer")
+    assert role.locked is True
+    assert role.description == "Can view repositories"
+
+
+def test_idempotent(db):
+    desired = {
+        "core.test_viewer": {
+            "description": "Can view repositories",
+            "permissions": [VIEW_REPO_PERM],
+        }
+    }
+    adjust_roles(apps, ROLE_PREFIX, desired, verbosity=0)
+    adjust_roles(apps, ROLE_PREFIX, desired, verbosity=0)
+
+    assert Role.objects.filter(name="core.test_viewer").count() == 1
+    role = Role.objects.get(name="core.test_viewer")
+    assert role.locked is True
+    assert role.description == "Can view repositories"
+
+
+def test_updates_description(db):
+    Role.objects.create(name="core.test_viewer", locked=True, description="Old description")
+
+    desired = {
+        "core.test_viewer": {
+            "description": "New description",
+            "permissions": [VIEW_REPO_PERM],
+        }
+    }
+    adjust_roles(apps, ROLE_PREFIX, desired, verbosity=0)
+
+    role = Role.objects.get(name="core.test_viewer")
+    assert role.description == "New description"
+
+
+def test_removes_obsolete_locked_roles(db):
+    Role.objects.create(name="core.test_obsolete", locked=True)
+
+    desired = {
+        "core.test_viewer": [VIEW_REPO_PERM],
+    }
+    adjust_roles(apps, ROLE_PREFIX, desired, verbosity=0)
+
+    assert not Role.objects.filter(name="core.test_obsolete").exists()
+    assert Role.objects.filter(name="core.test_viewer").exists()
+
+
+def test_preserves_unlocked_roles_on_cleanup(db):
+    Role.objects.create(name="core.test_custom", locked=False)
+
+    desired = {
+        "core.test_viewer": [VIEW_REPO_PERM],
+    }
+    adjust_roles(apps, ROLE_PREFIX, desired, verbosity=0)
+
+    assert Role.objects.filter(name="core.test_custom").exists()


### PR DESCRIPTION
Fixes: [AAP-73644 ](https://redhat.atlassian.net/browse/AAP-73644)

Hub `pulpcore-manager migrate` fails with `sycopg.errors.UniqueViolation: duplicate key value violates unique constraint "core_role_name_key"` when locked roles already exist in the database with `locked=False`. This happens because `get_or_create` looks up by both name and `locked=True`, misses the existing role, and then tries to insert a duplicate.

### How to reproduce locally
1. Start a clean Hub environment and run migrations so all roles are created normally
2. `pulpcore-manager shell_plus`
3. Set the role's locked flag to False to simulate the race condition:
```  
role = Role.objects.get(name="ansible.ansiblerepository_creator")
role.locked = False
role.save()
```
4.  `pulpcore-manager migrate`
6. It crashes with the `UniqueViolation` above because get_or_create(name=..., locked=True) doesn't find
  the existing role (it has locked=False) and tries to insert a duplicate. The crash happens in pulpcore/app/apps.py during the post_migrate signal when adjust_roles runs.


### Fix
Switched to `update_or_create` with lookup by name only so that existing roles get corrected `locked=True` instead of crashing.

### 📜 Checklist

- [x] Commits are cleanly separated with meaningful messages (simple features and bug fixes should be [squashed](https://pulpproject.org/pulpcore/docs/dev/guides/git/#rebasing-and-squashing) to one commit)
- [x] A [changelog entry](https://pulpproject.org/pulpcore/docs/dev/guides/git/#changelog-update) or entries has been added for any significant changes
- [x] Follows the [Pulp policy on AI Usage](https://pulpproject.org/help/more/governance/ai_policy/)
- [ ] (For new features) - User documentation and test coverage has been added

See: [Pull Request Walkthrough](https://pulpproject.org/pulpcore/docs/dev/guides/pull-request-walkthrough/)


