### PR TITLE
Expose `cancel_task` and `cancel_task_group` in pulpcore.plugin API

### DIFF
--- a/CHANGES/plugin_api/+expose-cancel-task.feature
+++ b/CHANGES/plugin_api/+expose-cancel-task.feature
@@ -1,0 +1,1 @@
+Exposed ``cancel_task`` and ``cancel_task_group`` from ``pulpcore.plugin.tasking`` so plugins can import them.

--- a/pulpcore/plugin/tasking.py
+++ b/pulpcore/plugin/tasking.py
@@ -12,10 +12,12 @@ from pulpcore.app.tasks import (
 )
 from pulpcore.app.tasks.repository import aadd_and_remove, add_and_remove
 from pulpcore.app.tasks.vulnerability_report import check_content
-from pulpcore.tasking.tasks import adispatch, dispatch
+from pulpcore.tasking.tasks import adispatch, cancel_task, cancel_task_group, dispatch
 
 __all__ = [
     "ageneral_update",
+    "cancel_task",
+    "cancel_task_group",
     "check_content",
     "dispatch",
     "adispatch",


### PR DESCRIPTION
Expose `cancel_task` and `cancel_task_group` in `pulpcore.plugin.tasking` so plugins can import it directly from the public API (`from pulpcore.plugin.tasking import cancel_task, cancel_task_group`) instead of reaching into the `pulpcore.tasking` module directly. 

<!---
Thank you for submitting a PR to the Pulp Project!

If this is your first time contributing, please read the Pull Request Walkthrough documentation
(https://pulpproject.org/pulpcore/docs/dev/guides/pull-request-walkthrough/).
-->

### 📜 Checklist

- [x] Commits are cleanly separated with meaningful messages (simple features and bug fixes should be [squashed](https://pulpproject.org/pulpcore/docs/dev/guides/git/#rebasing-and-squashing) to one commit)
- [x] A [changelog entry](https://pulpproject.org/pulpcore/docs/dev/guides/git/#changelog-update) or entries has been added for any significant changes
- [x] Follows the [Pulp policy on AI Usage](https://pulpproject.org/help/more/governance/ai_policy/)
- [ ] (For new features) - User documentation and test coverage has been added

See: [Pull Request Walkthrough](https://pulpproject.org/pulpcore/docs/dev/guides/pull-request-walkthrough/)
