### PR TITLE
Dependabot: Add one week cooldown

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,6 +5,8 @@ updates:
   schedule:
     interval: daily
   open-pull-requests-limit: 10
+  cooldown:
+    default-days: 7
   groups:
     otel:
       patterns:


### PR DESCRIPTION
More info about cooldowns and reasoning behind using them: https://blog.yossarian.net/2025/11/21/We-should-all-be-using-dependency-cooldowns