### PR TITLE
Use ThreadedResolver to honor /etc/hosts and nsswitch.conf

### DIFF
--- a/.ci/assets/ci_constraints.txt
+++ b/.ci/assets/ci_constraints.txt
@@ -15,5 +15,3 @@ azure-storage-blob!=12.28.*
 # Apparently does not work with current azurite.
 
 
-pycares<5
-# older aiodns versions don't pin pycares UB, and are broken by pycares>=5

--- a/pulpcore/download/factory.py
+++ b/pulpcore/download/factory.py
@@ -144,7 +144,13 @@ class DownloaderFactory:
         # I don't see why...
         # https://github.com/aio-libs/aiohttp/pull/3372
         return aiohttp.ClientSession(
-            connector=aiohttp.TCPConnector(loop=asyncio.get_event_loop(), **tcp_conn_opts),
+            # ThreadedResolver uses getaddrinfo() which honors /etc/hosts and nsswitch.conf;
+            # the default AsyncResolver (c-ares) bypasses the system resolver entirely.
+            connector=aiohttp.TCPConnector(
+                loop=asyncio.get_event_loop(),
+                resolver=aiohttp.resolver.ThreadedResolver(loop=asyncio.get_event_loop()),
+                **tcp_conn_opts,
+            ),
             timeout=timeout,
             headers=headers,
             requote_redirect_url=False,

--- a/pulpcore/download/http.py
+++ b/pulpcore/download/http.py
@@ -161,7 +161,9 @@ class HttpDownloader(BaseDownloader):
             self._close_session_on_finalize = False
         else:
             timeout = aiohttp.ClientTimeout(total=None, sock_connect=600, sock_read=600)
-            conn = aiohttp.TCPConnector()
+            # ThreadedResolver uses getaddrinfo() which honors /etc/hosts and nsswitch.conf;
+            # the default AsyncResolver (c-ares) bypasses the system resolver entirely.
+            conn = aiohttp.TCPConnector(resolver=aiohttp.resolver.ThreadedResolver())
             self.session = aiohttp.ClientSession(
                 connector=conn, timeout=timeout, headers=headers, requote_redirect_url=False
             )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,6 @@ classifiers=[
 ]
 requires-python = ">=3.11"
 dependencies = [
-  "aiodns>=3.3.0,<3.7",  # Looks like only bugfixes in z-Stream.
   "aiofiles>=22.1,<=25.1.0",  # Uses sort of CalVer, luckily not released often https://github.com/Tinche/aiofiles/issues/144 .
   "aiohttp>=3.10.10,<3.15",  # SemVer https://docs.aiohttp.org/en/stable/faq.html#what-is-the-api-stability-and-deprecation-policy .
   "asyncio-throttle>=1.0,<=1.0.2",  # Unsure about versioning, but not released often anyway.


### PR DESCRIPTION
Pulpcore depended on aiodns, which causes aiohttp to default to AsyncResolver (c-ares) for DNS resolution. c-ares is a DNS client that speaks the wire protocol directly -- it does not go through glibc's getaddrinfo() and therefore ignores nsswitch.conf and /etc/hosts. This causes sync to fail when the remote hostname is only resolvable via /etc/hosts or other non-DNS nsswitch sources.

Explicitly use aiohttp.resolver.ThreadedResolver, which wraps socket.getaddrinfo() in a thread pool. Since getaddrinfo() uses the system resolver, it respects nsswitch.conf ordering and reads /etc/hosts when configured.

The performance difference is negligible for Pulp's use case: DNS resolution happens once per host (aiohttp caches resolved addresses on the connector), and syncs typically talk to a small number of distinct hosts.

Since we now bypass c-ares entirely, drop the aiodns dependency and the related pycares version constraint from CI.

<!---
Thank you for submitting a PR to the Pulp Project!

If this is your first time contributing, please read the Pull Request Walkthrough documentation
(https://pulpproject.org/pulpcore/docs/dev/guides/pull-request-walkthrough/).
-->

### 📜 Checklist

- [ ] Commits are cleanly separated with meaningful messages (simple features and bug fixes should be [squashed](https://pulpproject.org/pulpcore/docs/dev/guides/git/#rebasing-and-squashing) to one commit)
- [ ] A [changelog entry](https://pulpproject.org/pulpcore/docs/dev/guides/git/#changelog-update) or entries has been added for any significant changes
- [ ] Follows the [Pulp policy on AI Usage](https://pulpproject.org/help/more/governance/ai_policy/)
- [ ] (For new features) - User documentation and test coverage has been added

See: [Pull Request Walkthrough](https://pulpproject.org/pulpcore/docs/dev/guides/pull-request-walkthrough/)
