### PR TITLE
Drop Support for Django4

### DIFF
--- a/CHANGES/7343.removal
+++ b/CHANGES/7343.removal
@@ -1,0 +1,1 @@
+Drop support for running with Django 4.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,9 +31,9 @@ dependencies = [
   "backoff>=2.1.2,<2.3",  # Looks like only bugfixes in z-Stream.
   "click>=8.1.0,<8.5",  # Uses milestone.feature.fix https://palletsprojects.com/versions .
   "cryptography>=44.0.3,<49.0",  # SemVer compatible https://cryptography.io/en/latest/api-stability/#versioning .
-  "Django>=4.2.24,<5.3, !=5.0, !=5.1",  # LTS version, switch only if we have a compelling reason to".
-  "django-filter>=23.1,<=25.2",  # Uses CalVer, not released often https://github.com/carltongibson/django-filter
-  "django-guid>=3.3.0,<3.7",  # Looks like only bugfixes in z-Stream.
+  "Django>=5.2.0,<5.3",  # LTS version, we aim at supporting one or two at a time.
+  "django-filter>=24.3,<=25.2",  # Uses CalVer, not released often https://github.com/carltongibson/django-filter
+  "django-guid>=3.4.0,<3.7",  # Looks like only bugfixes in z-Stream.
   "django-import-export>=2.9,<5.0",
   "django-lifecycle>=1.0,<=1.2.7",
   "djangorestframework>=3.14.0,<=3.17.1",


### PR DESCRIPTION
This should pave the way to start looking into Django6.

Fixes #7343

<!---
Thank you for submitting a PR to the Pulp Project!

If this is your first time contributing, please read the Pull Request Walkthrough documentation
(https://pulpproject.org/pulpcore/docs/dev/guides/pull-request-walkthrough/).
-->

### 📜 Checklist

- [ ] Commits are cleanly separated with meaningful messages (simple features and bug fixes should be [squashed](https://pulpproject.org/pulpcore/docs/dev/guides/git/#rebasing-and-squashing) to one commit)
- [ ] A [changelog entry](https://pulpproject.org/pulpcore/docs/dev/guides/git/#changelog-update) or entries has been added for any significant changes
- [ ] Follows the [Pulp policy on AI Usage](https://pulpproject.org/help/more/governance/ai_policy/)
- [ ] (For new features) - User documentation and test coverage has been added

See: [Pull Request Walkthrough](https://pulpproject.org/pulpcore/docs/dev/guides/pull-request-walkthrough/)
