### PR TITLE
Allow commas in pulp_labels values

### DIFF
--- a/CHANGES/7789.feature
+++ b/CHANGES/7789.feature
@@ -1,0 +1,2 @@
+Allow commas in `pulp_labels` values. To filter for labels containing commas, escape them
+with a backslash (e.g. `?pulp_label_select=key=val\,ue`).

--- a/pulp_file/tests/functional/api/test_labels.py
+++ b/pulp_file/tests/functional/api/test_labels.py
@@ -118,8 +118,56 @@ def test_invalid_labels(file_repository_factory):
     assert e_info.value.status == 400
 
     with pytest.raises(ApiException) as e_info:
-        file_repository_factory(name=str(uuid4()), pulp_labels={"arda": "eru,illuvata"})
+        file_repository_factory(name=str(uuid4()), pulp_labels={"arda": "eru(illuvata)"})
     assert e_info.value.status == 400
+
+
+@pytest.mark.parallel
+def test_labels_with_commas(file_repository_factory, file_bindings, monitor_task):
+    """Test that label values can contain commas."""
+    labels = {"signed_by": "release4,release2"}
+    file_repo = file_repository_factory(name=str(uuid4()), pulp_labels=labels)
+    assert file_repo.pulp_labels == labels
+
+    labels["signed_by"] = "a,b,c"
+    monitor_task(
+        file_bindings.RepositoriesFileApi.partial_update(
+            file_repo.pulp_href, {"pulp_labels": labels}
+        ).task
+    )
+    file_repo = file_bindings.RepositoriesFileApi.read(file_repo.pulp_href)
+    assert file_repo.pulp_labels == labels
+
+
+@pytest.mark.parallel
+def test_label_select_with_commas(file_repository_factory, file_bindings):
+    """Test filtering labels whose values contain commas using backslash-escaped commas."""
+    key = str(uuid4()).replace("-", "")
+
+    file_repository_factory(name=str(uuid4()), pulp_labels={key: "release4,release2"})
+    file_repository_factory(name=str(uuid4()), pulp_labels={key: "release4"})
+
+    # Escaped comma in value matches the label with a comma
+    results = file_bindings.RepositoriesFileApi.list(
+        pulp_label_select=f"{key}=release4\\,release2"
+    ).results
+    assert len(results) == 1
+    assert results[0].pulp_labels[key] == "release4,release2"
+
+    # Unescaped comma is still treated as a filter term separator
+    results = file_bindings.RepositoriesFileApi.list(pulp_label_select=f"{key}=release4").results
+    assert len(results) == 1
+    assert results[0].pulp_labels[key] == "release4"
+
+    # Escaped comma value combined with a second filter term
+    key2 = str(uuid4()).replace("-", "")
+    file_repository_factory(name=str(uuid4()), pulp_labels={key: "release4,release2", key2: "true"})
+    results = file_bindings.RepositoriesFileApi.list(
+        pulp_label_select=f"{key}=release4\\,release2,{key2}=true"
+    ).results
+    assert len(results) == 1
+    assert results[0].pulp_labels[key] == "release4,release2"
+    assert results[0].pulp_labels[key2] == "true"
 
 
 # Label Filtering

--- a/pulpcore/app/serializers/fields.py
+++ b/pulpcore/app/serializers/fields.py
@@ -435,9 +435,9 @@ def pulp_labels_validator(value):
                     " spaces, hyphens, and dots are allowed."
                 ).format(k)
             )
-        if v is not None and re.search(r"[,()]", v):
+        if v is not None and re.search(r"[()]", v):
             raise serializers.ValidationError(
-                _("Key '{}' contains value with comma or parenthesis.").format(k)
+                _("Key '{}' contains value with parenthesis.").format(k)
             )
 
     return value

--- a/pulpcore/app/viewsets/custom_filters.py
+++ b/pulpcore/app/viewsets/custom_filters.py
@@ -311,11 +311,13 @@ class LabelFilter(Filter):
             # user didn't supply a value
             return qs
 
-        for term in value.split(","):
+        for term in re.split(r"(?<!\\),", value):
             match = re.match(rf"(!?{LABEL_KEY_CHARS}+)(=|!=|~)?(.*)?", term)
             if not match:
                 raise DRFValidationError(_("Invalid search term: '{}'.").format(term))
             key, op, val = match.groups()
+            if val is not None:
+                val = val.replace("\\,", ",")
 
             if key.startswith("!") and op:
                 raise DRFValidationError(_("Cannot use an operator with '{}'.").format(key))

--- a/pulpcore/tests/unit/serializers/test_fields.py
+++ b/pulpcore/tests/unit/serializers/test_fields.py
@@ -20,6 +20,8 @@ from pulpcore.app.serializers.fields import (
         pytest.param({"my key": "value"}, id="spaced-key"),
         pytest.param({"my-dotted.key": "value"}, id="dotted-dash-key"),
         pytest.param({"spaced key-with.mixed_chars": "value"}, id="all-key"),
+        pytest.param({"key": "val,ue"}, id="comma-value"),
+        pytest.param({"key": "a,b,c"}, id="multiple-commas-value"),
     ],
 )
 def test_pulp_labels_validator_valid(labels):
@@ -31,7 +33,6 @@ def test_pulp_labels_validator_valid(labels):
 @pytest.mark.parametrize(
     "labels",
     [
-        pytest.param({"key": "val,ue"}, id="comma-value"),
         pytest.param({"key": "val(ue"}, id="open-parenthesis-value"),
         pytest.param({"key": "val)ue"}, id="close-parenthesis-value"),
         pytest.param({"bad!key": "value"}, id="exclamation-key"),


### PR DESCRIPTION
The label validator now permits commas in values, and the LabelFilter splits only on unescaped commas so that backslash-escaped commas in filter queries (e.g. ?pulp_label_select=key=val\,ue) match literal comma values.

closes #7789
Assisted-By: Claude Opus 4.6

<!---
Thank you for submitting a PR to the Pulp Project!

If this is your first time contributing, please read the Pull Request Walkthrough documentation
(https://pulpproject.org/pulpcore/docs/dev/guides/pull-request-walkthrough/).
-->

### 📜 Checklist

- [x] Commits are cleanly separated with meaningful messages (simple features and bug fixes should be [squashed](https://pulpproject.org/pulpcore/docs/dev/guides/git/#rebasing-and-squashing) to one commit)
- [x] A [changelog entry](https://pulpproject.org/pulpcore/docs/dev/guides/git/#changelog-update) or entries has been added for any significant changes
- [x] Follows the [Pulp policy on AI Usage](https://pulpproject.org/help/more/governance/ai_policy/)
- [ ] (For new features) - User documentation and test coverage has been added

See: [Pull Request Walkthrough](https://pulpproject.org/pulpcore/docs/dev/guides/pull-request-walkthrough/)
