### PR TITLE
Fix race condition inside SingleArtifactContentUploadSerializer

### DIFF
--- a/CHANGES/+concurrent-artifact-file-reuse.bugfix
+++ b/CHANGES/+concurrent-artifact-file-reuse.bugfix
@@ -1,0 +1,1 @@
+Fixed a race condition when creating content with `file_url` or `upload` that could result in a duplicate artifact error.

--- a/pulpcore/plugin/serializers/content.py
+++ b/pulpcore/plugin/serializers/content.py
@@ -3,7 +3,7 @@ from gettext import gettext as _
 from tempfile import NamedTemporaryFile
 from urllib.parse import urlparse
 
-from django.db import DatabaseError
+from django.db import DatabaseError, IntegrityError
 from rest_framework.serializers import (
     CharField,
     FileField,
@@ -14,7 +14,6 @@ from rest_framework.serializers import (
 from pulpcore.app.files import PulpTemporaryUploadedFile
 from pulpcore.app.models import Artifact, PulpTemporaryFile, Remote, Upload, UploadChunk
 from pulpcore.app.serializers import (
-    ArtifactSerializer,
     NoArtifactContentSerializer,
     RelatedField,
     SingleArtifactContentSerializer,
@@ -259,8 +258,7 @@ class SingleArtifactContentUploadSerializer(
             # if artifact already exists, let's use it
             try:
                 artifact = Artifact.objects.get(
-                    sha256=file.hashers["sha256"].hexdigest(),
-                    pulp_domain=get_domain_pk(),
+                    sha256=file.hashers["sha256"].hexdigest(), pulp_domain=get_domain_pk()
                 )
                 if not artifact.pulp_domain.get_storage().exists(artifact.file.name):
                     artifact.file = file
@@ -268,10 +266,13 @@ class SingleArtifactContentUploadSerializer(
                 else:
                     artifact.touch()
             except (Artifact.DoesNotExist, DatabaseError):
-                artifact_data = {"file": file}
-                serializer = ArtifactSerializer(data=artifact_data)
-                serializer.is_valid(raise_exception=True)
-                artifact = serializer.save()
+                artifact = Artifact.init_and_validate(file)
+                try:
+                    artifact.save()
+                except IntegrityError:
+                    artifact = Artifact.objects.get(
+                        sha256=artifact.sha256, pulp_domain=get_domain_pk()
+                    )
             data["artifact"] = artifact
         return data
 


### PR DESCRIPTION
The serializer approach runs into the issue of the UniqueValidator sometimes throwing an exception if we try to save a new artifact, but it was created concurrently inbetween our first retrieval and the new save. Not sure why we were using a serializer in the first place (maybe I'm missing something?), but just copy-paste the database pattern we use elsewhere should handle it.


### 📜 Checklist

- [ ] Commits are cleanly separated with meaningful messages (simple features and bug fixes should be [squashed](https://pulpproject.org/pulpcore/docs/dev/guides/git/#rebasing-and-squashing) to one commit)
- [ ] A [changelog entry](https://pulpproject.org/pulpcore/docs/dev/guides/git/#changelog-update) or entries has been added for any significant changes
- [ ] Follows the [Pulp policy on AI Usage](https://pulpproject.org/help/more/governance/ai_policy/)
- [ ] (For new features) - User documentation and test coverage has been added

See: [Pull Request Walkthrough](https://pulpproject.org/pulpcore/docs/dev/guides/pull-request-walkthrough/)
