### PR TITLE
Expose opt-in content_ids on repository version detail

### DIFF
--- a/CHANGES/7831.feature
+++ b/CHANGES/7831.feature
@@ -1,0 +1,1 @@
+Added an opt-in ``content_ids`` field to the repository version detail, returning the list of content unit UUIDs in the version when the request includes the ``content_ids=true`` query parameter. This lets clients diff content sets between versions directly instead of issuing expensive content filter queries.

--- a/pulpcore/app/serializers/repository.py
+++ b/pulpcore/app/serializers/repository.py
@@ -291,9 +291,25 @@ class RepositoryVersionSerializer(ModelSerializer, NestedHyperlinkedModelSeriali
     vuln_report = serializers.SerializerMethodField(
         read_only=True,
     )
+    content_ids = serializers.SerializerMethodField(
+        help_text=_(
+            "The list of content unit UUIDs in this version. Only returned when the request "
+            "includes the 'content_ids=true' query parameter; otherwise null."
+        ),
+        read_only=True,
+    )
 
     def get_vuln_report(self, object):
         return f"{reverse('vuln_report-list')}?repo_versions={get_prn(object)}"
+
+    def get_content_ids(self, object):
+        request = self.context.get("request")
+        if request is None:
+            return None
+        value = request.query_params.get("content_ids")
+        if value is None or value.lower() not in ("true", "1", "yes"):
+            return None
+        return object.content_ids
 
     class Meta:
         model = models.RepositoryVersion
@@ -304,6 +320,7 @@ class RepositoryVersionSerializer(ModelSerializer, NestedHyperlinkedModelSeriali
             "base_version",
             "content_summary",
             "vuln_report",
+            "content_ids",
         )
 
 

--- a/pulpcore/tests/unit/serializers/test_repository.py
+++ b/pulpcore/tests/unit/serializers/test_repository.py
@@ -1,5 +1,6 @@
 from types import SimpleNamespace
 from unittest.mock import Mock
+from uuid import uuid4
 
 import pytest
 from rest_framework import serializers
@@ -10,6 +11,7 @@ from pulpcore.app.serializers import (
     PublicationSerializer,
     RemoteSerializer,
     RepositorySyncURLSerializer,
+    RepositoryVersionSerializer,
     ValidateFieldsMixin,
 )
 
@@ -265,3 +267,36 @@ def test_create_remote_with_invalid_parameter():
     serializer = RemoteSerializer(data=data)
     with pytest.raises(serializers.ValidationError, match="Unexpected field"):
         serializer.validate(data)
+
+
+def _content_ids_serializer(query_params=None):
+    """Build a RepositoryVersionSerializer with an optional fake request in its context."""
+    context = {}
+    if query_params is not None:
+        context["request"] = SimpleNamespace(query_params=query_params)
+    return RepositoryVersionSerializer(context=context)
+
+
+def test_get_content_ids_omitted_without_request():
+    """content_ids is null when there is no request in the serializer context."""
+    obj = SimpleNamespace(content_ids=[uuid4()])
+    serializer = _content_ids_serializer()
+    assert serializer.get_content_ids(obj) is None
+
+
+@pytest.mark.parametrize("value", [None, "", "false", "0", "no", "False"])
+def test_get_content_ids_omitted_when_not_requested(value):
+    """content_ids is null unless the request explicitly opts in via the query parameter."""
+    query_params = {} if value is None else {"content_ids": value}
+    obj = SimpleNamespace(content_ids=[uuid4()])
+    serializer = _content_ids_serializer(query_params=query_params)
+    assert serializer.get_content_ids(obj) is None
+
+
+@pytest.mark.parametrize("value", ["true", "True", "TRUE", "1", "yes"])
+def test_get_content_ids_returned_when_requested(value):
+    """content_ids returns the version's UUIDs when the request opts in."""
+    content_ids = [uuid4(), uuid4()]
+    obj = SimpleNamespace(content_ids=content_ids)
+    serializer = _content_ids_serializer(query_params={"content_ids": value})
+    assert serializer.get_content_ids(obj) == content_ids


### PR DESCRIPTION
Add a content_ids SerializerMethodField to RepositoryVersionSerializer that returns the version's content unit UUIDs only when the request includes the content_ids=true query parameter (null otherwise). This lets clients diff content sets between versions directly instead of issuing expensive content filter queries.

Closes #7831

Assisted by: Claude Opus 4.8

<!---
Thank you for submitting a PR to the Pulp Project!

If this is your first time contributing, please read the Pull Request Walkthrough documentation
(https://pulpproject.org/pulpcore/docs/dev/guides/pull-request-walkthrough/).
-->

### 📜 Checklist

- [x] Commits are cleanly separated with meaningful messages (simple features and bug fixes should be [squashed](https://pulpproject.org/pulpcore/docs/dev/guides/git/#rebasing-and-squashing) to one commit)
- [x] A [changelog entry](https://pulpproject.org/pulpcore/docs/dev/guides/git/#changelog-update) or entries has been added for any significant changes
- [x] Follows the [Pulp policy on AI Usage](https://pulpproject.org/help/more/governance/ai_policy/)
- [x] (For new features) - User documentation and test coverage has been added

See: [Pull Request Walkthrough](https://pulpproject.org/pulpcore/docs/dev/guides/pull-request-walkthrough/)
