### PR TITLE
Fix changelog formating

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -424,7 +424,6 @@ No significant changes.
 
 - Added option to `pulpcore-content` and `pulpcore-api` to configure the gunicorn control socket path.
   The default path could cause permission errors on certain deployments setups.
-
   This feature was added in gunicorn>=25.1 and is ignored for lower version.
   [#7574](https://github.com/pulp/pulpcore/issues/7574)
 - Optimized cleanup_old_versions() by rewriting protected_versions() to avoid expensive JOINs


### PR DESCRIPTION
Every now and then a changelog entry wants to be extra helpful by introducing paragraphs. This breaks the formatting of Markdown lists.

<!---
Thank you for submitting a PR to the Pulp Project!

If this is your first time contributing, please read the Pull Request Walkthrough documentation
(https://pulpproject.org/pulpcore/docs/dev/guides/pull-request-walkthrough/).
-->

### 📜 Checklist

- [ ] Commits are cleanly separated with meaningful messages (simple features and bug fixes should be [squashed](https://pulpproject.org/pulpcore/docs/dev/guides/git/#rebasing-and-squashing) to one commit)
- [ ] A [changelog entry](https://pulpproject.org/pulpcore/docs/dev/guides/git/#changelog-update) or entries has been added for any significant changes
- [ ] Follows the [Pulp policy on AI Usage](https://pulpproject.org/help/more/governance/ai_policy/)
- [ ] (For new features) - User documentation and test coverage has been added

See: [Pull Request Walkthrough](https://pulpproject.org/pulpcore/docs/dev/guides/pull-request-walkthrough/)
