### PR TITLE
Fix RepositoryVersion.remove_content using wrong queryset for lazy co…

### DIFF
--- a/CHANGES/7851.bugfix
+++ b/CHANGES/7851.bugfix
@@ -1,0 +1,1 @@
+Fixed `RepositoryVersion.remove_content` failing when the queryset is derived from `self.content` and the repository version contains >= 65,535 content items. The lazy queryset was re-evaluated after `content_ids` was already updated, causing `RepositoryContent` entries to be left orphaned.

--- a/pulpcore/app/models/repository.py
+++ b/pulpcore/app/models/repository.py
@@ -1223,10 +1223,6 @@ class RepositoryVersion(BaseModel):
         content_ids = set(self.content_ids)
         to_remove = set(content.values_list("pk", flat=True))
         with transaction.atomic():
-            if to_remove:
-                self.content_ids = list(content_ids - to_remove)
-                self.save()
-
             # Normalize representation if content has already been added in this version.
             # Undo addition by deleting the RepositoryContent.
             RepositoryContent.objects.filter(
@@ -1240,6 +1236,10 @@ class RepositoryVersion(BaseModel):
                 repository=self.repository, content_id__in=content, version_removed=None
             )
             q_set.update(version_removed=self)
+
+            if to_remove:
+                self.content_ids = list(content_ids - to_remove)
+                self.save()
 
     def set_content(self, content):
         """


### PR DESCRIPTION
…ntent

The remove_content method was incorrectly using the unfiltered `content` queryset instead of `to_remove` when deleting or marking RepositoryContent entries as removed. This caused all content to be removed from the repository version rather than only the specified lazy content.

Fixes: https://github.com/pulp/pulpcore/issues/7851

<!---
Thank you for submitting a PR to the Pulp Project!

If this is your first time contributing, please read the Pull Request Walkthrough documentation
(https://pulpproject.org/pulpcore/docs/dev/guides/pull-request-walkthrough/).
-->

### 📜 Checklist

- [ ] Commits are cleanly separated with meaningful messages (simple features and bug fixes should be [squashed](https://pulpproject.org/pulpcore/docs/dev/guides/git/#rebasing-and-squashing) to one commit)
- [ ] A [changelog entry](https://pulpproject.org/pulpcore/docs/dev/guides/git/#changelog-update) or entries has been added for any significant changes
- [ ] Follows the [Pulp policy on AI Usage](https://pulpproject.org/help/more/governance/ai_policy/)
- [ ] (For new features) - User documentation and test coverage has been added

See: [Pull Request Walkthrough](https://pulpproject.org/pulpcore/docs/dev/guides/pull-request-walkthrough/)
