### PR TITLE
Update aiohttp requirement from <3.14,>=3.10.10 to >=3.10.10,<3.15

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ requires-python = ">=3.11"
 dependencies = [
   "aiodns>=3.3.0,<3.7",  # Looks like only bugfixes in z-Stream.
   "aiofiles>=22.1,<=24.1.0",  # Uses sort of CalVer, luckily not released often https://github.com/Tinche/aiofiles/issues/144 .
-  "aiohttp>=3.8.3,<3.14",  # SemVer https://docs.aiohttp.org/en/stable/faq.html#what-is-the-api-stability-and-deprecation-policy .
+  "aiohttp>=3.8.3,<3.15",  # SemVer https://docs.aiohttp.org/en/stable/faq.html#what-is-the-api-stability-and-deprecation-policy .
   "asyncio-throttle>=1.0,<=1.0.2",  # Unsure about versioning, but not released often anyway.
   "backoff>=2.1.2,<2.3",  # Looks like only bugfixes in z-Stream.
   "click>=8.1.0,<8.4",  # Uses milestone.feature.fix https://palletsprojects.com/versions .


### PR DESCRIPTION
---
updated-dependencies:
- dependency-name: aiohttp dependency-version: 3.14.0 dependency-type: direct:production ...


(cherry picked from commit 47bb6c32adb246c82a4e99bf97b09b2f132e5945)

<!---
Thank you for submitting a PR to the Pulp Project!

If this is your first time contributing, please read the Pull Request Walkthrough documentation
(https://pulpproject.org/pulpcore/docs/dev/guides/pull-request-walkthrough/).
-->

### 📜 Checklist

- [ ] Commits are cleanly separated with meaningful messages (simple features and bug fixes should be [squashed](https://pulpproject.org/pulpcore/docs/dev/guides/git/#rebasing-and-squashing) to one commit)
- [ ] A [changelog entry](https://pulpproject.org/pulpcore/docs/dev/guides/git/#changelog-update) or entries has been added for any significant changes
- [ ] Follows the [Pulp policy on AI Usage](https://pulpproject.org/help/more/governance/ai_policy/)
- [ ] (For new features) - User documentation and test coverage has been added

See: [Pull Request Walkthrough](https://pulpproject.org/pulpcore/docs/dev/guides/pull-request-walkthrough/)
