### PR TITLE
Prevent path traversal attack in FilesystemExporter

### DIFF
--- a/CHANGES/+fs_export_traversal.bugfix
+++ b/CHANGES/+fs_export_traversal.bugfix
@@ -1,0 +1,1 @@
+Improved validation of relative paths to prevent a path traversal attack in filesystem exports. (CVE-2026-12701)

--- a/pulpcore/app/serializers/fields.py
+++ b/pulpcore/app/serializers/fields.py
@@ -20,6 +20,10 @@ def relative_path_validator(relative_path):
         raise serializers.ValidationError(
             _("Relative path can't start with '/'. {0}").format(relative_path)
         )
+    if os.path.normpath(relative_path).startswith("../"):
+        raise serializers.ValidationError(
+            _("Relative path must not reach beyond the base path. {0}").format(relative_path)
+        )
 
 
 # Prefer JSONDictField and JSONListField over JSONField:

--- a/pulpcore/app/tasks/export.py
+++ b/pulpcore/app/tasks/export.py
@@ -29,7 +29,7 @@ from pulpcore.app.models import (
     Task,
 )
 from pulpcore.app.models.content import ContentArtifact
-from pulpcore.app.serializers import PulpExportSerializer
+from pulpcore.app.serializers import PulpExportSerializer, relative_path_validator
 from pulpcore.app.util import Crc32Hasher, compute_file_hash
 from pulpcore.constants import FS_EXPORT_METHODS
 
@@ -98,6 +98,7 @@ def _export_to_file_system(path, relative_paths_to_artifacts, method=FS_EXPORT_M
         method = FS_EXPORT_METHODS.WRITE
 
     for relative_path, artifact in relative_paths_to_artifacts.items():
+        relative_path_validator(relative_path)
         dest = os.path.join(path, relative_path)
         os.makedirs(os.path.split(dest)[0], exist_ok=True)
 

--- a/pulpcore/tests/unit/serializers/test_fields.py
+++ b/pulpcore/tests/unit/serializers/test_fields.py
@@ -2,6 +2,7 @@ import pytest
 from rest_framework import serializers
 
 from pulpcore.app.serializers import fields
+from pulpcore.app.serializers.fields import relative_path_validator
 
 
 @pytest.mark.parametrize(
@@ -47,3 +48,16 @@ def test_custom_json_dict_field_raises(field_and_data, binary_arg):
     error_msg = "Invalid type"
     with pytest.raises(serializers.ValidationError, match=error_msg):
         custom_field.to_internal_value(data)
+
+
+@pytest.mark.parametrize(
+    ("path",),
+    [
+        pytest.param("/absolute/path", id="absolute"),
+        pytest.param("../sneaky/path", id="path_traversal"),
+        pytest.param("suspicious/../../sneaky/path", id="hidden_path_traversal"),
+    ],
+)
+def test_relative_path_validator_rejects(path):
+    with pytest.raises(serializers.ValidationError):
+        relative_path_validator(path)


### PR DESCRIPTION
Fix validation so that relative paths cannot escape their base path by introducing "../" segments.

<!---
Thank you for submitting a PR to the Pulp Project!

If this is your first time contributing, please read the Pull Request Walkthrough documentation
(https://pulpproject.org/pulpcore/docs/dev/guides/pull-request-walkthrough/).
-->

### 📜 Checklist

- [ ] Commits are cleanly separated with meaningful messages (simple features and bug fixes should be [squashed](https://pulpproject.org/pulpcore/docs/dev/guides/git/#rebasing-and-squashing) to one commit)
- [ ] A [changelog entry](https://pulpproject.org/pulpcore/docs/dev/guides/git/#changelog-update) or entries has been added for any significant changes
- [ ] Follows the [Pulp policy on AI Usage](https://pulpproject.org/help/more/governance/ai_policy/)
- [ ] (For new features) - User documentation and test coverage has been added

See: [Pull Request Walkthrough](https://pulpproject.org/pulpcore/docs/dev/guides/pull-request-walkthrough/)
