### PR TITLE
Narrow distribution locks with safe base_path protection

### DIFF
--- a/CHANGES/3322.bugfix
+++ b/CHANGES/3322.bugfix
@@ -1,0 +1,1 @@
+Reduced lock contention for distribution updates that leave `base_path` unchanged.

--- a/CHANGES/7896.bugfix
+++ b/CHANGES/7896.bugfix
@@ -1,0 +1,1 @@
+Reduced lock contention for distribution updates that leave `base_path` unchanged.

--- a/pulpcore/app/viewsets/base.py
+++ b/pulpcore/app/viewsets/base.py
@@ -451,6 +451,14 @@ class AsyncReservedObjectMixin:
         ).format(self.__class__.__name__)
         return [instance]
 
+    def async_shared_resources(self, instance, **kwargs):
+        """
+        Return shared resources to reserve for the task created by the Async...Mixins.
+
+        This default implementation does not add any shared reservations.
+        """
+        return []
+
 
 class AsyncCreateMixin:
     """
@@ -472,6 +480,7 @@ class AsyncCreateMixin:
         task = dispatch(
             tasks.base.general_create,
             exclusive_resources=self.async_reserved_resources(None),
+            shared_resources=self.async_shared_resources(None),
             args=(app_label, serializer.__class__.__name__),
             kwargs=task_kwargs,
         )
@@ -506,6 +515,7 @@ class AsyncUpdateMixin(AsyncReservedObjectMixin):
             task = dispatch(
                 tasks.base.ageneral_update,
                 exclusive_resources=self.async_reserved_resources(instance),
+                shared_resources=self.async_shared_resources(instance),
                 args=(pk, app_label, serializer.__class__.__name__),
                 kwargs=task_kwargs,
                 immediate=self.ALLOW_NON_BLOCKING_UPDATE,
@@ -542,6 +552,7 @@ class AsyncRemoveMixin(AsyncReservedObjectMixin):
         task = dispatch(
             tasks.base.ageneral_delete,
             exclusive_resources=self.async_reserved_resources(instance),
+            shared_resources=self.async_shared_resources(instance),
             args=(pk, app_label, serializer.__class__.__name__),
             immediate=self.ALLOW_NON_BLOCKING_DELETE,
         )

--- a/pulpcore/app/viewsets/publication.py
+++ b/pulpcore/app/viewsets/publication.py
@@ -527,7 +527,31 @@ class BaseDistributionViewSet(NamedModelViewSet):
         return qs
 
     def async_reserved_resources(self, instance):
-        """Return resource that locks all Distributions."""
+        """
+        Reserve safe distribution locks for async operations.
+
+        The explicit distribution.base_path lock protects the domain-wide base_path invariant.
+        The older domain-scoped distributions lock remains shared so tasks queued before an upgrade
+        still overlap safely with new tasks.
+        """
+        distribution_base_path = f"pdrn:{get_domain().pulp_id}:distribution.base_path"
+        if instance is None:
+            return [distribution_base_path]
+
+        if getattr(self, "action", "") == "destroy":
+            return [instance]
+
+        request_data = getattr(getattr(self, "request", None), "data", {})
+        requested_base_path = request_data.get("base_path", instance.base_path)
+        if requested_base_path == instance.base_path:
+            return [instance]
+
+        return [instance, distribution_base_path]
+
+    def async_shared_resources(self, instance):
+        """
+        Keep the legacy domain-scoped distribution lock shared for upgrade compatibility.
+        """
         return [f"pdrn:{get_domain().pulp_id}:distributions"]
 
 
@@ -567,9 +591,9 @@ class DistributionViewSet(
     LabelsMixin,
 ):
     """
-    Provides read and list methods and also provides asynchronous CUD methods to dispatch tasks
-    with reservation that lock all Distributions preventing race conditions during base_path
-    checking.
+    Provides read and list methods plus asynchronous CUD methods that reserve per-distribution
+    locks, an explicit base_path lock when needed, and the legacy domain-wide distributions lock in
+    shared mode for upgrade compatibility.
     """
 
 

--- a/pulpcore/tests/functional/api/using_plugin/test_distributions.py
+++ b/pulpcore/tests/functional/api/using_plugin/test_distributions.py
@@ -168,6 +168,81 @@ def test_distribution_base_path(
 
 
 @pytest.mark.parallel
+def test_distribution_update_task_reservations(
+    file_bindings,
+    monitor_task,
+):
+    def has_shared_distributions_lock(task):
+        return any(
+            resource.startswith("shared:") and resource.endswith(":distributions")
+            for resource in task.reserved_resources_record
+        )
+
+    def has_exclusive_distributions_lock(task):
+        return any(
+            not resource.startswith("shared:") and resource.endswith(":distributions")
+            for resource in task.reserved_resources_record
+        )
+
+    def has_base_path_lock(task):
+        return any(
+            not resource.startswith("shared:") and resource.endswith(":distribution.base_path")
+            for resource in task.reserved_resources_record
+        )
+
+    create_task = monitor_task(
+        file_bindings.DistributionsFileApi.create(
+            {"name": str(uuid4()), "base_path": str(uuid4())}
+        ).task
+    )
+    assert has_base_path_lock(create_task)
+    assert has_shared_distributions_lock(create_task)
+    assert not has_exclusive_distributions_lock(create_task)
+    distribution = file_bindings.DistributionsFileApi.read(create_task.created_resources[0])
+    assert distribution.prn not in create_task.reserved_resources_record
+
+    no_base_path_update_task = monitor_task(
+        file_bindings.DistributionsFileApi.partial_update(
+            distribution.pulp_href,
+            {"name": str(uuid4())},
+        ).task
+    )
+    assert distribution.prn in no_base_path_update_task.reserved_resources_record
+    assert not has_base_path_lock(no_base_path_update_task)
+    assert has_shared_distributions_lock(no_base_path_update_task)
+    assert not has_exclusive_distributions_lock(no_base_path_update_task)
+
+    unchanged_base_path_update_task = monitor_task(
+        file_bindings.DistributionsFileApi.partial_update(
+            distribution.pulp_href,
+            {"name": str(uuid4()), "base_path": distribution.base_path},
+        ).task
+    )
+    assert distribution.prn in unchanged_base_path_update_task.reserved_resources_record
+    assert not has_base_path_lock(unchanged_base_path_update_task)
+    assert has_shared_distributions_lock(unchanged_base_path_update_task)
+    assert not has_exclusive_distributions_lock(unchanged_base_path_update_task)
+
+    base_path_update_task = monitor_task(
+        file_bindings.DistributionsFileApi.partial_update(
+            distribution.pulp_href, {"base_path": str(uuid4())}
+        ).task
+    )
+    assert distribution.prn in base_path_update_task.reserved_resources_record
+    assert has_base_path_lock(base_path_update_task)
+    assert has_shared_distributions_lock(base_path_update_task)
+    assert not has_exclusive_distributions_lock(base_path_update_task)
+
+    delete_task = monitor_task(
+        file_bindings.DistributionsFileApi.delete(distribution.pulp_href).task
+    )
+    assert distribution.prn in delete_task.reserved_resources_record
+    assert not has_base_path_lock(delete_task)
+    assert has_shared_distributions_lock(delete_task)
+    assert not has_exclusive_distributions_lock(delete_task)
+
+
+@pytest.mark.parallel
 def test_distribution_filtering(
     file_bindings,
     file_remote_factory,


### PR DESCRIPTION
## Problem

Async distribution CUD operations currently reserve the domain-wide
`pdrn:<domain>:distributions` resource too broadly. For ordinary updates
that leave `base_path` unchanged, this serializes unrelated
`pulpcore.app.tasks.base.ageneral_update` tasks behind a lock they do not
need.

This showed up as a bottleneck during capsule sync, where many
`RefreshDistribution` updates can run at once but end up waiting on the
same reservation.

## What this changes

This patch narrows distribution task reservations while keeping the
`base_path` namespace protected in the safer way discussed in review:

- ordinary updates that leave `base_path` unchanged reserve only the
  distribution instance
- create and update operations that create or change a `base_path` also
  reserve a dedicated domain-scoped `distribution.base_path` resource
- delete does not take the new `distribution.base_path` lock
- the legacy `domain:distributions` reservation is still added in shared
  mode for mixed-version upgrade compatibility

The implementation also handles partial `PATCH` requests correctly by
falling back to `instance.base_path` when `base_path` is omitted from the
request body.

As part of the final cleanup, the `shared_resources` plumbing now lives in
the generic async mixins in `base.py`, while `publication.py` only defines
the distribution-specific lock policy.

## Test coverage

Adds a functional test covering the reservation behavior for:

- create
- partial update with no `base_path` in the payload
- partial update with unchanged `base_path`
- partial update with changed `base_path`
- delete

## Performance notes

Tested with Satellite 6.20 Stream,
~175 capsules, 15 Pulp workers.

For completed `pulpcore.app.tasks.base.ageneral_update` tasks, lock usage
shifted from all domain-wide reservations to a mix of domain and
instance-scoped reservations:

| Lock type | Before patch | After patch |
| --- | ---: | ---: |
| Domain-wide | 110 | 26 |
| Instance-only | 0 | 42 |

Block wait times improved substantially:

| Metric | Before (domain-locked) | After domain-locked | After instance-locked |
| --- | ---: | ---: | ---: |
| P95 | 6.98s | 75ms | 28ms |
| P99 | 10.12s | 105ms | 29ms |
| Max | 10.16s | 121ms | 29ms |

These results are consistent with removing unnecessary serialization for
ordinary distribution updates while preserving explicit protection when the
`base_path` namespace can change.