### PR TITLE
Fix domain list returning all domains to any authenticated user

### DIFF
--- a/CHANGES/7898.bugfix
+++ b/CHANGES/7898.bugfix
@@ -1,0 +1,1 @@
+Fixed domain list returning all domains to authenticated users instead of only domains they can view.

--- a/pulpcore/app/viewsets/domain.py
+++ b/pulpcore/app/viewsets/domain.py
@@ -49,6 +49,7 @@ class DomainViewSet(
     serializer_class = DomainSerializer
     endpoint_name = "domains"
     filterset_class = DomainFilter
+    queryset_filtering_required_permission = "core.view_domain"
     DEFAULT_ACCESS_POLICY = {
         "statements": [
             {

--- a/pulpcore/tests/functional/api/test_crud_domains.py
+++ b/pulpcore/tests/functional/api/test_crud_domains.py
@@ -360,3 +360,41 @@ def test_set_label_on_domain(pulpcore_bindings, domain_factory, gen_user):
         response = pulpcore_bindings.DomainsApi.unset_label(domain.pulp_href, {"key": "abc"})
         assert response.key == "abc"
         assert response.value == "def"
+
+
+@pytest.mark.parallel
+def test_domain_list_queryset_scoping(pulpcore_bindings, gen_user, gen_object_with_cleanup):
+    """Test that domain list is scoped to domains the user can view."""
+    body = {
+        "name": str(uuid.uuid4()),
+        "storage_class": "pulpcore.app.models.storage.FileSystem",
+        "storage_settings": {"MEDIA_ROOT": ""},
+    }
+    domain = gen_object_with_cleanup(pulpcore_bindings.DomainsApi, body)
+    gen_object_with_cleanup(pulpcore_bindings.DomainsApi, {**body, "name": str(uuid.uuid4())})
+
+    # Authenticated users without view_domain see no domains
+    with gen_user():
+        assert pulpcore_bindings.DomainsApi.list().count == 0
+
+    # Object-level domain_viewer can see only that domain
+    with gen_user(object_roles=[("core.domain_viewer", domain.pulp_href)]):
+        domains = pulpcore_bindings.DomainsApi.list()
+        assert domains.count == 1
+        assert domains.results[0].pulp_href == domain.pulp_href
+
+    # Object-level domain_owner can see only that domain
+    with gen_user(object_roles=[("core.domain_owner", domain.pulp_href)]):
+        domains = pulpcore_bindings.DomainsApi.list()
+        assert domains.count == 1
+        assert domains.results[0].pulp_href == domain.pulp_href
+
+    # Domain creator sees domains they create (via creation_hooks), not others
+    creator = gen_user(model_roles=["core.domain_creator"])
+    with creator:
+        created = gen_object_with_cleanup(
+            pulpcore_bindings.DomainsApi, {**body, "name": str(uuid.uuid4())}
+        )
+        domains = pulpcore_bindings.DomainsApi.list()
+        assert domains.count == 1
+        assert domains.results[0].pulp_href == created.pulp_href


### PR DESCRIPTION
DomainViewSet was missing queryset_filtering_required_permission, so scope_queryset never filtered listings by core.view_domain. Scope the queryset so users only see domains they have permission to view.

closes #7898

Assisted-By: Cursor

<!---
Thank you for submitting a PR to the Pulp Project!

If this is your first time contributing, please read the Pull Request Walkthrough documentation
(https://pulpproject.org/pulpcore/docs/dev/guides/pull-request-walkthrough/).
-->

### 📜 Checklist

- [ ] Commits are cleanly separated with meaningful messages (simple features and bug fixes should be [squashed](https://pulpproject.org/pulpcore/docs/dev/guides/git/#rebasing-and-squashing) to one commit)
- [ ] A [changelog entry](https://pulpproject.org/pulpcore/docs/dev/guides/git/#changelog-update) or entries has been added for any significant changes
- [ ] Follows the [Pulp policy on AI Usage](https://pulpproject.org/help/more/governance/ai_policy/)
- [ ] (For new features) - User documentation and test coverage has been added

See: [Pull Request Walkthrough](https://pulpproject.org/pulpcore/docs/dev/guides/pull-request-walkthrough/)
