### PR TITLE
Fix temp file leak in pull-through metadata streaming.

### DIFF
--- a/CHANGES/7846.bugfix
+++ b/CHANGES/7846.bugfix
@@ -1,0 +1,1 @@
+Fix temp file leak in pull-through metadata streaming.

--- a/pulpcore/content/handler.py
+++ b/pulpcore/content/handler.py
@@ -904,6 +904,7 @@ class Handler:
                     # Try to stream the RemoteArtifact and potentially save it as a new Content unit
                     save_artifact = (
                         remote.get_remote_artifact_content_type(original_rel_path) is not None
+                        and remote.policy != Remote.STREAMED
                     )
                     ca = ContentArtifact(relative_path=original_rel_path)
                     ra = RemoteArtifact(remote=remote, url=url, content_artifact=ca)
@@ -972,7 +973,10 @@ class Handler:
         )
         async for remote_artifact in remote_artifacts:
             try:
-                response = await self._stream_remote_artifact(request, response, remote_artifact)
+                save_artifact = remote_artifact.remote.policy != Remote.STREAMED
+                response = await self._stream_remote_artifact(
+                    request, response, remote_artifact, save_artifact=save_artifact
+                )
                 return response
             except SKIPPABLE_EXCEPTIONS as e:
                 log.warning(
@@ -1179,7 +1183,7 @@ class Handler:
             return response
 
     async def _stream_remote_artifact(
-        self, request, response, remote_artifact, save_artifact=True, repository=None
+        self, request, response, remote_artifact, save_artifact, repository=None
     ):
         """
         Stream and save a RemoteArtifact.
@@ -1289,12 +1293,12 @@ class Handler:
                     data_size_handled = data_size_handled + len(data)
                 else:
                     await response.write(data)
-            if remote.policy != Remote.STREAMED:
+            if save_artifact:
                 await original_handle_data(data)
 
         async def finalize():
             nonlocal failed_download
-            if save_artifact and remote.policy != Remote.STREAMED:
+            if save_artifact:
                 await original_finalize()
             failed_download = False
 
@@ -1342,7 +1346,7 @@ class Handler:
             if hasattr(downloader, "session"):
                 await downloader.session.close()
 
-        if save_artifact and remote.policy != Remote.STREAMED:
+        if save_artifact:
             content_artifacts = await asyncio.shield(
                 sync_to_async(self._save_artifact)(download_result, remote_artifact, request)
             )


### PR DESCRIPTION
Currently there is a problem with non content type files staying indefinitely on the disk when using _stream_remote_artifact() even if save_artifact flag is set to false. 

I don't see a good reason for writing this data on disk in the first place, this pr fixes that.
 
fixes: #7846

### 📜 Checklist

- [ ] Commits are cleanly separated with meaningful messages (simple features and bug fixes should be [squashed](https://pulpproject.org/pulpcore/docs/dev/guides/git/#rebasing-and-squashing) to one commit)
- [ ] A [changelog entry](https://pulpproject.org/pulpcore/docs/dev/guides/git/#changelog-update) or entries has been added for any significant changes
- [ ] Follows the [Pulp policy on AI Usage](https://pulpproject.org/help/more/governance/ai_policy/)
- [ ] (For new features) - User documentation and test coverage has been added

See: [Pull Request Walkthrough](https://pulpproject.org/pulpcore/docs/dev/guides/pull-request-walkthrough/)
