### PR TITLE
[3.63] Convert all settings.get to getattr

### DIFF
--- a/pulpcore/app/redis_connection.py
+++ b/pulpcore/app/redis_connection.py
@@ -8,9 +8,9 @@ _a_conn = None
 
 
 def _get_connection_from_class(redis_class):
-    if not settings.get("CACHE_ENABLED"):
+    if not getattr(settings, "CACHE_ENABLED", None):
         return None
-    redis_url = settings.get("REDIS_URL")
+    redis_url = getattr(settings, "REDIS_URL", None)
     if redis_url is not None:
         return redis_class.from_url(redis_url)
     else:

--- a/pulpcore/app/tasks/importer.py
+++ b/pulpcore/app/tasks/importer.py
@@ -510,7 +510,7 @@ def pulp_import(importer_pk, path, toc, create_repositories):
         #
         # By default (setting is not-set), import will continue to use 100% of the available
         # workers.
-        import_workers_percent = int(settings.get("IMPORT_WORKERS_PERCENT", 100))
+        import_workers_percent = int(getattr(settings, "IMPORT_WORKERS_PERCENT", 100))
         total_workers = Worker.objects.online().count()
         import_workers = max(1, int(total_workers * (import_workers_percent / 100.0)))
 

--- a/pulpcore/app/util.py
+++ b/pulpcore/app/util.py
@@ -446,7 +446,7 @@ def configure_analytics():
     dispatch_interval = timedelta(days=1)
     name = "Post Anonymous Analytics Periodically"
     analytics = settings.ANALYTICS
-    if settings.get("TELEMETRY") is not None:
+    if getattr(settings, "TELEMETRY", None) is not None:
         deprecation_logger.warning("TELEMETRY setting is deprecated. Use ANALYTICS.")
         analytics = settings.TELEMETRY
     if analytics:

--- a/pulpcore/tasking/kafka.py
+++ b/pulpcore/tasking/kafka.py
@@ -24,16 +24,16 @@ else:
 
     _logger = logging.getLogger(__name__)
     _kafka_producer = None
-    _producer_poll_timeout = settings.get("KAFKA_PRODUCER_POLL_TIMEOUT")
-    _security_protocol = settings.get("KAFKA_SECURITY_PROTOCOL")
-    _ssl_ca_pem = settings.get("KAFKA_SSL_CA_PEM")
-    _sasl_mechanism = settings.get("KAFKA_SASL_MECHANISM")
-    _sasl_username = settings.get("KAFKA_SASL_USERNAME")
-    _sasl_password = settings.get("KAFKA_SASL_PASSWORD")
+    _producer_poll_timeout = getattr(settings, "KAFKA_PRODUCER_POLL_TIMEOUT", None)
+    _security_protocol = getattr(settings, "KAFKA_SECURITY_PROTOCOL", None)
+    _ssl_ca_pem = getattr(settings, "KAFKA_SSL_CA_PEM", None)
+    _sasl_mechanism = getattr(settings, "KAFKA_SASL_MECHANISM", None)
+    _sasl_username = getattr(settings, "KAFKA_SASL_USERNAME", None)
+    _sasl_password = getattr(settings, "KAFKA_SASL_PASSWORD", None)
 
-    _kafka_tasks_status_topic = settings.get("KAFKA_TASKS_STATUS_TOPIC")
-    _kafka_tasks_status_producer_sync_enabled = settings.get(
-        "KAFKA_TASKS_STATUS_PRODUCER_SYNC_ENABLED"
+    _kafka_tasks_status_topic = getattr(settings, "KAFKA_TASKS_STATUS_TOPIC", None)
+    _kafka_tasks_status_producer_sync_enabled = getattr(
+        settings, "KAFKA_TASKS_STATUS_PRODUCER_SYNC_ENABLED", None
     )
 
     class KafkaProducerPollingWorker:


### PR DESCRIPTION
Turning off dynaconf's boxify requires we now use getattr

(cherry picked from commit dee04db820ff59bd39f66a95e52b6faff5bed5b4) (cherry picked from commit 7f59d5c5e7fcc05c672c964c28edb7db055d96f8)

<!---
Thank you for submitting a PR to the Pulp Project!

If this is your first time contributing, please read the Pull Request Walkthrough documentation
(https://pulpproject.org/pulpcore/docs/dev/guides/pull-request-walkthrough/).
-->

### 📜 Checklist

- [ ] Commits are cleanly separated with meaningful messages (simple features and bug fixes should be [squashed](https://pulpproject.org/pulpcore/docs/dev/guides/git/#rebasing-and-squashing) to one commit)
- [ ] A [changelog entry](https://pulpproject.org/pulpcore/docs/dev/guides/git/#changelog-update) or entries has been added for any significant changes
- [ ] Follows the [Pulp policy on AI Usage](https://pulpproject.org/help/more/governance/ai_policy/)
- [ ] (For new features) - User documentation and test coverage has been added

See: [Pull Request Walkthrough](https://pulpproject.org/pulpcore/docs/dev/guides/pull-request-walkthrough/)
