### PR TITLE
fix: make redis workers to know the current num of workers at startup

### DIFF
--- a/CHANGES/+redis-worker-startup-poll.bugfix
+++ b/CHANGES/+redis-worker-startup-poll.bugfix
@@ -1,0 +1,1 @@
+Fixed Redis workers polling the database at the single-worker rate during startup by learning the online worker count before the first heartbeat.

--- a/pulpcore/tasking/redis_worker.py
+++ b/pulpcore/tasking/redis_worker.py
@@ -133,8 +133,10 @@ class RedisWorker:
         # Metric recording interval
         self.metric_heartbeat_countdown = METRIC_HEARTBEAT_INTERVAL
 
-        # Cache worker count for sleep calculation (updated during beat)
-        self.num_workers = 1
+        # Cache worker count for sleep calculation. Learn the real fleet size at
+        # startup so new workers do not poll at the single-worker rate until the
+        # first heartbeat (~WORKER_TTL/3). Refreshed on each heartbeat in beat().
+        self.num_workers = max(1, AppStatus.objects.online().filter(app_type="worker").count())
 
         # Redis connection for distributed locks
         self.redis_conn = get_redis_connection()
@@ -157,7 +159,10 @@ class RedisWorker:
 
         startup_hook()
 
-        _logger.info("Initialized RedisWorker with Redis lock-based algorithm")
+        _logger.info(
+            "Initialized RedisWorker with Redis lock-based algorithm (online workers=%d)",
+            self.num_workers,
+        )
 
     def _init_instrumentation(self):
         """Initialize OpenTelemetry instrumentation if enabled."""
@@ -210,7 +215,11 @@ class RedisWorker:
             self.app_status.save_heartbeat()
             _logger.debug(msg)
         except (IntegrityError, DatabaseError):
-            _logger.error(f"Updating the heartbeat of worker {self.name} failed.")
+            _logger.error(
+                "Updating the heartbeat of worker %s failed.",
+                self.name,
+                exc_info=True,
+            )
             self.shutdown_requested = True
 
     def handle_redis_heartbeat(self):
@@ -363,7 +372,7 @@ class RedisWorker:
                     self.record_waiting_tasks_metric()
 
             # Update cached worker count for sleep calculation
-            self.num_workers = AppStatus.objects.online().filter(app_type="worker").count()
+            self.num_workers = max(1, AppStatus.objects.online().filter(app_type="worker").count())
 
     def _maybe_release_locks(self, task, mark_released=True):
         """


### PR DESCRIPTION
Fixes: https://github.com/pulp/pulpcore/issues/7912
Addresses: https://redhat.atlassian.net/browse/PULP-2149

## Problem
Redis workers find work by repeatedly asking the database for waiting tasks, then sleeping briefly. Sleep is supposed to get longer as the fleet grows, so many workers don’t all pound the DB at once.

But each new worker starts life assuming the fleet has one worker. It only learns the real count on its first heartbeat (~10s later). Until then it polls about every 10 ms.

So a scale-up (e.g. 25 → 150) creates a short window of thousands of SELECTs per second against core_task. The DB saturates, heartbeat writes fail, workers exit, replacements start, and the same aggressive startup polling happens again.

## Solution
workers should learn fleet size at startup before first heartbeat

### 📜 Checklist

- [ ] Commits are cleanly separated with meaningful messages (simple features and bug fixes should be [squashed](https://pulpproject.org/pulpcore/docs/dev/guides/git/#rebasing-and-squashing) to one commit)
- [ ] A [changelog entry](https://pulpproject.org/pulpcore/docs/dev/guides/git/#changelog-update) or entries has been added for any significant changes
- [ ] Follows the [Pulp policy on AI Usage](https://pulpproject.org/help/more/governance/ai_policy/)
- [ ] (For new features) - User documentation and test coverage has been added

See: [Pull Request Walkthrough](https://pulpproject.org/pulpcore/docs/dev/guides/pull-request-walkthrough/)
