### PR TITLE
Speed up CI by parallelizing pulp-cli livetests and using uv.

### DIFF
--- a/.ci/ansible/Containerfile.j2
+++ b/.ci/ansible/Containerfile.j2
@@ -9,7 +9,7 @@ ADD ./{{ plugin_name }}/{{ plugin_name | replace("-", "_") }}/app/webserver_snip
 ADD ./{{ item.origin }} {{ item.destination }}
 {%- endfor %}
 
-# This MUST be the ONLY call to pip install in inside the container.
+# This MUST be the ONLY package install inside the container.
 RUN --mount=type=cache,target=/root/.cache/uv uv pip install --upgrade setuptools wheel && \
   uv pip install {{ image.source }}
 {%- if image.upperbounds | default(false) -%}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,16 +31,23 @@ jobs:
       - uses: "actions/setup-python@v6"
         with:
           python-version: "3.11"
+      - name: "Install uv"
+        uses: "astral-sh/setup-uv@v7"
+        with:
+          enable-cache: true
+      - name: "Configure uv to use system Python"
+        run: |
+          echo "UV_SYSTEM_PYTHON=1" >> "$GITHUB_ENV"
       - name: "Install python dependencies"
         run: |
-          pip install build packaging twine wheel mkdocs jq
+          uv pip install build packaging twine wheel mkdocs jq
       - name: "Build package"
         run: |
           python3 -m build
           twine check dist/*
       - name: "Install built packages"
         run: |
-          pip install dist/pulpcore-*-py3-none-any.whl -c .ci/assets/ci_constraints.txt
+          uv pip install dist/pulpcore-*-py3-none-any.whl -c .ci/assets/ci_constraints.txt
       - name: "Generate api specs"
         run: |
           pulpcore-manager openapi --file "api.json"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,9 +28,16 @@ jobs:
       - uses: "actions/setup-python@v6"
         with:
           python-version: "3.11"
+      - name: "Install uv"
+        uses: "astral-sh/setup-uv@v7"
+        with:
+          enable-cache: true
+      - name: "Configure uv to use system Python"
+        run: |
+          echo "UV_SYSTEM_PYTHON=1" >> "$GITHUB_ENV"
       - name: "Install python dependencies"
         run: |
-          pip install requests pygithub pyyaml
+          uv pip install requests pygithub pyyaml
       - name: "Check commit message"
         if: github.event_name == 'pull_request'
         env:
@@ -56,9 +63,16 @@ jobs:
         with:
           python-version: "3.12"
 
+      - name: "Install uv"
+        uses: "astral-sh/setup-uv@v7"
+        with:
+          enable-cache: true
+      - name: "Configure uv to use system Python"
+        run: |
+          echo "UV_SYSTEM_PYTHON=1" >> "$GITHUB_ENV"
       - name: "Install python dependencies"
         run: |
-          pip install gitpython
+          uv pip install gitpython
 
       - name: "Analyze changed files"
         id: "check"

--- a/.github/workflows/create-branch.yml
+++ b/.github/workflows/create-branch.yml
@@ -39,9 +39,16 @@ jobs:
         with:
           python-version: "3.11"
 
+      - name: "Install uv"
+        uses: "astral-sh/setup-uv@v7"
+        with:
+          enable-cache: true
+      - name: "Configure uv to use system Python"
+        run: |
+          echo "UV_SYSTEM_PYTHON=1" >> "$GITHUB_ENV"
       - name: "Install python dependencies"
         run: |
-          pip install bump-my-version packaging -r plugin_template/requirements.txt
+          uv pip install bump-my-version packaging -r plugin_template/requirements.txt
 
       - name: "Setting secrets"
         working-directory: "pulpcore"

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -29,9 +29,16 @@ jobs:
       - uses: "actions/setup-python@v6"
         with:
           python-version: "3.12"
+      - name: "Install uv"
+        uses: "astral-sh/setup-uv@v7"
+        with:
+          enable-cache: true
+      - name: "Configure uv to use system Python"
+        run: |
+          echo "UV_SYSTEM_PYTHON=1" >> "$GITHUB_ENV"
       - name: "Install python dependencies"
         run: |
-          pip install towncrier
+          uv pip install towncrier
       - name: "Build changelog"
         run: |
           towncrier build --yes --version 4.0.0.ci

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -28,9 +28,16 @@ jobs:
         with:
           python-version: "3.11"
 
+      - name: "Install uv"
+        uses: "astral-sh/setup-uv@v7"
+        with:
+          enable-cache: true
+      - name: "Configure uv to use system Python"
+        run: |
+          echo "UV_SYSTEM_PYTHON=1" >> "$GITHUB_ENV"
       - name: "Install python dependencies"
         run: |
-          pip install -r lint_requirements.txt
+          uv pip install -r lint_requirements.txt
 
       - name: "Lint workflow files"
         run: |

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -45,9 +45,16 @@ jobs:
         with:
           python-version: "3.13"
 
+      - name: "Install uv"
+        uses: "astral-sh/setup-uv@v7"
+        with:
+          enable-cache: true
+      - name: "Configure uv to use system Python"
+        run: |
+          echo "UV_SYSTEM_PYTHON=1" >> "$GITHUB_ENV"
       - name: "Install python dependencies"
         run: |
-          pip install gitpython packaging toml
+          uv pip install gitpython packaging toml
 
       - name: "Configure Git with pulpbot name and email"
         run: |

--- a/.github/workflows/pr_checks.yml
+++ b/.github/workflows/pr_checks.yml
@@ -38,9 +38,16 @@ jobs:
       - uses: "actions/setup-python@v6"
         with:
           python-version: "3.11"
+      - name: "Install uv"
+        uses: "astral-sh/setup-uv@v7"
+        with:
+          enable-cache: true
+      - name: "Configure uv to use system Python"
+        run: |
+          echo "UV_SYSTEM_PYTHON=1" >> "$GITHUB_ENV"
       - name: "Determine PR labels"
         run: |
-          pip install GitPython==3.1.42
+          uv pip install GitPython==3.1.42
           git fetch origin ${{ github.event.pull_request.head.sha }}
           python .ci/scripts/pr_labels.py "origin/${{ github.base_ref }}" "${{ github.event.pull_request.head.sha }}" >> "$GITHUB_ENV"
       - uses: "actions/github-script@v8"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -131,10 +131,17 @@ jobs:
       - uses: "actions/setup-python@v6"
         with:
           python-version: "3.11"
+      - name: "Install uv"
+        uses: "astral-sh/setup-uv@v7"
+        with:
+          enable-cache: true
+      - name: "Configure uv to use system Python"
+        run: |
+          echo "UV_SYSTEM_PYTHON=1" >> "$GITHUB_ENV"
 
       - name: "Install towncrier"
         run: |
-          pip install towncrier
+          uv pip install towncrier
 
       - name: "Get release notes"
         id: "get_release_notes"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,9 +32,16 @@ jobs:
         with:
           python-version: "3.11"
 
+      - name: "Install uv"
+        uses: "astral-sh/setup-uv@v7"
+        with:
+          enable-cache: true
+      - name: "Configure uv to use system Python"
+        run: |
+          echo "UV_SYSTEM_PYTHON=1" >> "$GITHUB_ENV"
       - name: "Install python dependencies"
         run: |
-          pip install bump-my-version towncrier
+          uv pip install bump-my-version towncrier
 
       - name: "Configure Git with pulpbot name and email"
         run: |

--- a/.github/workflows/sanity.yml
+++ b/.github/workflows/sanity.yml
@@ -31,9 +31,16 @@ jobs:
         with:
           python-version: "3.11"
 
+      - name: "Install uv"
+        uses: "astral-sh/setup-uv@v7"
+        with:
+          enable-cache: true
+      - name: "Configure uv to use system Python"
+        run: |
+          echo "UV_SYSTEM_PYTHON=1" >> "$GITHUB_ENV"
       - name: "Install python dependencies"
         run: |
-          pip install -r lint_requirements.txt
+          uv pip install -r lint_requirements.txt
 
       - name: "Verify bump version config"
         run: |

--- a/.github/workflows/scripts/before_script.sh
+++ b/.github/workflows/scripts/before_script.sh
@@ -39,12 +39,12 @@ echo "# Constraints Files:"
 tail -v -n +1  ../*/*constraints.txt || true
 
 echo
-echo "# pip list outside the container"
-pip list
+echo "# package list outside the container"
+uv pip list
 
 echo
-echo "# pip list inside the container"
-cmd_prefix bash -c "pip3 list"
+echo "# package list inside the container"
+cmd_prefix bash -c "uv pip list"
 
 echo
 echo "# State of the containers"

--- a/.github/workflows/scripts/install.sh
+++ b/.github/workflows/scripts/install.sh
@@ -17,8 +17,8 @@ source .github/workflows/scripts/utils.sh
 
 PIP_REQUIREMENTS=("pulp-cli" "yq")
 
-# This must be the **only** call to "pip install" on the test runner.
-pip install ${PIP_REQUIREMENTS[*]}
+# This must be the **only** package install on the test runner.
+uv pip install ${PIP_REQUIREMENTS[*]}
 
 if [[ "$TEST" = "s3" ]]; then
 for i in {1..3}
@@ -33,7 +33,7 @@ fi
 fi
 
 # Check out the pulp-cli branch matching the installed version.
-PULP_CLI_VERSION="$(pip freeze | sed -n -e 's/pulp-cli==//p')"
+PULP_CLI_VERSION="$(uv pip freeze | sed -n -e 's/pulp-cli==//p')"
 git clone --depth 1 --branch "$PULP_CLI_VERSION" https://github.com/pulp/pulp-cli.git ../pulp-cli
 
 PULP_API_ROOT="$(yq -r '.pulp_scenario_settings.api_root // .pulp_settings.api_root // "/pulp/"' < .ci/ansible/vars/main.yaml)"

--- a/.github/workflows/scripts/script.sh
+++ b/.github/workflows/scripts/script.sh
@@ -117,7 +117,7 @@ cmd_stdin_prefix bash -c "cat > /tmp/unittest_requirements.txt" < unittest_requi
 cmd_stdin_prefix bash -c "cat > /tmp/functest_requirements.txt" < functest_requirements.txt
 cmd_stdin_prefix bash -c "cat > /tmp/bindings_requirements.txt" < bindings_requirements.txt
 cmd_stdin_prefix bash -c "cat > /tmp/bindings_constraints.txt" < bindings_constraints.txt
-cmd_prefix pip3 install -r /tmp/unittest_requirements.txt -r /tmp/functest_requirements.txt -r /tmp/bindings_requirements.txt -c /tmp/bindings_constraints.txt
+cmd_prefix uv pip install -r /tmp/unittest_requirements.txt -r /tmp/functest_requirements.txt -r /tmp/bindings_requirements.txt -c /tmp/bindings_constraints.txt
 
 CERTIFI=$(cmd_prefix python3 -c 'import certifi; print(certifi.where())')
 cmd_prefix bash -c "cat /etc/pulp/certs/pulp_webserver.crt >> '$CERTIFI'"
@@ -170,12 +170,15 @@ export PULP_FIXTURES_URL="http://pulp-fixtures:8080"
 # some pulp-cli tests use the api root envvar
 export PULP_API_ROOT="$(EDITOR=cat pulp config edit 2>/dev/null | awk -F'"' '/api_root/{print $2; exit}')"
 pushd ../pulp-cli
+# livetests are parallel-safe (pytest-xdist).
+CLI_MARK="live and (pulpcore or pulp_file or pulp_certguard)"
 if [[ -f "test_requirements.txt" ]]
 then
-  pip install -r test_requirements.txt
-  pytest -v tests -m "pulpcore or pulp_file or pulp_certguard"
+  uv pip install -r test_requirements.txt
+  pytest -v tests -m "${CLI_MARK}" -n 8
 else
-  PULP_CA_BUNDLE="/usr/local/share/ca-certificates/pulp_webserver.crt" make livetest PYTEST_MARK="live and (pulpcore or pulp_file or pulp_certguard)"
+  PULP_CA_BUNDLE="/usr/local/share/ca-certificates/pulp_webserver.crt" \
+    uv run pytest -v tests pulp-glue/tests -m "${CLI_MARK}" -n 8
 fi
 popd
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -42,11 +42,6 @@ jobs:
         with:
           python-version: "3.11"
 
-      - name: "Install uv"
-        uses: "astral-sh/setup-uv@v7"
-        with:
-          enable-cache: true
-
       - name: "Download plugin package"
         uses: "actions/download-artifact@v8"
         with:
@@ -81,9 +76,16 @@ jobs:
           tar xvf "../../pulpcore/certguard-python-client.tar"
           popd
 
+      - name: "Install uv"
+        uses: "astral-sh/setup-uv@v7"
+        with:
+          enable-cache: true
+      - name: "Configure uv to use system Python"
+        run: |
+          echo "UV_SYSTEM_PYTHON=1" >> "$GITHUB_ENV"
       - name: "Install python dependencies"
         run: |
-          pip install build towncrier twine wheel httpie docker netaddr boto3 'ansible~=10.3.0' mkdocs jq jsonpatch bump-my-version
+          uv pip install build towncrier twine wheel httpie docker netaddr boto3 'ansible~=10.3.0' mkdocs jq jsonpatch bump-my-version
           echo "HTTPIE_CONFIG_DIR=$GITHUB_WORKSPACE/pulpcore/.ci/assets/httpie/" >> $GITHUB_ENV
 
       - name: "Set environment variables"
@@ -153,5 +155,5 @@ jobs:
           docker logs pulp || true
           docker exec pulp ls -latr /etc/yum.repos.d/ || true
           docker exec pulp cat /etc/yum.repos.d/* || true
-          docker exec pulp bash -c "pip3 list" || true
+          docker exec pulp bash -c "uv pip list" || true
 ...

--- a/.github/workflows/update-labels.yml
+++ b/.github/workflows/update-labels.yml
@@ -26,9 +26,16 @@ jobs:
         run: |
           git config --global user.name 'pulpbot'
           git config --global user.email 'pulp-infra@redhat.com'
+      - name: "Install uv"
+        uses: "astral-sh/setup-uv@v7"
+        with:
+          enable-cache: true
+      - name: "Configure uv to use system Python"
+        run: |
+          echo "UV_SYSTEM_PYTHON=1" >> "$GITHUB_ENV"
       - name: "Install python dependencies"
         run: |
-          pip install requests pyyaml
+          uv pip install requests pyyaml
       - uses: "actions/checkout@v6"
       - name: "Update labels"
         run: |

--- a/.github/workflows/update_ci.yml
+++ b/.github/workflows/update_ci.yml
@@ -33,9 +33,16 @@ jobs:
         with:
           python-version: "3.11"
 
+      - name: "Install uv"
+        uses: "astral-sh/setup-uv@v7"
+        with:
+          enable-cache: true
+      - name: "Configure uv to use system Python"
+        run: |
+          echo "UV_SYSTEM_PYTHON=1" >> "$GITHUB_ENV"
       - name: "Install python dependencies"
         run: |
-          pip install gitpython packaging -r plugin_template/requirements.txt
+          uv pip install gitpython packaging -r plugin_template/requirements.txt
 
       - name: "Configure Git with pulpbot name and email"
         run: |

--- a/CHANGES/+ci-parallel-cli-uv.misc
+++ b/CHANGES/+ci-parallel-cli-uv.misc
@@ -1,0 +1,1 @@
+Run pulp-cli livetests in parallel with pytest-xdist, and use uv instead of pip in CI.


### PR DESCRIPTION
This is the first test to see if we can get the CI back under 30 mins. There's some more areas we can improve, but going to tackle this incrementally. 


Assisted-By: Cursor Grok 4.5

<!---
Thank you for submitting a PR to the Pulp Project!

If this is your first time contributing, please read the Pull Request Walkthrough documentation
(https://pulpproject.org/pulpcore/docs/dev/guides/pull-request-walkthrough/).
-->

### 📜 Checklist

- [ ] Commits are cleanly separated with meaningful messages (simple features and bug fixes should be [squashed](https://pulpproject.org/pulpcore/docs/dev/guides/git/#rebasing-and-squashing) to one commit)
- [ ] A [changelog entry](https://pulpproject.org/pulpcore/docs/dev/guides/git/#changelog-update) or entries has been added for any significant changes
- [ ] Follows the [Pulp policy on AI Usage](https://pulpproject.org/help/more/governance/ai_policy/)
- [ ] (For new features) - User documentation and test coverage has been added

See: [Pull Request Walkthrough](https://pulpproject.org/pulpcore/docs/dev/guides/pull-request-walkthrough/)
