### PR TITLE
Narrow distribution locks with safe base_path protection

### DIFF
--- a/.ci/assets/ci_constraints.txt
+++ b/.ci/assets/ci_constraints.txt
@@ -17,3 +17,7 @@ azure-storage-blob!=12.28.*
 
 pycares<5
 # older aiodns versions don't pin pycares UB, and are broken by pycares>=5
+
+
+pytest-django!=4.13.0
+# This version seems not to not have a proper requirement on Django.

--- a/CHANGES/3322.bugfix
+++ b/CHANGES/3322.bugfix
@@ -1,0 +1,1 @@
+Reduced lock contention for distribution updates that leave `base_path` unchanged.

--- a/CHANGES/7896.bugfix
+++ b/CHANGES/7896.bugfix
@@ -1,0 +1,1 @@
+Reduced lock contention for distribution updates that leave `base_path` unchanged.

--- a/pulpcore/app/viewsets/base.py
+++ b/pulpcore/app/viewsets/base.py
@@ -449,6 +449,14 @@ class AsyncReservedObjectMixin:
         ).format(self.__class__.__name__)
         return [instance]
 
+    def async_shared_resources(self, instance, **kwargs):
+        """
+        Return shared resources to reserve for the task created by the Async...Mixins.
+
+        This default implementation does not add any shared reservations.
+        """
+        return []
+
 
 class AsyncCreateMixin:
     """
@@ -469,6 +477,7 @@ class AsyncCreateMixin:
         task = dispatch(
             tasks.base.general_create,
             exclusive_resources=self.async_reserved_resources(None),
+            shared_resources=self.async_shared_resources(None),
             args=(app_label, serializer.__class__.__name__),
             kwargs={"data": request.data},
         )
@@ -495,6 +504,7 @@ class AsyncUpdateMixin(AsyncReservedObjectMixin):
         task = dispatch(
             tasks.base.ageneral_update,
             exclusive_resources=self.async_reserved_resources(instance),
+            shared_resources=self.async_shared_resources(instance),
             args=(pk, app_label, serializer.__class__.__name__),
             kwargs={"data": request.data, "partial": partial},
             immediate=self.ALLOW_NON_BLOCKING_UPDATE,
@@ -531,6 +541,7 @@ class AsyncRemoveMixin(AsyncReservedObjectMixin):
         task = dispatch(
             tasks.base.ageneral_delete,
             exclusive_resources=self.async_reserved_resources(instance),
+            shared_resources=self.async_shared_resources(instance),
             args=(pk, app_label, serializer.__class__.__name__),
             immediate=self.ALLOW_NON_BLOCKING_DELETE,
         )

--- a/pulpcore/app/viewsets/publication.py
+++ b/pulpcore/app/viewsets/publication.py
@@ -527,7 +527,31 @@ class BaseDistributionViewSet(NamedModelViewSet):
         return qs
 
     def async_reserved_resources(self, instance):
-        """Return resource that locks all Distributions."""
+        """
+        Reserve safe distribution locks for async operations.
+
+        The explicit distribution.base_path lock protects the domain-wide base_path invariant.
+        The older domain-scoped distributions lock remains shared so tasks queued before an upgrade
+        still overlap safely with new tasks.
+        """
+        distribution_base_path = f"pdrn:{get_domain().pulp_id}:distribution.base_path"
+        if instance is None:
+            return [distribution_base_path]
+
+        if getattr(self, "action", "") == "destroy":
+            return [instance]
+
+        request_data = getattr(getattr(self, "request", None), "data", {})
+        requested_base_path = request_data.get("base_path", instance.base_path)
+        if requested_base_path == instance.base_path:
+            return [instance]
+
+        return [instance, distribution_base_path]
+
+    def async_shared_resources(self, instance):
+        """
+        Keep the legacy domain-scoped distribution lock shared for upgrade compatibility.
+        """
         return [f"pdrn:{get_domain().pulp_id}:distributions"]
 
 
@@ -567,9 +591,9 @@ class DistributionViewSet(
     LabelsMixin,
 ):
     """
-    Provides read and list methods and also provides asynchronous CUD methods to dispatch tasks
-    with reservation that lock all Distributions preventing race conditions during base_path
-    checking.
+    Provides read and list methods plus asynchronous CUD methods that reserve per-distribution
+    locks, an explicit base_path lock when needed, and the legacy domain-wide distributions lock in
+    shared mode for upgrade compatibility.
     """
 
 

--- a/pulpcore/tests/functional/api/using_plugin/test_distributions.py
+++ b/pulpcore/tests/functional/api/using_plugin/test_distributions.py
@@ -161,6 +161,81 @@ def test_distribution_base_path(
 
 
 @pytest.mark.parallel
+def test_distribution_update_task_reservations(
+    file_bindings,
+    monitor_task,
+):
+    def has_shared_distributions_lock(task):
+        return any(
+            resource.startswith("shared:") and resource.endswith(":distributions")
+            for resource in task.reserved_resources_record
+        )
+
+    def has_exclusive_distributions_lock(task):
+        return any(
+            not resource.startswith("shared:") and resource.endswith(":distributions")
+            for resource in task.reserved_resources_record
+        )
+
+    def has_base_path_lock(task):
+        return any(
+            not resource.startswith("shared:") and resource.endswith(":distribution.base_path")
+            for resource in task.reserved_resources_record
+        )
+
+    create_task = monitor_task(
+        file_bindings.DistributionsFileApi.create(
+            {"name": str(uuid4()), "base_path": str(uuid4())}
+        ).task
+    )
+    assert has_base_path_lock(create_task)
+    assert has_shared_distributions_lock(create_task)
+    assert not has_exclusive_distributions_lock(create_task)
+    distribution = file_bindings.DistributionsFileApi.read(create_task.created_resources[0])
+    assert distribution.prn not in create_task.reserved_resources_record
+
+    no_base_path_update_task = monitor_task(
+        file_bindings.DistributionsFileApi.partial_update(
+            distribution.pulp_href,
+            {"name": str(uuid4())},
+        ).task
+    )
+    assert distribution.prn in no_base_path_update_task.reserved_resources_record
+    assert not has_base_path_lock(no_base_path_update_task)
+    assert has_shared_distributions_lock(no_base_path_update_task)
+    assert not has_exclusive_distributions_lock(no_base_path_update_task)
+
+    unchanged_base_path_update_task = monitor_task(
+        file_bindings.DistributionsFileApi.partial_update(
+            distribution.pulp_href,
+            {"name": str(uuid4()), "base_path": distribution.base_path},
+        ).task
+    )
+    assert distribution.prn in unchanged_base_path_update_task.reserved_resources_record
+    assert not has_base_path_lock(unchanged_base_path_update_task)
+    assert has_shared_distributions_lock(unchanged_base_path_update_task)
+    assert not has_exclusive_distributions_lock(unchanged_base_path_update_task)
+
+    base_path_update_task = monitor_task(
+        file_bindings.DistributionsFileApi.partial_update(
+            distribution.pulp_href, {"base_path": str(uuid4())}
+        ).task
+    )
+    assert distribution.prn in base_path_update_task.reserved_resources_record
+    assert has_base_path_lock(base_path_update_task)
+    assert has_shared_distributions_lock(base_path_update_task)
+    assert not has_exclusive_distributions_lock(base_path_update_task)
+
+    delete_task = monitor_task(
+        file_bindings.DistributionsFileApi.delete(distribution.pulp_href).task
+    )
+    assert distribution.prn in delete_task.reserved_resources_record
+    assert not has_base_path_lock(delete_task)
+    assert has_shared_distributions_lock(delete_task)
+    assert not has_exclusive_distributions_lock(delete_task)
+
+
+@pytest.mark.parallel
 def test_distribution_filtering(
     file_bindings,
     file_remote_factory,

--- a/unittest_requirements.txt
+++ b/unittest_requirements.txt
@@ -2,7 +2,7 @@
 mock
 aiotools
 pytest<8
-pytest-django
+pytest-django[django]
 pytest-asyncio
 pytest-aiohttp
 pytest-redis<3.1.0 # https://github.com/ClearcodeHQ/pytest-redis/issues/679


### PR DESCRIPTION
Reserve per-distribution locks for ordinary updates while serializing creates and base_path changes on a dedicated domain-scoped distribution.base_path resource. Keep the legacy domain:distributions reservation in shared mode for mixed-version upgrade safety, and move the shared-resource plumbing into the generic async mixins so publication.py only defines the distribution-specific lock policy.

Fixes: #3322


(cherry picked from commit d57f7275e4fb599f5488fe207fb1c8ae4472f4f5)

<!---
Thank you for submitting a PR to the Pulp Project!

If this is your first time contributing, please read the Pull Request Walkthrough documentation
(https://pulpproject.org/pulpcore/docs/dev/guides/pull-request-walkthrough/).
-->

### 📜 Checklist

- [ ] Commits are cleanly separated with meaningful messages (simple features and bug fixes should be [squashed](https://pulpproject.org/pulpcore/docs/dev/guides/git/#rebasing-and-squashing) to one commit)
- [ ] A [changelog entry](https://pulpproject.org/pulpcore/docs/dev/guides/git/#changelog-update) or entries has been added for any significant changes
- [ ] Follows the [Pulp policy on AI Usage](https://pulpproject.org/help/more/governance/ai_policy/)
- [ ] (For new features) - User documentation and test coverage has been added

See: [Pull Request Walkthrough](https://pulpproject.org/pulpcore/docs/dev/guides/pull-request-walkthrough/)
