### PR TITLE
Enable RHSM certguard tests under domains

### DIFF
--- a/CHANGES/pulp_certguard/+rhsm-domain-compat.bugfix
+++ b/CHANGES/pulp_certguard/+rhsm-domain-compat.bugfix
@@ -1,0 +1,1 @@
+Fixed RHSM certguard path matching when domains are enabled.

--- a/pulp_certguard/app/models.py
+++ b/pulp_certguard/app/models.py
@@ -155,6 +155,21 @@ class RHSMCertGuard(BaseCertGuard):
         content_path_prefix_without_trail_slash = settings.CONTENT_PATH_PREFIX.rstrip("/")
         len_prefix_to_remove = len(content_path_prefix_without_trail_slash)
         path_without_content_path_prefix = request.path[len_prefix_to_remove:]
+        if settings.DOMAIN_ENABLED:
+            # We strip the leading /{domain} segment before matching: /domain/rest... -> /rest...
+            #
+            # This is safe because domain isolation is enforced by the content guard's CA trust
+            # boundary, not by the path: a distribution only consults its own content guard
+            # (also in the current domain), and we only reach the path check once we have already
+            # verified the issuer is trusted. The path check then scopes *which content* is
+            # allowed.
+            #
+            # Limitation: the domain cannot be used to scope an entitlement to a specific domain
+            # via the path. If the same issuer CA is trusted by content guards in two domains, an
+            # entitlement cert is honored in both. For per-domain isolation, use a distinct issuer
+            # (CA) per domain rather than relying on domain-specific entitlement certificates.
+            segments = path_without_content_path_prefix.lstrip("/").split("/", 1)
+            path_without_content_path_prefix = "/" + (segments[1] if len(segments) > 1 else "")
         self._check_paths(cert, path_without_content_path_prefix)
 
     @staticmethod

--- a/pulp_certguard/docs/user/learn/overview.md
+++ b/pulp_certguard/docs/user/learn/overview.md
@@ -82,7 +82,9 @@ some/path/bar
 !!! note
     The `pulpcore-content` app typically serves `Distribution.base_path` at a url starting with
     `/pulp/content/`. When performing path checking only the `Distribution.base_path` portion of
-    the URL is checked.
+    the URL is checked. When domains are enabled the leading `/{domain}/` segment is likewise
+    excluded, so entitlement paths are matched against `Distribution.base_path` alone regardless
+    of the domain.
 
 `Distribution.base_bath` uses partial paths so it does *not* start with slash or end with one.
 The Authorized URLs on the other hand do start with a slash. The RHSM path authorization check

--- a/pulp_certguard/docs/user/tutorials/quickstart.md
+++ b/pulp_certguard/docs/user/tutorials/quickstart.md
@@ -138,14 +138,7 @@ Server: nginx/1.16.1
 
 ## RHSM-CertGuard-specific rules
 
-!!! note
-    To use the `RHSMCertGuard` you have to manually install the [rhsm Python module](https://pypi.org/project/rhsm/) which provides RHSM certificate parsing on the pulp server.
-    It requires some system level dependencies, e.g. OpenSSL libraries, which are not the same on
-    all operating operating systems. `rhsm` from PyPI not being cross-distro is why this requires
-    manual installation.
-
-
-If the RHSM client cert contains entitlement paths, **they must match the full path to the
-Distribution** the client is fetching from. In this example that is `/pulp/content/somepath/`.
-
-
+If the RHSM client cert contains entitlement paths, **they must match the `Distribution.base_path`**
+the client is fetching from. In this example that is `somepath`. Only the `base_path` portion of the
+URL is checked; the `/pulp/content/` prefix (and the `/{domain}/` segment when domains are enabled)
+is excluded.

--- a/pulp_certguard/tests/functional/api/test_rhsm_certguard.py
+++ b/pulp_certguard/tests/functional/api/test_rhsm_certguard.py
@@ -3,7 +3,6 @@ from urllib.parse import quote, urljoin
 
 import pytest
 import requests
-from django.conf import settings
 
 from pulp_certguard.tests.functional.constants import (
     RHSM_CA_CERT_FILE_PATH,
@@ -25,9 +24,6 @@ from pulp_certguard.tests.functional.constants import (
     RHSM_V3_ZERO_VAR_CLIENT_CERT,
     THIRDPARTY_CA_CERT_FILE_PATH,
 )
-
-if settings.DOMAIN_ENABLED:
-    pytest.skip("RHSM tests are currently not compatible with domains.", allow_module_level=True)
 
 
 @pytest.fixture(scope="class")
@@ -197,7 +193,7 @@ class TestRHSMCertGuard:
     """Api tests for RHSMCertGard with RHSM Certificates."""
 
     def test_allow_request_when_cert_matches_zero_var_path(
-        self, rhsm_guarded_distribution_v3_zero, content_path
+        self, rhsm_guarded_distribution_v3_zero, distribution_base_url, content_path
     ):
         """
         Assert a correctly configured client can fetch content from a zero-variable path.
@@ -205,17 +201,17 @@ class TestRHSMCertGuard:
         1. Configure the distribution with a zero-variable path in the RHSM Cert.
         2. Attempt to download content.
         """
-
+        url = distribution_base_url(rhsm_guarded_distribution_v3_zero.base_url)
         with open(RHSM_V3_ZERO_VAR_CLIENT_CERT, "r") as cert_file:
             cert_data = quote(cert_file.read())
         response = requests.get(
-            urljoin(rhsm_guarded_distribution_v3_zero.base_url, content_path),
+            urljoin(url, content_path),
             headers={"X-CLIENT-CERT": cert_data},
         )
         assert response.status_code == 200
 
     def test_allow_request_when_cert_matches_one_var_path(
-        self, rhsm_guarded_distribution_v3_one, content_path
+        self, rhsm_guarded_distribution_v3_one, distribution_base_url, content_path
     ):
         """
         Assert a correctly configured client can fetch content from a one-variable path.
@@ -223,16 +219,17 @@ class TestRHSMCertGuard:
         1. Configure the distribution with a one-variable path in the RHSM Cert.
         2. Attempt to download content.
         """
+        url = distribution_base_url(rhsm_guarded_distribution_v3_one.base_url)
         with open(RHSM_V3_ONE_AND_TWO_VAR_CLIENT_CERT, "r") as cert_file:
             cert_data = quote(cert_file.read())
         response = requests.get(
-            urljoin(rhsm_guarded_distribution_v3_one.base_url, content_path),
+            urljoin(url, content_path),
             headers={"X-CLIENT-CERT": cert_data},
         )
         assert response.status_code == 200
 
     def test_allow_request_when_cert_matches_two_var_path(
-        self, rhsm_guarded_distribution_v3_two, content_path
+        self, rhsm_guarded_distribution_v3_two, distribution_base_url, content_path
     ):
         """
         Assert a correctly configured client can fetch content from a two-variable path.
@@ -240,15 +237,18 @@ class TestRHSMCertGuard:
         1. Configure the distribution with a two-variable path in the RHSM Cert.
         2. Attempt to download content.
         """
+        url = distribution_base_url(rhsm_guarded_distribution_v3_two.base_url)
         with open(RHSM_V3_ONE_AND_TWO_VAR_CLIENT_CERT, "r") as cert_file:
             cert_data = quote(cert_file.read())
         response = requests.get(
-            urljoin(rhsm_guarded_distribution_v3_two.base_url, content_path),
+            urljoin(url, content_path),
             headers={"X-CLIENT-CERT": cert_data},
         )
         assert response.status_code == 200
 
-    def test_allow_request_to_subdir_of_path(self, rhsm_guarded_distribution_v3_zero):
+    def test_allow_request_to_subdir_of_path(
+        self, rhsm_guarded_distribution_v3_zero, distribution_base_url
+    ):
         """
         Assert a correctly configured client can fetch content from a subdir of a distribution.
 
@@ -256,12 +256,13 @@ class TestRHSMCertGuard:
         2. Attempt to download a content url with a subdir in it.
         3. Assert a 404 was received.
         """
+        url = distribution_base_url(rhsm_guarded_distribution_v3_zero.base_url)
         content_path = "somedir/made_up_content.iso"
 
         with open(RHSM_V3_ZERO_VAR_CLIENT_CERT, "r") as cert_file:
             cert_data = quote(cert_file.read())
         response = requests.get(
-            urljoin(rhsm_guarded_distribution_v3_zero.base_url, content_path),
+            urljoin(url, content_path),
             headers={"X-CLIENT-CERT": cert_data},
         )
         # The path doesn't exist so we expect a 404, but the authorization part we are testing works
@@ -269,59 +270,69 @@ class TestRHSMCertGuard:
 
     @pytest.mark.parametrize("cert_data", [None, "", "this is not cert data"])
     def test_deny_requests_with_bad_cert_data(
-        self, cert_data, content_path, rhsm_guarded_distribution_v3_zero
+        self, cert_data, content_path, rhsm_guarded_distribution_v3_zero, distribution_base_url
     ):
+        url = distribution_base_url(rhsm_guarded_distribution_v3_zero.base_url)
         response = requests.get(
-            urljoin(rhsm_guarded_distribution_v3_zero.base_url, content_path),
+            urljoin(url, content_path),
             headers=cert_data and {"X-CLIENT-CERT": cert_data},
         )
         assert response.status_code == 403
 
     def test_deny_when_client_cert_does_not_contain_subpath_of_distribution_base_path(
-        self, rhsm_guarded_distribution_v3_invalid, content_path
+        self, rhsm_guarded_distribution_v3_invalid, distribution_base_url, content_path
     ):
+        url = distribution_base_url(rhsm_guarded_distribution_v3_invalid.base_url)
         with open(RHSM_V3_ZERO_VAR_CLIENT_CERT, "r") as cert_file:
             cert_data = quote(cert_file.read())
         response = requests.get(
-            urljoin(rhsm_guarded_distribution_v3_invalid.base_url, content_path),
+            urljoin(url, content_path),
             headers=cert_data and {"X-CLIENT-CERT": cert_data},
         )
         assert response.status_code == 403
 
     def test_deny_when_client_cert_is_trusted_but_expired(
-        self, rhsm_guarded_distribution_v3_one, content_path
+        self, rhsm_guarded_distribution_v3_one, distribution_base_url, content_path
     ):
+        url = distribution_base_url(rhsm_guarded_distribution_v3_one.base_url)
         with open(RHSM_CLIENT_CERT_TRUSTED_BUT_EXPIRED, "r") as cert_file:
             cert_data = quote(cert_file.read())
         response = requests.get(
-            urljoin(rhsm_guarded_distribution_v3_one.base_url, content_path),
+            urljoin(url, content_path),
             headers=cert_data and {"X-CLIENT-CERT": cert_data},
         )
         assert response.status_code == 403
 
     def test_deny_when_client_cert_is_untrusted(
-        self, rhsm_guarded_distribution_v3_one, content_path
+        self, rhsm_guarded_distribution_v3_one, distribution_base_url, content_path
     ):
+        url = distribution_base_url(rhsm_guarded_distribution_v3_one.base_url)
         with open(RHSM_CLIENT_CERT_FROM_UNTRUSTED_CA, "r") as cert_file:
             cert_data = quote(cert_file.read())
         response = requests.get(
-            urljoin(rhsm_guarded_distribution_v3_one.base_url, content_path),
+            urljoin(url, content_path),
             headers=cert_data and {"X-CLIENT-CERT": cert_data},
         )
         assert response.status_code == 403
 
     def test_allow_request_with_uber_cert_for_any_subpath(
-        self, rhsm_guarded_distribution_uber_one, rhsm_guarded_distribution_uber_two, content_path
+        self,
+        rhsm_guarded_distribution_uber_one,
+        rhsm_guarded_distribution_uber_two,
+        distribution_base_url,
+        content_path,
     ):
         with open(RHSM_UBER_CLIENT_CERT, "r") as cert_file:
             cert_data = quote(cert_file.read())
+        url_one = distribution_base_url(rhsm_guarded_distribution_uber_one.base_url)
         response = requests.get(
-            urljoin(rhsm_guarded_distribution_uber_one.base_url, content_path),
+            urljoin(url_one, content_path),
             headers=cert_data and {"X-CLIENT-CERT": cert_data},
         )
         assert response.status_code == 200
+        url_two = distribution_base_url(rhsm_guarded_distribution_uber_two.base_url)
         response = requests.get(
-            urljoin(rhsm_guarded_distribution_uber_two.base_url, content_path),
+            urljoin(url_two, content_path),
             headers=cert_data and {"X-CLIENT-CERT": cert_data},
         )
         assert response.status_code == 200
@@ -329,7 +340,7 @@ class TestRHSMCertGuard:
 
 class TestRHSMV1CertGuard:
     def test_v1_allow_request_when_cert_matches_zero_var_path(
-        self, rhsm_guarded_distribution_v1_zero, content_path
+        self, rhsm_guarded_distribution_v1_zero, distribution_base_url, content_path
     ):
         """
         Assert a correctly configured client can fetch content from a zero-variable path.
@@ -337,16 +348,17 @@ class TestRHSMV1CertGuard:
         1. Configure the distribution with a zero-variable path in the RHSM Cert.
         2. Attempt to download content.
         """
+        url = distribution_base_url(rhsm_guarded_distribution_v1_zero.base_url)
         with open(RHSM_V1_ZERO_VAR_CLIENT_CERT, "r") as cert_file:
             cert_data = quote(cert_file.read())
         response = requests.get(
-            urljoin(rhsm_guarded_distribution_v1_zero.base_url, content_path),
+            urljoin(url, content_path),
             headers=cert_data and {"X-CLIENT-CERT": cert_data},
         )
         assert response.status_code == 200
 
     def test_v1_allow_request_when_cert_matches_one_var_path(
-        self, rhsm_guarded_distribution_v1_one, content_path
+        self, rhsm_guarded_distribution_v1_one, distribution_base_url, content_path
     ):
         """
         Assert a correctly configured client can fetch content from a one-variable path.
@@ -354,16 +366,17 @@ class TestRHSMV1CertGuard:
         1. Configure the distribution with a one-variable path in the RHSM Cert.
         2. Attempt to download content.
         """
+        url = distribution_base_url(rhsm_guarded_distribution_v1_one.base_url)
         with open(RHSM_V1_ONE_AND_TWO_VAR_CLIENT_CERT, "r") as cert_file:
             cert_data = quote(cert_file.read())
         response = requests.get(
-            urljoin(rhsm_guarded_distribution_v1_one.base_url, content_path),
+            urljoin(url, content_path),
             headers=cert_data and {"X-CLIENT-CERT": cert_data},
         )
         assert response.status_code == 200
 
     def test_v1_allow_request_when_cert_matches_two_var_path(
-        self, rhsm_guarded_distribution_v1_two, content_path
+        self, rhsm_guarded_distribution_v1_two, distribution_base_url, content_path
     ):
         """
         Assert a correctly configured client can fetch content from a two-variable path.
@@ -371,15 +384,18 @@ class TestRHSMV1CertGuard:
         1. Configure the distribution with a two-variable path in the RHSM Cert.
         2. Attempt to download content.
         """
+        url = distribution_base_url(rhsm_guarded_distribution_v1_two.base_url)
         with open(RHSM_V1_ONE_AND_TWO_VAR_CLIENT_CERT, "r") as cert_file:
             cert_data = quote(cert_file.read())
         response = requests.get(
-            urljoin(rhsm_guarded_distribution_v1_two.base_url, content_path),
+            urljoin(url, content_path),
             headers=cert_data and {"X-CLIENT-CERT": cert_data},
         )
         assert response.status_code == 200
 
-    def test_v1_allow_request_to_subdir_of_path(self, rhsm_guarded_distribution_v1_zero):
+    def test_v1_allow_request_to_subdir_of_path(
+        self, rhsm_guarded_distribution_v1_zero, distribution_base_url
+    ):
         """
         Assert a correctly configured client can fetch content from a subdir of a distribution.
 
@@ -387,11 +403,12 @@ class TestRHSMV1CertGuard:
         2. Attempt to download a content url with a subdir in it.
         3. Assert a 404 was received.
         """
+        url = distribution_base_url(rhsm_guarded_distribution_v1_zero.base_url)
         content_path = "somedir/made_up_content.iso"
         with open(RHSM_V1_ZERO_VAR_CLIENT_CERT, "r") as cert_file:
             cert_data = quote(cert_file.read())
         response = requests.get(
-            urljoin(rhsm_guarded_distribution_v1_zero.base_url, content_path),
+            urljoin(url, content_path),
             headers=cert_data and {"X-CLIENT-CERT": cert_data},
         )
         # The path doesn't exist so we expect a 404, but the authorization part we are testing works
@@ -402,11 +419,14 @@ class TestRHSMCACertGuard:
     """Api tests for RHSMCertGard with RHSM Certificate bundles."""
 
     # Extra class because base_path collides.
-    def test_allow_request_with_ca_bundle(self, rhsmca_guarded_distribution, content_path):
+    def test_allow_request_with_ca_bundle(
+        self, rhsmca_guarded_distribution, distribution_base_url, content_path
+    ):
+        url = distribution_base_url(rhsmca_guarded_distribution.base_url)
         with open(RHSM_V3_ZERO_VAR_CLIENT_CERT, "r") as cert_file:
             cert_data = quote(cert_file.read())
         response = requests.get(
-            urljoin(rhsmca_guarded_distribution.base_url, content_path),
+            urljoin(url, content_path),
             headers=cert_data and {"X-CLIENT-CERT": cert_data},
         )
         assert response.status_code == 200


### PR DESCRIPTION
<!---
Thank you for submitting a PR to the Pulp Project!

If this is your first time contributing, please read the Pull Request Walkthrough documentation
(https://pulpproject.org/pulpcore/docs/dev/guides/pull-request-walkthrough/).
-->

### 📜 Checklist

- [ ] Commits are cleanly separated with meaningful messages (simple features and bug fixes should be [squashed](https://pulpproject.org/pulpcore/docs/dev/guides/git/#rebasing-and-squashing) to one commit)
- [ ] A [changelog entry](https://pulpproject.org/pulpcore/docs/dev/guides/git/#changelog-update) or entries has been added for any significant changes
- [ ] Follows the [Pulp policy on AI Usage](https://pulpproject.org/help/more/governance/ai_policy/)
- [ ] (For new features) - User documentation and test coverage has been added

See: [Pull Request Walkthrough](https://pulpproject.org/pulpcore/docs/dev/guides/pull-request-walkthrough/)
