### PR TITLE
fix: fetch_task() blocked-resource exclusion to prevent head-of-line blocking

### DIFF
--- a/pulpcore/tasking/redis_worker.py
+++ b/pulpcore/tasking/redis_worker.py
@@ -477,27 +477,37 @@ class RedisWorker:
         Fetch an available waiting task using Redis locks.
 
         This method:
-        1. Queries waiting tasks (sorted by creation time, limited)
-        2. For each task, attempts to acquire Redis distributed locks for exclusive resources
-        3. If resource locks acquired, attempts to claim the task
-           with a Redis task lock (24h expiration)
-        4. Returns the first task for which both locks can be acquired
-        5. If no task found in the batch, doubles the fetch limit and retries from the oldest
+        1. Queries waiting tasks (sorted by creation time, limited batch size)
+        2. Excludes tasks whose resources are known to be blocked from prior batches
+        3. For each task, attempts to acquire Redis distributed locks
+        4. If locks acquired, attempts to claim the task via DB update
+        5. Returns the first successfully claimed task
+        6. If no task claimed, re-queries with an expanded blocked-resource exclusion set
+
+        The blocked-resource exclusion leverages the existing GIN index on
+        reserved_resources_record to skip tasks at the DB level, avoiding the
+        head-of-line blocking problem where thousands of tasks for one serialized
+        resource prevent workers from reaching tasks with free resources.
 
         Returns:
             Task: A task object if one was successfully locked, None otherwise
         """
-        fetch_limit = FETCH_TASK_LIMIT
+        blocked_resources = set()
 
         while True:
             taken_exclusive = set()
             taken_shared = set()
 
-            waiting_tasks = list(
+            qs = (
                 Task.objects.filter(state=TASK_STATES.WAITING, app_lock=None)
                 .exclude(pk__in=self.ignored_task_ids)
-                .order_by("pulp_created")
-                .select_related("pulp_domain")[:fetch_limit]
+            )
+            if blocked_resources:
+                qs = qs.exclude(reserved_resources_record__overlap=list(blocked_resources))
+
+            waiting_tasks = list(
+                qs.order_by("pulp_created")
+                .select_related("pulp_domain")[:FETCH_TASK_LIMIT]
             )
 
             if not waiting_tasks:
@@ -533,6 +543,10 @@ class RedisWorker:
                         shared_resources,
                     )
                     if blocked_resource_list:
+                        for br in blocked_resource_list:
+                            br_str = br.decode() if isinstance(br, bytes) else str(br)
+                            if br_str != "__task_lock__":
+                                blocked_resources.add(br_str)
                         continue
 
                     rows = Task.objects.filter(
@@ -557,10 +571,8 @@ class RedisWorker:
                         pass
                     continue
 
-            if len(waiting_tasks) < fetch_limit:
+            if len(waiting_tasks) < FETCH_TASK_LIMIT:
                 break
-
-            fetch_limit *= 2
 
         return None
 

--- a/pulpcore/tests/unit/tasking/test_fetch_task_head_of_line.py
+++ b/pulpcore/tests/unit/tasking/test_fetch_task_head_of_line.py
@@ -1,0 +1,136 @@
+"""Tests for fetch_task() blocked-resource DB-level exclusion (issue #7900)."""
+
+from types import SimpleNamespace
+from unittest.mock import patch
+from uuid import uuid4
+
+import pytest
+
+from pulpcore.app.models import AppStatus, Task
+from pulpcore.constants import TASK_STATES
+from pulpcore.tasking.redis_worker import FETCH_TASK_LIMIT, RedisWorker
+
+
+def _create_waiting_task(resources=None, name="test.fetch_task"):
+    return Task.objects.create(
+        name=name,
+        state=TASK_STATES.WAITING,
+        logging_cid="",
+        reserved_resources_record=resources,
+    )
+
+
+@pytest.fixture
+def worker():
+    """Build a minimal object with the attributes fetch_task() needs."""
+    AppStatus.objects._current_app_status = None
+    app_status = AppStatus.objects.create(
+        name=f"test-worker-{uuid4()}", app_type="worker", versions={}
+    )
+    w = SimpleNamespace(
+        redis_conn=None,
+        name=app_status.name,
+        ignored_task_ids=[],
+        app_status=app_status,
+    )
+    yield w
+    app_status.delete()
+    AppStatus.objects._current_app_status = None
+
+
+@pytest.mark.django_db
+def test_blocked_resource_exclusion_reaches_free_tasks(worker):
+    """When queue head is dominated by one blocked resource, fetch_task skips
+    them at the DB level and claims a task with a free resource."""
+    blocked_res = f"prn:core.repository:{uuid4()}"
+    free_res = f"prn:core.repository:{uuid4()}"
+
+    for _ in range(FETCH_TASK_LIMIT + 5):
+        _create_waiting_task(resources=[blocked_res])
+
+    free_task = _create_waiting_task(resources=[free_res])
+
+    acquire_calls = []
+
+    def mock_acquire(_conn, _owner, _task_key, exclusive, shared):
+        acquire_calls.append(exclusive + shared)
+        resources = exclusive + shared
+        if any(r == blocked_res for r in resources):
+            return [blocked_res.encode()]
+        return []
+
+    with patch("pulpcore.tasking.redis_worker.acquire_locks", side_effect=mock_acquire):
+        result = RedisWorker.fetch_task(worker)
+
+    assert result is not None
+    assert result.pk == free_task.pk
+    assert len(acquire_calls) <= FETCH_TASK_LIMIT + 1
+
+
+@pytest.mark.django_db
+def test_no_infinite_loop_all_blocked(worker):
+    """When every task is blocked, fetch_task returns None without looping."""
+    blocked_res = f"prn:core.repository:{uuid4()}"
+
+    for _ in range(5):
+        _create_waiting_task(resources=[blocked_res])
+
+    def mock_acquire(_conn, _owner, _task_key, exclusive, shared):
+        return [blocked_res.encode()]
+
+    with patch("pulpcore.tasking.redis_worker.acquire_locks", side_effect=mock_acquire):
+        result = RedisWorker.fetch_task(worker)
+
+    assert result is None
+
+
+@pytest.mark.django_db
+def test_multiple_blocked_resources_excluded(worker):
+    """Resources from multiple failed acquire_locks calls are all excluded."""
+    res_a = f"prn:core.repository:{uuid4()}"
+    res_b = f"prn:core.repository:{uuid4()}"
+    free_res = f"prn:core.repository:{uuid4()}"
+
+    for _ in range(10):
+        _create_waiting_task(resources=[res_a])
+    for _ in range(10):
+        _create_waiting_task(resources=[res_b])
+
+    free_task = _create_waiting_task(resources=[free_res])
+
+    def mock_acquire(_conn, _owner, _task_key, exclusive, shared):
+        resources = exclusive + shared
+        if any(r == res_a for r in resources):
+            return [res_a.encode()]
+        if any(r == res_b for r in resources):
+            return [res_b.encode()]
+        return []
+
+    with patch("pulpcore.tasking.redis_worker.acquire_locks", side_effect=mock_acquire):
+        result = RedisWorker.fetch_task(worker)
+
+    assert result is not None
+    assert result.pk == free_task.pk
+
+
+@pytest.mark.django_db
+def test_task_lock_not_added_to_blocked_resources(worker):
+    """__task_lock__ from acquire_locks is not treated as a resource exclusion."""
+    res_a = f"prn:core.repository:{uuid4()}"
+    res_b = f"prn:core.repository:{uuid4()}"
+
+    _create_waiting_task(resources=[res_a])
+    _create_waiting_task(resources=[res_b])
+
+    call_count = [0]
+
+    def mock_acquire(_conn, _owner, _task_key, exclusive, shared):
+        call_count[0] += 1
+        if call_count[0] == 1:
+            return [b"__task_lock__"]
+        return []
+
+    with patch("pulpcore.tasking.redis_worker.acquire_locks", side_effect=mock_acquire):
+        result = RedisWorker.fetch_task(worker)
+
+    assert result is not None


### PR DESCRIPTION
## Summary

Fixes #7900 — `fetch_task()` in `RedisWorker` now tracks resources that `acquire_locks()` reports as blocked and excludes tasks needing those resources from subsequent DB queries using the existing GIN index on `reserved_resources_record`.

**Problem:** When the queue head is dominated by tasks needing the same exclusive resource (e.g., 17,000+ `general_create` tasks for one Python repository), all workers scan the same FIFO head, find everything blocked, and never reach tasks with free resources further down the queue. The previous `fetch_limit` doubling mechanism was insufficient because it always re-queried from position 0, re-examining already-checked tasks.

**Fix:** After `acquire_locks()` fails, add the blocked resource names to a `blocked_resources` set. On the next batch query, use `reserved_resources_record__overlap` to exclude tasks for those resources at the DB level. This leverages the existing partial GIN index (`pulp_task_resources_index`). In the incident scenario, the second query skips all 17,000 blocked tasks and returns tasks with free resources.

**Key properties:**
- FIFO fairness within same resource preserved
- No changes to Redis lock mechanism (`acquire_locks` Lua script unchanged)
- No changes to `handle_tasks()` interface (`fetch_task()` still returns Task or None)
- `blocked_resources` is local to each `fetch_task()` call — starts fresh after each task completes
- Conservative resource exclusion — only raw resource names added (not `shared:` prefixed)

## Test plan

- [x] Unit test: blocked-resource exclusion reaches free tasks past queue head
- [x] Unit test: all-blocked terminates without infinite loop
- [x] Unit test: multiple blocked resources accumulated across batches
- [x] Unit test: `__task_lock__` not treated as resource exclusion
- [ ] CI passes