### PR TITLE
Fix escape character warning in migration

### DIFF
--- a/pulpcore/app/migrations/0155_create_rel_path_domains.py
+++ b/pulpcore/app/migrations/0155_create_rel_path_domains.py
@@ -3,7 +3,7 @@
 from django.db import migrations
 
 
-CREATE_REL_PATH_DOMAINS = """
+CREATE_REL_PATH_DOMAINS = r"""
 CREATE DOMAIN "relative_path" AS text CHECK ('/' || VALUE || '/' !~ '[\n\r\s\t\?#]|(/\.{0,2}/)');
 """
 


### PR DESCRIPTION
```
/src/pulpcore/pulpcore/app/migrations/0155_create_rel_path_domains.py:7: SyntaxWarning: invalid escape sequence '\s'
  CREATE DOMAIN "relative_path" AS text CHECK ('/' || VALUE || '/' !~ '[\n\r\s\t\?#]|(/\.{0,2}/)');
```

Set the SQL string to raw to avoid warning when file is loaded.

### 📜 Checklist

- [ ] Commits are cleanly separated with meaningful messages (simple features and bug fixes should be [squashed](https://pulpproject.org/pulpcore/docs/dev/guides/git/#rebasing-and-squashing) to one commit)
- [ ] A [changelog entry](https://pulpproject.org/pulpcore/docs/dev/guides/git/#changelog-update) or entries has been added for any significant changes
- [ ] Follows the [Pulp policy on AI Usage](https://pulpproject.org/help/more/governance/ai_policy/)
- [ ] (For new features) - User documentation and test coverage has been added

See: [Pull Request Walkthrough](https://pulpproject.org/pulpcore/docs/dev/guides/pull-request-walkthrough/)
