### PR TITLE
Return correct error code on failed authentication

### DIFF
--- a/CHANGES/+fix-content-401-unauthenticated.bugfix
+++ b/CHANGES/+fix-content-401-unauthenticated.bugfix
@@ -1,0 +1,1 @@
+Fixed the content app returning `403 Forbidden` instead of `401 Unauthorized` when a request to a guarded distribution had no (or invalid) credentials at all.

--- a/pulpcore/app/models/__init__.py
+++ b/pulpcore/app/models/__init__.py
@@ -51,6 +51,7 @@ from .importer import (
 )
 
 from .publication import (
+    AuthenticationRequired,
     ContentGuard,
     Distribution,
     DistributedPublication,
@@ -139,6 +140,7 @@ __all__ = [
     "Importer",
     "PulpImport",
     "PulpImporter",
+    "AuthenticationRequired",
     "ContentGuard",
     "Distribution",
     "DistributedPublication",

--- a/pulpcore/app/models/publication.py
+++ b/pulpcore/app/models/publication.py
@@ -17,7 +17,7 @@ from django.contrib.postgres.indexes import OpClass, SpGistIndex
 from django.db import DatabaseError, IntegrityError, models, transaction
 from django.utils import timezone
 from django_lifecycle import AFTER_CREATE, AFTER_UPDATE, BEFORE_CREATE, BEFORE_DELETE, hook
-from rest_framework.exceptions import APIException
+from rest_framework.exceptions import APIException, AuthenticationFailed, NotAuthenticated
 from url_normalize import url_normalize
 
 from pulpcore.app.files import PulpTemporaryUploadedFile
@@ -366,6 +366,17 @@ class PublishedMetadata(Content):
         unique_together = ("publication", "relative_path")
 
 
+class AuthenticationRequired(PermissionError):
+    """
+    Raised by a :class:`ContentGuard` when the request has no (or invalid) credentials at all.
+
+    This is distinct from a plain :class:`PermissionError`, which signals that the request was
+    authenticated but is not authorized to access the content. The content app maps this
+    exception to an HTTP 401 response (with a `WWW-Authenticate` header), while a plain
+    `PermissionError` is mapped to an HTTP 403, matching normal HTTP authentication semantics.
+    """
+
+
 class ContentGuard(MasterModel):
     """
     Defines a named content guard.
@@ -399,6 +410,9 @@ class ContentGuard(MasterModel):
 
         Raises:
             PermissionError: When not authorized.
+            AuthenticationRequired: When no (or invalid) credentials were provided at all. This
+                is a subclass of `PermissionError`, so guards that don't distinguish the two
+                cases can keep raising a plain `PermissionError` and will keep getting a 403.
         """
         raise NotImplementedError()
 
@@ -433,8 +447,11 @@ class RBACContentGuard(ContentGuard, AutoAddObjPermsMixin):
         setattr(view, "action", "download")
         try:
             view.check_permissions(drequest)
+        except (NotAuthenticated, AuthenticationFailed) as e:
+            # No (or invalid) credentials were provided at all -> 401, not 403.
+            raise AuthenticationRequired(e) from e
         except APIException as e:
-            raise PermissionError(e)
+            raise PermissionError(e) from e
 
     class Meta:
         default_related_name = "%(app_label)s_%(model_name)s"
@@ -599,6 +616,9 @@ class CompositeContentGuard(ContentGuard, AutoAddObjPermsMixin):
             try:
                 detail_guard.permit(request)
                 return  # success on first-pass
+            except AuthenticationRequired:
+                # Re-raise immediately to preserve 401 status, don't aggregate with other denials
+                raise
             except PermissionError as pe:
                 guard_error = _("Guard: '{}', HREF: '{}', class: '{}', denial: [{}].").format(
                     detail_guard.name, get_url(detail_guard), type(detail_guard), str(pe)

--- a/pulpcore/content/handler.py
+++ b/pulpcore/content/handler.py
@@ -18,6 +18,7 @@ from aiohttp.web_exceptions import (
     HTTPMovedPermanently,
     HTTPNotFound,
     HTTPRequestRangeNotSatisfiable,
+    HTTPUnauthorized,
 )
 from asgiref.sync import sync_to_async
 from django.utils import timezone
@@ -48,6 +49,7 @@ from pulpcore.app import mime_types  # noqa: E402
 from pulpcore.app.models import (  # noqa: E402
     Artifact,
     ArtifactDistribution,
+    AuthenticationRequired,
     ContentArtifact,
     Distribution,
     Publication,
@@ -262,7 +264,7 @@ class Handler:
             )
             try:
                 guard = await sync_to_async(cls._permit)(request, distro)
-            except HTTPForbidden:
+            except (HTTPForbidden, HTTPUnauthorized):
                 guard = True
                 raise
             finally:
@@ -490,12 +492,20 @@ class Handler:
 
         Raises:
             [aiohttp.web_exceptions.HTTPForbidden][]: When not permitted.
+            [aiohttp.web_exceptions.HTTPUnauthorized][]: When no (or invalid) credentials were
+                provided at all.
         """
         guard = distribution.content_guard
         if not guard:
             return False
         try:
             guard.cast().permit(request)
+        except AuthenticationRequired as ar:
+            log.debug(
+                'Path: %(p)s not authenticated for guard: "%(g)s" reason: %(r)s',
+                {"p": request.path, "g": guard.name, "r": str(ar)},
+            )
+            raise HTTPUnauthorized(reason=str(ar))
         except PermissionError as pe:
             log.debug(
                 'Path: %(p)s not permitted by guard: "%(g)s" reason: %(r)s',

--- a/pulpcore/tests/functional/api/using_plugin/test_contentguard.py
+++ b/pulpcore/tests/functional/api/using_plugin/test_contentguard.py
@@ -46,7 +46,14 @@ def test_rbac_content_guard_full_workflow(
             else:
                 auth = None
             response = get_from_url(distribution_base_url(distro.base_url), auth=auth)
-            expected_status = 404 if user in authorized_users else 403
+            if user in authorized_users:
+                expected_status = 404
+            elif user is anonymous_user:
+                # No credentials at all -> Unauthorized, not Forbidden.
+                expected_status = 401
+            else:
+                # Authenticated, but not permitted.
+                expected_status = 403
             assert response.status == expected_status, f"Failed on {user.username=}"
 
     # Make sure all users can access the distribution URL without a content guard

--- a/pulpcore/tests/unit/test_content_guard.py
+++ b/pulpcore/tests/unit/test_content_guard.py
@@ -4,8 +4,15 @@ from base64 import b64encode
 from unittest.mock import Mock
 
 import pytest
+from rest_framework.exceptions import NotAuthenticated, PermissionDenied
 
-from pulpcore.app.models import ContentRedirectContentGuard, HeaderContentGuard
+from pulpcore.app.models import (
+    AuthenticationRequired,
+    ContentRedirectContentGuard,
+    HeaderContentGuard,
+    RBACContentGuard,
+)
+from pulpcore.app.viewsets import RBACContentGuardViewSet
 
 
 def test_preauthenticate_urls():
@@ -142,3 +149,38 @@ def test_header_content_guard(db):
     encoded_value = b64encode(b"somevalue")
     request.headers = {"x-header-name": encoded_value}
     assert not content_guard_without_jq_filter.permit(request)
+
+
+def test_rbac_content_guard_no_credentials_raises_authentication_required(monkeypatch):
+    """
+    No credentials at all must surface as AuthenticationRequired (-> HTTP 401), not a plain
+    PermissionError (-> HTTP 403). Regression test for the content app returning 403 for
+    unauthenticated requests.
+    """
+
+    def raise_not_authenticated(self, request):
+        raise NotAuthenticated()
+
+    monkeypatch.setattr(RBACContentGuardViewSet, "check_permissions", raise_not_authenticated)
+
+    content_guard = RBACContentGuard(name="rbac_guard")
+    request = {"drf_request": Mock()}
+
+    with pytest.raises(AuthenticationRequired):
+        content_guard.permit(request)
+
+
+def test_rbac_content_guard_bad_permissions_raises_permission_error(monkeypatch):
+    """An authenticated-but-unauthorized request should still raise a plain PermissionError."""
+
+    def raise_permission_denied(self, request):
+        raise PermissionDenied()
+
+    monkeypatch.setattr(RBACContentGuardViewSet, "check_permissions", raise_permission_denied)
+
+    content_guard = RBACContentGuard(name="rbac_guard")
+    request = {"drf_request": Mock()}
+
+    with pytest.raises(PermissionError) as exc_info:
+        content_guard.permit(request)
+    assert not isinstance(exc_info.value, AuthenticationRequired)


### PR DESCRIPTION
Similarly to https://github.com/pulp/pulpcore/issues/3730, if a user try to fetch a Python package wheel from a pulp private PyPI registry without authentication, Pulp returns 403 Forbidden instead of 401 Unauthorized as expected.

This PR address that, by adding a new error class `AuthenticationRequired` which is raised when not authenticated. In turn, this raise a `aiohttp.web_exceptions.HTTPUnauthorized` which emits a 401 error as expected.

Fixes #7994

AI assisted the creation of the patch, I manually verified the outcome.

### 📜 Checklist

- [x] Commits are cleanly separated with meaningful messages (simple features and bug fixes should be [squashed](https://pulpproject.org/pulpcore/docs/dev/guides/git/#rebasing-and-squashing) to one commit)
- [x] A [changelog entry](https://pulpproject.org/pulpcore/docs/dev/guides/git/#changelog-update) or entries has been added for any significant changes
- [x] Follows the [Pulp policy on AI Usage](https://pulpproject.org/help/more/governance/ai_policy/)
- [ ] (For new features) - User documentation and test coverage has been added

See: [Pull Request Walkthrough](https://pulpproject.org/pulpcore/docs/dev/guides/pull-request-walkthrough/)
