### PR TITLE
Reuse existing Artifacts on synchronous File uploads

### DIFF
--- a/CHANGES/pulp_file/+reuse-upload-artifacts.bugfix
+++ b/CHANGES/pulp_file/+reuse-upload-artifacts.bugfix
@@ -1,0 +1,1 @@
+Fixed synchronous File uploads failing with "Artifact already exists" instead of reusing the existing Artifact.

--- a/pulp_file/app/serializers.py
+++ b/pulp_file/app/serializers.py
@@ -2,14 +2,13 @@ from gettext import gettext as _
 from tempfile import NamedTemporaryFile
 
 from django.conf import settings
-from django.db import DatabaseError
+from django.db import DatabaseError, IntegrityError, transaction
 from rest_framework import serializers
 
 from pulpcore.plugin import models
 from pulpcore.plugin.files import PulpTemporaryUploadedFile
 from pulpcore.plugin.serializers import (
     AlternateContentSourceSerializer,
-    ArtifactSerializer,
     ContentChecksumSerializer,
     DetailRelatedField,
     DistributionSerializer,
@@ -90,21 +89,25 @@ class FileContentUploadSerializer(FileContentSerializer):
                 file_url, expected_digests=expected_digests, expected_size=expected_size
             )
         if file := data.pop("file", None):
-            # if artifact already exists, let's use it
+            artifact = models.Artifact.init_and_validate(file)
             try:
                 artifact = models.Artifact.objects.get(
-                    sha256=file.hashers["sha256"].hexdigest(), pulp_domain=get_domain_pk()
+                    sha256=artifact.sha256, pulp_domain=get_domain_pk()
                 )
                 if not artifact.pulp_domain.get_storage().exists(artifact.file.name):
+                    # save() rewrites storage only when file is set and dirty
                     artifact.file = file
-                    artifact.save()
-                else:
-                    artifact.touch()
+                    raise models.Artifact.DoesNotExist
+                artifact.touch()
             except (models.Artifact.DoesNotExist, DatabaseError):
-                artifact_data = {"file": file}
-                serializer = ArtifactSerializer(data=artifact_data)
-                serializer.is_valid(raise_exception=True)
-                artifact = serializer.save()
+                try:
+                    with transaction.atomic():
+                        artifact.save()
+                except IntegrityError:
+                    artifact = models.Artifact.objects.get(
+                        sha256=artifact.sha256, pulp_domain=get_domain_pk()
+                    )
+                    artifact.touch()
             data["artifact"] = artifact
 
         data["digest"] = data["artifact"].sha256

--- a/pulpcore/tests/functional/api/test_upload.py
+++ b/pulpcore/tests/functional/api/test_upload.py
@@ -3,6 +3,7 @@
 import hashlib
 import os
 import uuid
+from concurrent.futures import ThreadPoolExecutor
 from random import shuffle
 
 import pytest
@@ -259,3 +260,41 @@ def test_upload_synchronous(file_bindings, gen_user, file_fixtures_root):
         upload_attrs = {"file": str(file_path), "relative_path": "1.iso", "pulp_labels": labels}
         file_bindings.ContentFilesApi.upload(**upload_attrs)
     assert ctx.value.status == 403
+
+
+@pytest.mark.parallel
+def test_sync_upload_reuses_existing_artifact(file_bindings, tmp_path):
+    """Uploading the same bytes twice should reuse the Artifact instead of 400ing."""
+    path = tmp_path / "blob"
+    path.write_bytes(uuid.uuid4().bytes)
+
+    first = file_bindings.ContentFilesApi.upload(
+        relative_path=f"{uuid.uuid4()}.bin", file=str(path)
+    )
+    second = file_bindings.ContentFilesApi.upload(
+        relative_path=f"{uuid.uuid4()}.bin", file=str(path)
+    )
+    first = file_bindings.ContentFilesApi.read(first.pulp_href)
+    second = file_bindings.ContentFilesApi.read(second.pulp_href)
+
+    assert first.pulp_href != second.pulp_href
+    assert first.sha256 == second.sha256
+    assert first.artifact == second.artifact
+
+
+@pytest.mark.parallel
+def test_sync_upload_reuses_artifact_concurrently(file_bindings, tmp_path):
+    """Concurrent uploads of the same bytes must share one Artifact."""
+    path = tmp_path / "blob"
+    path.write_bytes(uuid.uuid4().bytes)
+    names = [f"{uuid.uuid4()}.bin" for _ in range(4)]
+
+    def _upload(name):
+        return file_bindings.ContentFilesApi.upload(relative_path=name, file=str(path))
+
+    with ThreadPoolExecutor(max_workers=4) as pool:
+        results = list(pool.map(_upload, names))
+
+    contents = [file_bindings.ContentFilesApi.read(result.pulp_href) for result in results]
+    assert len({content.artifact for content in contents}) == 1
+    assert len({content.pulp_href for content in contents}) == 4


### PR DESCRIPTION
The upload serializer rejected concurrent uploads of the same bytes with a unique-validator 400 instead of reusing the Artifact, which failed s3 CI under xdist (https://github.com/pulp/pulpcore/actions/runs/33015779152/job/98338927345?pr=8014#step:15:24815)

Assisted by: cursor-grok-4.6

<!---
Thank you for submitting a PR to the Pulp Project!

If this is your first time contributing, please read the Pull Request Walkthrough documentation
(https://pulpproject.org/pulpcore/docs/dev/guides/pull-request-walkthrough/).
-->

### 📜 Checklist

- [ ] Commits are cleanly separated with meaningful messages (simple features and bug fixes should be [squashed](https://pulpproject.org/pulpcore/docs/dev/guides/git/#rebasing-and-squashing) to one commit)
- [ ] A [changelog entry](https://pulpproject.org/pulpcore/docs/dev/guides/git/#changelog-update) or entries has been added for any significant changes
- [ ] Follows the [Pulp policy on AI Usage](https://pulpproject.org/help/more/governance/ai_policy/)
- [ ] (For new features) - User documentation and test coverage has been added

See: [Pull Request Walkthrough](https://pulpproject.org/pulpcore/docs/dev/guides/pull-request-walkthrough/)
