### PR TITLE
Defer GitPython import into GitFirstState.run()

### DIFF
--- a/CHANGES/pulp_file/+defer-gitpython-import.bugfix
+++ b/CHANGES/pulp_file/+defer-gitpython-import.bugfix
@@ -1,0 +1,1 @@
+GitPython is now imported only when syncing a `FileGitRemote`, so `pulp_file` loads on installs with no `git` executable on `PATH`.

--- a/pulp_file/app/tasks/synchronizing.py
+++ b/pulp_file/app/tasks/synchronizing.py
@@ -7,10 +7,8 @@ from gettext import gettext as _
 from hashlib import sha256
 from urllib.parse import quote, urlparse, urlunparse
 
-import git as gitpython
 from django.conf import settings
 from django.core.files import File
-from gitdb.exc import BadName, BadObject
 
 from pulpcore.plugin.exceptions import SyncError
 from pulpcore.plugin.models import Artifact, ProgressReport, PublishedMetadata, Remote
@@ -406,6 +404,16 @@ class GitFirstStage(Stage):
         """
         Build and emit `DeclarativeContent` from the Git repository tree.
         """
+        # Imported here rather than at module scope: GitPython runs refresh() on
+        # import and raises unless a git binary is on PATH, which would make the
+        # whole plugin unimportable on installs that only use FileRemote.
+        try:
+            import git as gitpython
+            from gitdb.exc import BadName, BadObject
+        except ImportError:
+            raise SyncError(
+                _("Syncing a FileGitRemote requires GitPython and a git executable on PATH.")
+            )
 
         remote = self.remote
         git_ref = remote.git_ref or "HEAD"


### PR DESCRIPTION
gitpython calls refresh() on import, which obnoxiously raises if git binary isnt on PATH. Since the file plugin can be used without git at all, this doesn't make sense to impose as a hard requirement. this changes moves the import to only when git repos are being requested.

<!---
Thank you for submitting a PR to the Pulp Project!

If this is your first time contributing, please read the Pull Request Walkthrough documentation
(https://pulpproject.org/pulpcore/docs/dev/guides/pull-request-walkthrough/).
-->

### 📜 Checklist

- [x] Commits are cleanly separated with meaningful messages (simple features and bug fixes should be [squashed](https://pulpproject.org/pulpcore/docs/dev/guides/git/#rebasing-and-squashing) to one commit)
- [x] A [changelog entry](https://pulpproject.org/pulpcore/docs/dev/guides/git/#changelog-update) or entries has been added for any significant changes
- [x] Follows the [Pulp policy on AI Usage](https://pulpproject.org/help/more/governance/ai_policy/)
- [ ] (For new features) - User documentation and test coverage has been added

See: [Pull Request Walkthrough](https://pulpproject.org/pulpcore/docs/dev/guides/pull-request-walkthrough/)
