### PR TITLE
Add --no-control-socket flag for disabling gunicorn control socket

### DIFF
--- a/CHANGES/+no-control-socket.feature
+++ b/CHANGES/+no-control-socket.feature
@@ -1,0 +1,1 @@
+Added `--no-control-socket` flag to `pulpcore-api` and `pulpcore-content` commands to disable the gunicorn control socket.

--- a/pulpcore/app/entrypoint.py
+++ b/pulpcore/app/entrypoint.py
@@ -189,6 +189,14 @@ class PulpcoreApiApplication(PulpcoreGunicornApplication):
     help="Path to the gunicorn control socket (requires gunicorn>=25.1).",
 )
 @click.option(
+    "--no-control-socket",
+    "control_socket_disable",
+    default=None,
+    is_flag=True,
+    flag_value=True,
+    help="Disable the gunicorn control socket (requires gunicorn>=25.1).",
+)
+@click.option(
     "--name-template",
     type=str,
     help="Format string to use for the status name. "

--- a/pulpcore/app/pulpcore_gunicorn_application.py
+++ b/pulpcore/app/pulpcore_gunicorn_application.py
@@ -5,18 +5,34 @@ from gunicorn.app.base import Application
 
 
 def handle_control_interface_feature(options):
-    """Drop control_socket from options if gunicorn<25.1, which introduced the feature."""
+    """Drop control_socket/control_socket_disable from options if gunicorn<25.1."""
     # TODO: remove this function when gunicorn lowerbound>=25.1
-    if options.get("control_socket") is None:
+    has_control_socket = options.get("control_socket") is not None
+    has_control_socket_disable = options.get("control_socket_disable") is True
+
+    if not has_control_socket and not has_control_socket_disable:
         return
+
+    if has_control_socket and has_control_socket_disable:
+        sys.stderr.write(
+            "Error: --control-socket and --no-control-socket are mutually exclusive.\n"
+        )
+        exit(1)
 
     gunicorn_version = tuple(int(x) for x in pkg_version("gunicorn").split(".")[:2])
     if gunicorn_version < (25, 1):
-        sys.stderr.write(
-            "Warning: --control-socket requires gunicorn>=25.1, ignoring "
-            f"(installed: {'.'.join(str(x) for x in gunicorn_version)}).\n"
-        )
-        options["control_socket"] = None
+        if has_control_socket:
+            sys.stderr.write(
+                "Warning: --control-socket requires gunicorn>=25.1, ignoring "
+                f"(installed: {'.'.join(str(x) for x in gunicorn_version)}).\n"
+            )
+            options["control_socket"] = None
+        if has_control_socket_disable:
+            sys.stderr.write(
+                "Warning: --no-control-socket requires gunicorn>=25.1, ignoring "
+                f"(installed: {'.'.join(str(x) for x in gunicorn_version)}).\n"
+            )
+            options["control_socket_disable"] = None
 
 
 class PulpcoreGunicornApplication(Application):

--- a/pulpcore/content/entrypoint.py
+++ b/pulpcore/content/entrypoint.py
@@ -60,6 +60,14 @@ class PulpcoreContentApplication(PulpcoreGunicornApplication):
     help="Path to the gunicorn control socket (requires gunicorn>=25.1).",
 )
 @click.option(
+    "--no-control-socket",
+    "control_socket_disable",
+    default=None,
+    is_flag=True,
+    flag_value=True,
+    help="Disable the gunicorn control socket (requires gunicorn>=25.1).",
+)
+@click.option(
     "--name-template",
     type=str,
     help="Format string to use for the status name. "


### PR DESCRIPTION
Exposes gunicorn's `--no-control-path` option as `--no-control-socket` flag for `pulpcore-api` and `pulpcore-content` commands.

Earlier #7591 added `--control-socket` to allow operators to redirect the control socket path. While working on [pulp-oci-images#87](https://github.com/theforeman/pulp-oci-images/pull/87) we found that some environments need to disable the control socket entirely and this option is missing, so this PR adds the complementary `--no-control-socket` flag.

Silently ignored on gunicorn<25.1, which introduced the feature.

<!---
Thank you for submitting a PR to the Pulp Project!

If this is your first time contributing, please read the Pull Request Walkthrough documentation
(https://pulpproject.org/pulpcore/docs/dev/guides/pull-request-walkthrough/).
-->

### 📜 Checklist

- [x] Commits are cleanly separated with meaningful messages (simple features and bug fixes should be [squashed](https://pulpproject.org/pulpcore/docs/dev/guides/git/#rebasing-and-squashing) to one commit)
- [x] A [changelog entry](https://pulpproject.org/pulpcore/docs/dev/guides/git/#changelog-update) or entries has been added for any significant changes
- [x] Follows the [Pulp policy on AI Usage](https://pulpproject.org/help/more/governance/ai_policy/)
- [ ] (For new features) - User documentation and test coverage has been added

See: [Pull Request Walkthrough](https://pulpproject.org/pulpcore/docs/dev/guides/pull-request-walkthrough/)
