### PR TITLE
Replace all usage of double-ticks with single-ticks in code

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -320,7 +320,7 @@ No significant changes.
 
 #### Features {: #3.113.0-rest-api-feature }
 
-- Added support for passing ``q_select`` as a parameter to the replicate action, allowing users to selectively sync a subset of upstream distributions without modifying the stored upstream-pulp configuration.
+- Added support for passing `q_select` as a parameter to the replicate action, allowing users to selectively sync a subset of upstream distributions without modifying the stored upstream-pulp configuration.
   [#7617](https://github.com/pulp/pulpcore/issues/7617)
 - Added the `FeatureNotImplementedError` exception to indicate that a requested feature is not yet implemented.
 
@@ -342,8 +342,8 @@ No significant changes.
 
 #### Features {: #3.113.0-plugin-api-feature }
 
-- Exposed ``StableOrderingFilter`` in the plugin API so pulp plugins can import it from ``pulpcore.plugin``.
-- Exposed ``cancel_task`` and ``cancel_task_group`` from ``pulpcore.plugin.tasking`` so plugins can import them.
+- Exposed `StableOrderingFilter` in the plugin API so pulp plugins can import it from `pulpcore.plugin`.
+- Exposed `cancel_task` and `cancel_task_group` from `pulpcore.plugin.tasking` so plugins can import them.
 
 ### Pulp File {: #3.113.0-pulp-file }
 
@@ -370,7 +370,7 @@ No significant changes.
 
 #### Features {: #3.112.1-plugin-api-feature }
 
-- Exposed ``StableOrderingFilter`` in the plugin API so pulp plugins can import it from ``pulpcore.plugin``.
+- Exposed `StableOrderingFilter` in the plugin API so pulp plugins can import it from `pulpcore.plugin`.
 
 ### Pulp File {: #3.112.1-pulp-file }
 
@@ -786,7 +786,7 @@ No significant changes.
 
 #### Bugfixes {: #3.108.0-rest-api-bugfix }
 
-- Set default ``--max-requests 10000`` and ``--max-requests-jitter 500`` for API workers
+- Set default `--max-requests 10000` and `--max-requests-jitter 500` for API workers
   to prevent unbounded RSS growth from glibc heap fragmentation over long-lived worker processes.
   [#7482](https://github.com/pulp/pulpcore/issues/7482)
 - Fixed `reset-admin-password` command failing when using `--random` option on Django 5.
@@ -875,7 +875,7 @@ No significant changes.
   [#7004](https://github.com/pulp/pulpcore/issues/7004)
 - Add a data repair API for admins - for more granular control and operations which are too long for migrations.
   [#7272](https://github.com/pulp/pulpcore/issues/7272)
-- Added ``retain_checkpoints`` field to Repository to automatically clear the checkpoint flag on older publications exceeding the limit.
+- Added `retain_checkpoints` field to Repository to automatically clear the checkpoint flag on older publications exceeding the limit.
   [#7428](https://github.com/pulp/pulpcore/issues/7428)
 - Added `/pulp/api/v3/datarepair/7465/` endpoint to add missing repository version content_ids cache to all repository versions.
   [#7465](https://github.com/pulp/pulpcore/issues/7465)
@@ -912,7 +912,7 @@ No significant changes.
 
 #### Features {: #3.106.0-plugin-api-feature }
 
-- Added ``PgpKeyFingerprintField`` serializer field to the plugin API for validating and normalizing type-prefixed OpenPGP key identifiers.
+- Added `PgpKeyFingerprintField` serializer field to the plugin API for validating and normalizing type-prefixed OpenPGP key identifiers.
 
 #### Bugfixes {: #3.106.0-plugin-api-bugfix }
 
@@ -1155,7 +1155,7 @@ No significant changes.
 
 #### Features {: #3.105.8-plugin-api-feature }
 
-- Exposed ``StableOrderingFilter`` in the plugin API so pulp plugins can import it from ``pulpcore.plugin``.
+- Exposed `StableOrderingFilter` in the plugin API so pulp plugins can import it from `pulpcore.plugin`.
 
 ### Pulp File {: #3.105.8-pulp-file }
 
@@ -1195,7 +1195,7 @@ No significant changes.
 
 #### Bugfixes {: #3.105.6-rest-api-bugfix }
 
-- Set default ``--max-requests 10000`` and ``--max-requests-jitter 500`` for API workers
+- Set default `--max-requests 10000` and `--max-requests-jitter 500` for API workers
   to prevent unbounded RSS growth from glibc heap fragmentation over long-lived worker processes.
   [#7482](https://github.com/pulp/pulpcore/issues/7482)
 - Added option to `pulpcore-content` and `pulpcore-api` to configure the gunicorn control socket path.
@@ -2495,7 +2495,7 @@ No significant changes.
 
 #### Features {: #3.85.22-plugin-api-feature }
 
-- Exposed ``StableOrderingFilter`` in the plugin API so pulp plugins can import it from ``pulpcore.plugin``.
+- Exposed `StableOrderingFilter` in the plugin API so pulp plugins can import it from `pulpcore.plugin`.
 
 ### Pulp File {: #3.85.22-pulp-file }
 
@@ -2555,7 +2555,7 @@ No significant changes.
 
 #### Bugfixes {: #3.85.19-rest-api-bugfix }
 
-- Set default ``--max-requests 10000`` and ``--max-requests-jitter 500`` for API workers
+- Set default `--max-requests 10000` and `--max-requests-jitter 500` for API workers
   to prevent unbounded RSS growth from glibc heap fragmentation over long-lived worker processes.
   [#7482](https://github.com/pulp/pulpcore/issues/7482)
 - Fixed `TypeError: 'str' object has no attribute 'tolower'` in `_ensure_bool` during incremental content exports. Changed `.tolower()` to `.lower()`.
@@ -2778,8 +2778,8 @@ No significant changes.
 - Adapted PulpImport/Export to allow update django-import-export==4.x.
   [#5324](https://github.com/pulp/pulpcore/issues/5324)
 - Allow use of Django 5 as well as Django 4. Note the following breaking changes if upgrading to
-  Django 5: storage configuration must use the new ``STORAGES`` format instead of
-  ``DEFAULT_FILE_STORAGE``, Python >= 3.10 is required, and PostgreSQL >= 14 is required.
+  Django 5: storage configuration must use the new `STORAGES` format instead of
+  `DEFAULT_FILE_STORAGE`, Python >= 3.10 is required, and PostgreSQL >= 14 is required.
   [#6988](https://github.com/pulp/pulpcore/issues/6988)
 
 #### Bugfixes {: #3.85.10-rest-api-bugfix }
@@ -3912,7 +3912,7 @@ No significant changes.
 
 #### Features {: #3.73.36-plugin-api-feature }
 
-- Exposed ``StableOrderingFilter`` in the plugin API so pulp plugins can import it from ``pulpcore.plugin``.
+- Exposed `StableOrderingFilter` in the plugin API so pulp plugins can import it from `pulpcore.plugin`.
 
 ### Pulp File {: #3.73.36-pulp-file }
 
@@ -3972,7 +3972,7 @@ No significant changes.
 
 #### Bugfixes {: #3.73.33-rest-api-bugfix }
 
-- Set default ``--max-requests 10000`` and ``--max-requests-jitter 500`` for API workers
+- Set default `--max-requests 10000` and `--max-requests-jitter 500` for API workers
   to prevent unbounded RSS growth from glibc heap fragmentation over long-lived worker processes.
   [#7482](https://github.com/pulp/pulpcore/issues/7482)
 - Fixed `TypeError: 'str' object has no attribute 'tolower'` in `_ensure_bool` during incremental content exports. Changed `.tolower()` to `.lower()`.
@@ -4170,8 +4170,8 @@ No significant changes.
 - Adapted PulpImport/Export to allow update django-import-export==4.x.
   [#5324](https://github.com/pulp/pulpcore/issues/5324)
 - Allow use of Django 5 as well as Django 4. Note the following breaking changes if upgrading to
-  Django 5: storage configuration must use the new ``STORAGES`` format instead of
-  ``DEFAULT_FILE_STORAGE``, Python >= 3.10 is required, and PostgreSQL >= 14 is required.
+  Django 5: storage configuration must use the new `STORAGES` format instead of
+  `DEFAULT_FILE_STORAGE`, Python >= 3.10 is required, and PostgreSQL >= 14 is required.
   [#6988](https://github.com/pulp/pulpcore/issues/6988)
 
 #### Bugfixes {: #3.73.25-rest-api-bugfix }
@@ -4836,7 +4836,7 @@ No significant changes.
 
 #### Features {: #3.72.0-rest-api-feature }
 
-- Added ``ENABLED_PLUGINS`` option to allow selecting installed plugins to be enabled.
+- Added `ENABLED_PLUGINS` option to allow selecting installed plugins to be enabled.
   [#5235](https://github.com/pulp/pulpcore/issues/5235)
 - Added support for labels on domains.
   [#6236](https://github.com/pulp/pulpcore/issues/6236)
@@ -5412,7 +5412,7 @@ No significant changes.
 
 - Started using an upstream version of the OpenTelemetry aiohttp server instrumentation.
   [#5833](https://github.com/pulp/pulpcore/issues/5833)
-- Included the worker's name in the ``http.server.duration`` OpenTelemetry metric attributes.
+- Included the worker's name in the `http.server.duration` OpenTelemetry metric attributes.
   [#5844](https://github.com/pulp/pulpcore/issues/5844)
 
 #### Bugfixes {: #3.64.0-rest-api-bugfix }
@@ -5614,7 +5614,7 @@ No significant changes.
 
 #### Bugfixes {: #3.63.37-rest-api-bugfix }
 
-- Set default ``--max-requests 10000`` and ``--max-requests-jitter 500`` for API workers
+- Set default `--max-requests 10000` and `--max-requests-jitter 500` for API workers
   to prevent unbounded RSS growth from glibc heap fragmentation over long-lived worker processes.
   [#7482](https://github.com/pulp/pulpcore/issues/7482)
 - Fixed `TypeError: 'str' object has no attribute 'tolower'` in `_ensure_bool` during incremental content exports. Changed `.tolower()` to `.lower()`.
@@ -5787,8 +5787,8 @@ No significant changes.
 - Adapted PulpImport/Export to allow update django-import-export==4.x.
   [#5324](https://github.com/pulp/pulpcore/issues/5324)
 - Allow use of Django 5 as well as Django 4. Note the following breaking changes if upgrading to
-  Django 5: storage configuration must use the new ``STORAGES`` format instead of
-  ``DEFAULT_FILE_STORAGE``, Python >= 3.10 is required, and PostgreSQL >= 14 is required.
+  Django 5: storage configuration must use the new `STORAGES` format instead of
+  `DEFAULT_FILE_STORAGE`, Python >= 3.10 is required, and PostgreSQL >= 14 is required.
   [#6988](https://github.com/pulp/pulpcore/issues/6988)
 
 #### Bugfixes {: #3.63.30-rest-api-bugfix }
@@ -6533,7 +6533,7 @@ No significant changes.
 
 - Added `name`, `base_url` and `last_replication` filters for UpstreamPulps.
   [#4110](https://github.com/pulp/pulpcore/issues/4110)
-- Added new setting ``API_ROOT_REWRITE_HEADER`` that when specified allows the API_ROOT to be rewritten
+- Added new setting `API_ROOT_REWRITE_HEADER` that when specified allows the API_ROOT to be rewritten
   per request based on the header's value.
   [#4207](https://github.com/pulp/pulpcore/issues/4207)
 - Added new `q_select` field to UpstreamPulp to allow for more advanced filtering on upstream distributions.
@@ -6555,8 +6555,8 @@ No significant changes.
 
 #### Features {: #3.62.0-plugin-api-feature }
 
-- Added new ``reverse`` method that handles Pulp specific url formatting. Plugins should update
-  instances of ``django.urls.reverse`` and ``rest_framework.reverse`` to this new Pulp one.
+- Added new `reverse` method that handles Pulp specific url formatting. Plugins should update
+  instances of `django.urls.reverse` and `rest_framework.reverse` to this new Pulp one.
   [#4207](https://github.com/pulp/pulpcore/issues/4207)
 
 #### Deprecations {: #3.62.0-plugin-api-deprecation }
@@ -6942,12 +6942,12 @@ No significant changes.
 
 #### Removals {: #3.55.0-rest-api-removal }
 
-- Removed ``pulp_hrefs`` from task reserved resources record. Task resource locking will now use Pulp
-  Resource Names (PRNs) that are immutable with respect to settings changes. A resource's ``pulp_href``
-  can still be used in task's ``reserved_resources`` filter, Pulp will convert it to the new format
+- Removed `pulp_hrefs` from task reserved resources record. Task resource locking will now use Pulp
+  Resource Names (PRNs) that are immutable with respect to settings changes. A resource's `pulp_href`
+  can still be used in task's `reserved_resources` filter, Pulp will convert it to the new format
   behind the scenes.
   [#5148](https://github.com/pulp/pulpcore/issues/5148)
-- Removed task's ``reserved_resources_record`` filter. Please use ``reserved_resources`` instead.
+- Removed task's `reserved_resources_record` filter. Please use `reserved_resources` instead.
   [#5415](https://github.com/pulp/pulpcore/issues/5415)
 - Removed deprecated `plugin` query string parameter from api doc endpoint.
   Please use a list of app labels with the `component` parameter instead.
@@ -7499,7 +7499,7 @@ No significant changes.
 
 #### Bugfixes {: #3.49.60-rest-api-bugfix }
 
-- Set default ``--max-requests 10000`` and ``--max-requests-jitter 500`` for API workers
+- Set default `--max-requests 10000` and `--max-requests-jitter 500` for API workers
   to prevent unbounded RSS growth from glibc heap fragmentation over long-lived worker processes.
   [#7482](https://github.com/pulp/pulpcore/issues/7482)
 - Fixed `TypeError: 'str' object has no attribute 'tolower'` in `_ensure_bool` during incremental content exports. Changed `.tolower()` to `.lower()`.
@@ -7728,8 +7728,8 @@ No significant changes.
 - Adapted PulpImport/Export to allow update django-import-export==4.x.
   [#5324](https://github.com/pulp/pulpcore/issues/5324)
 - Allow use of Django 5 as well as Django 4. Note the following breaking changes if upgrading to
-  Django 5: storage configuration must use the new ``STORAGES`` format instead of
-  ``DEFAULT_FILE_STORAGE``, Python >= 3.10 is required, and PostgreSQL >= 14 is required.
+  Django 5: storage configuration must use the new `STORAGES` format instead of
+  `DEFAULT_FILE_STORAGE`, Python >= 3.10 is required, and PostgreSQL >= 14 is required.
   [#6988](https://github.com/pulp/pulpcore/issues/6988)
 
 ### Plugin API {: #3.49.50-plugin-api }
@@ -12499,7 +12499,7 @@ No significant changes.
     list endpoint.
     [#3280](https://github.com/pulp/pulpcore/issues/3280)
 -   The postgresql version is now included in analytics data posted. The payload looks like:
-    `` {`'postgresqlVersion': 90200} ``. The integer value is the raw format postgresql reports its
+    `{'postgresqlVersion': 90200}`. The integer value is the raw format postgresql reports its
     version as.
     [#3396](https://github.com/pulp/pulpcore/issues/3396)
 -   The new `ANALYTICS` setting replaced the `TELEMETRY` setting to avoid confusion with
@@ -12570,7 +12570,7 @@ No significant changes.
 
 #### Deprecations
 
--   `` TELEMETRY` setting was deprecated in favor of ``ANALYTICS`.
+-   `TELEMETRY` setting was deprecated in favor of `ANALYTICS`.
     #3417 <[https://github.com/pulp/pulpcore/issues/3417](https://github.com/pulp/pulpcore/issues/3417)>`__
 
 #### Misc
@@ -16773,7 +16773,7 @@ No significant changes.
 
 #### Removals
 
--   The `component` field of the `versions` section of the status API `` `/pulp/api/v3/status/ `` now
+-   The `component` field of the `versions` section of the status API `/pulp/api/v3/status/` now
     lists the Django app name, not the Python package name. Similarly the OpenAPI schema at
     `/pulp/api/v3` does also.
     [#8198](https://pulp.plan.io/issues/8198)
@@ -17662,7 +17662,7 @@ No significant changes.
     `QueryModelResources`.
     [#7277](https://pulp.plan.io/issues/7277)
 
--   Viewsets that subclass `` pulpcore.plugin.viewsets.NamedModelViewSet` can declare the ``queryset_filtering_required_permission`[ class attribute naming the permission required to view
+-   Viewsets that subclass `pulpcore.plugin.viewsets.NamedModelViewSet` can declare the `queryset_filtering_required_permission` class attribute naming the permission required to view
     an object. See the *queryset_scoping* documentation for more information.
     ]{.title-ref}#7300 <<https://pulp.plan.io/issues/7300>>`__
 
@@ -18217,7 +18217,7 @@ No significant changes.
 
 #### Deprecations and Removals
 
--   The `` `Handler._handle_file_response` has been removed. It was renamed to ``_serve_content_artifact`` and has the following signature:
+-   The `Handler._handle_file_response` has been removed. It was renamed to `_serve_content_artifact` and has the following signature:
 
         def _serve_content_artifact(self, content_artifact, headers):
 

--- a/docs/admin/guides/auth/keycloak.md
+++ b/docs/admin/guides/auth/keycloak.md
@@ -103,7 +103,7 @@ Enable python social and Keycloak integration with the following steps:
 
 3) Configure the Client `Access Type` to be "confidential.
 
-Provide `` Valid Redirect URIs` `` with
+Provide `Valid Redirect URIs` with
  `http://<pulp-hostname>:<port>/*`. Set the `User Info Signed Response Algorithm` and
  `Request Object Signature Algorithm` is set to `RS256` in the
  `Fine Grain OpenID Connect Configuration` section

--- a/docs/admin/learn/architecture.md
+++ b/docs/admin/learn/architecture.md
@@ -24,12 +24,12 @@ Pulp's REST API is a Django application that runs standalone using the `gunicorn
     entrypoint. It is `gunicorn` based and provides many of its options.
 
 !!! note "API worker recycling"
-    By default, `pulpcore-api` enables gunicorn ``--max-requests`` and ``--max-requests-jitter`` so
+    By default, `pulpcore-api` enables gunicorn `--max-requests` and `--max-requests-jitter` so
     worker processes are periodically replaced. That limits memory growth from allocator
     fragmentation in long-lived workers. Override via gunicorn's usual mechanisms (CLI flags,
-    ``GUNICORN_CMD_ARGS``, or a config file). To **disable** recycling and keep unlimited worker
-    lifetime, pass ``--max-requests 0`` on the ``pulpcore-api`` command line (gunicorn treats
-    ``0`` as unlimited; Pulp only applies its own defaults when ``--max-requests`` was not passed
+    `GUNICORN_CMD_ARGS`, or a config file). To **disable** recycling and keep unlimited worker
+    lifetime, pass `--max-requests 0` on the `pulpcore-api` command line (gunicorn treats
+    `0` as unlimited; Pulp only applies its own defaults when `--max-requests` was not passed
     there). Disabling recycling is not recommended for production.
 
 The REST API should only be deployed via the `pulpcore-api` entrypoint.

--- a/docs/dev/learn/other/task-scheduling.md
+++ b/docs/dev/learn/other/task-scheduling.md
@@ -3,7 +3,7 @@
 # Task Scheduling
 
 % warning: This feature is only accessible by direct manipulation of
-% ``TaskSchedule`` objects. It is targeted for plugin writers and no api access is planned.
+% `TaskSchedule` objects. It is targeted for plugin writers and no api access is planned.
 
 Pulp supports scheduling of tasks. Scheduled tasks will be dispatched shortly after their
 `next_dispatch` time, and be rescheduled one `dispatch_interval` after that, if the latter is

--- a/docs/dev/learn/subclassing/viewsets.md
+++ b/docs/dev/learn/subclassing/viewsets.md
@@ -73,7 +73,7 @@ See `pulpcore.plugin.tasking.dispatch` for more details.
 def sync(self, request, pk):
     """
     Synchronizes a repository.
-    The ``repository`` field has to be provided.
+    The `repository` field has to be provided.
     """
     remote = self.get_object()
     serializer = RepositorySyncURLSerializer(data=request.data, context={'request': request})

--- a/pulp_file/app/models.py
+++ b/pulp_file/app/models.py
@@ -65,8 +65,8 @@ class FileGitRemote(Remote, AutoAddObjPermsMixin):
     """
     Remote for syncing files from a Git repository (without PULP_MANIFEST).
 
-    The URL should point to a Git repository. The ``git_ref`` field can be used to specify a
-    branch, tag, or commit to sync from (defaults to ``HEAD``).
+    The URL should point to a Git repository. The `git_ref` field can be used to specify a
+    branch, tag, or commit to sync from (defaults to `HEAD`).
     """
 
     TYPE = "git"

--- a/pulp_file/app/tasks/synchronizing.py
+++ b/pulp_file/app/tasks/synchronizing.py
@@ -355,9 +355,9 @@ class GitFirstStage(Stage):
     The first stage of a pulp_file sync pipeline for Git repositories.
 
     Performs a bare clone of the Git repository, resolves the specified git_ref, and
-    walks the tree to emit ``DeclarativeContent`` for each blob. Computes sha256 for
-    each blob so that ``QueryExistingArtifacts`` can match already-known artifacts and
-    ``FileContent.digest`` is available for content matching.
+    walks the tree to emit `DeclarativeContent` for each blob. Computes sha256 for
+    each blob so that `QueryExistingArtifacts` can match already-known artifacts and
+    `FileContent.digest` is available for content matching.
     """
 
     def __init__(self, remote):

--- a/pulp_file/app/viewsets.py
+++ b/pulp_file/app/viewsets.py
@@ -262,7 +262,7 @@ class FileRepositoryViewSet(RepositoryViewSet, ModifyRepositoryActionMixin, Role
         """
         Synchronizes a repository.
 
-        The ``repository`` field has to be provided.
+        The `repository` field has to be provided.
         """
         serializer = FileRepositorySyncURLSerializer(
             data=request.data, context={"request": request, "repository_pk": pk}
@@ -566,7 +566,7 @@ class FilePublicationViewSet(PublicationViewSet, RolesMixin):
         """
         Publishes a repository.
 
-        Either the ``repository`` or the ``repository_version`` fields can
+        Either the `repository` or the `repository_version` fields can
         be provided but not both at the same time.
         """
         serializer = self.get_serializer(data=request.data)

--- a/pulpcore/app/global_access_conditions.py
+++ b/pulpcore/app/global_access_conditions.py
@@ -31,7 +31,7 @@ def has_model_perms(request, view, action, permission):
             `app_label.codename`, e.g. "core.delete_task".
 
     Returns:
-        True if the user has the Permission named by the ``permission`` argument at the model-level.
+        True if the user has the Permission named by the `permission` argument at the model-level.
             False otherwise.
     """
     return request.user.has_perm(permission)
@@ -54,8 +54,8 @@ def has_obj_perms(request, view, action, permission):
     Checks if the current user has object-level permission on the specific object.
 
     The object in this case is the one the action is operating on, e.g. the URL
-    ``/pulp/api/v3/tasks/15939b47-6b6d-4613-a441-939ca4ba6e63/`` is operating on the Task object
-    with ``pk=15939b47-6b6d-4613-a441-939ca4ba6e63``.
+    `/pulp/api/v3/tasks/15939b47-6b6d-4613-a441-939ca4ba6e63/` is operating on the Task object
+    with `pk=15939b47-6b6d-4613-a441-939ca4ba6e63`.
 
     This is usable as a conditional check in an AccessPolicy. Here is an example checking for the
     "file.view_fileremote" permissions at the object-level.
@@ -76,7 +76,7 @@ def has_obj_perms(request, view, action, permission):
             `app_label.codename`, e.g. "core.delete_task".
 
     Returns:
-        True if the user has the Permission named by the ``permission`` argument on the object being
+        True if the user has the Permission named by the `permission` argument on the object being
             operated on at the object-level. False otherwise.
     """
     obj = view.get_object()
@@ -109,8 +109,8 @@ def has_model_or_obj_perms(request, view, action, permission):
     Checks if the current user has either model-level or object-level permissions.
 
     The object in this case is the one the action is operating on, e.g. the URL
-    ``/pulp/api/v3/tasks/15939b47-6b6d-4613-a441-939ca4ba6e63/`` is operating on the Task object
-    with ``pk=15939b47-6b6d-4613-a441-939ca4ba6e63``.
+    `/pulp/api/v3/tasks/15939b47-6b6d-4613-a441-939ca4ba6e63/` is operating on the Task object
+    with `pk=15939b47-6b6d-4613-a441-939ca4ba6e63`.
 
     This is usable as a conditional check in an AccessPolicy. Here is an example checking for
     "file.view_fileremote" permission at either the model-level or object-level.
@@ -131,7 +131,7 @@ def has_model_or_obj_perms(request, view, action, permission):
             `app_label.codename`, e.g. "core.delete_task".
 
     Returns:
-        True if the user has the Permission named by the ``permission`` argument at the model-level
+        True if the user has the Permission named by the `permission` argument at the model-level
             or on the object being operated on at the object-level. False otherwise.
     """
     return has_model_perms(request, view, action, permission) or has_obj_perms(
@@ -144,10 +144,10 @@ def has_model_or_obj_perms(request, view, action, permission):
 
 def has_remote_param_obj_perms(request, view, action, permission):
     """
-    Checks if the current user has object-level permission on the ``remote`` object.
+    Checks if the current user has object-level permission on the `remote` object.
 
-    The object in this case is the one specified by the ``remote`` parameter. For example when
-    syncing the ``remote`` parameter is passed in as an argument.
+    The object in this case is the one specified by the `remote` parameter. For example when
+    syncing the `remote` parameter is passed in as an argument.
 
     This is usable as a conditional check in an AccessPolicy. Here is an example checking for the
     "file.view_fileremote" permissions at the object-level.
@@ -159,11 +159,11 @@ def has_remote_param_obj_perms(request, view, action, permission):
             "condition": "has_remote_param_obj_perms:file.view_fileremote",
         }
 
-    Since it is checking a ``remote`` object the permission argument should be one of the following:
+    Since it is checking a `remote` object the permission argument should be one of the following:
 
-    * "file.change_fileremote" - Permission to change the ``FileRemote``.
-    * "file.view_fileremote" - Permission to view the ``FileRemote``.
-    * "file.delete_fileremote" - Permission to delete the ``FileRemote``.
+    * "file.change_fileremote" - Permission to change the `FileRemote`.
+    * "file.view_fileremote" - Permission to view the `FileRemote`.
+    * "file.delete_fileremote" - Permission to delete the `FileRemote`.
 
     Args:
         request (rest_framework.request.Request): The request being made.
@@ -175,7 +175,7 @@ def has_remote_param_obj_perms(request, view, action, permission):
             separated by commas.
 
     Returns:
-        True if the user has the Permission named by the ``permission`` argument on the ``remote``
+        True if the user has the Permission named by the `permission` argument on the `remote`
             parameter at the object-level or if there is no remote. False otherwise.
     """
     kwargs = {}
@@ -197,7 +197,7 @@ def has_remote_param_obj_perms(request, view, action, permission):
 
 def has_remote_param_model_or_domain_or_obj_perms(request, view, action, permission):
     """
-    Checks if the current user has the permission on the ``remote`` param.
+    Checks if the current user has the permission on the `remote` param.
     """
     return has_model_or_domain_perms(
         request, view, action, permission
@@ -206,10 +206,10 @@ def has_remote_param_model_or_domain_or_obj_perms(request, view, action, permiss
 
 def has_remote_param_model_or_obj_perms(request, view, action, permission):
     """
-    Checks if the current user has either model-level or object-level permissions on the ``remote``.
+    Checks if the current user has either model-level or object-level permissions on the `remote`.
 
-    The object in this case is the one specified by the ``remote`` parameter. For example when
-    syncing the ``remote`` parameter is passed in as an argument.
+    The object in this case is the one specified by the `remote` parameter. For example when
+    syncing the `remote` parameter is passed in as an argument.
 
     This is usable as a conditional check in an AccessPolicy. Here is an example checking for
     "file.view_fileremote" permission at either the model-level or object-level.
@@ -221,11 +221,11 @@ def has_remote_param_model_or_obj_perms(request, view, action, permission):
             "condition": "has_remote_param_model_or_obj_perms:file.view_fileremote",
         }
 
-    Since it is checking a ``remote`` object the permission argument should be one of the following:
+    Since it is checking a `remote` object the permission argument should be one of the following:
 
-    * "file.change_fileremote" - Permission to change the ``FileRemote``.
-    * "file.view_fileremote" - Permission to view the ``FileRemote``.
-    * "file.delete_fileremote" - Permission to delete the ``FileRemote``.
+    * "file.change_fileremote" - Permission to change the `FileRemote`.
+    * "file.view_fileremote" - Permission to view the `FileRemote`.
+    * "file.delete_fileremote" - Permission to delete the `FileRemote`.
 
     Args:
         request (rest_framework.request.Request): The request being made.
@@ -236,8 +236,8 @@ def has_remote_param_model_or_obj_perms(request, view, action, permission):
             `app_label.codename`, e.g. "core.delete_task".
 
     Returns:
-        True if the user has the Permission named by the ``permission`` at the model-level or on the
-            argument on the ``remote`` parameter at the object-level. False otherwise.
+        True if the user has the Permission named by the `permission` at the model-level or on the
+            argument on the `remote` parameter at the object-level. False otherwise.
     """
     return has_model_perms(request, view, action, permission) or has_remote_param_obj_perms(
         request, view, action, permission
@@ -249,10 +249,10 @@ def has_remote_param_model_or_obj_perms(request, view, action, permission):
 
 def has_repo_attr_obj_perms(request, view, action, permission):
     """
-    Checks if the current user has object-level permission on a ``repository`` attribute.
+    Checks if the current user has object-level permission on a `repository` attribute.
 
-    The object in this case is the one specified by the ``repository`` attribute of a resource
-    which is being operated on. For example, when deleting a repository version, a ``repository``
+    The object in this case is the one specified by the `repository` attribute of a resource
+    which is being operated on. For example, when deleting a repository version, a `repository`
     is its attribute.
 
     This is usable as a conditional check in an AccessPolicy. Here is an example checking for the
@@ -265,12 +265,12 @@ def has_repo_attr_obj_perms(request, view, action, permission):
             "condition": "has_repo_attr_obj_perms:file.view_filerepository",
         }
 
-    Since it is checking a ``repository`` object the permission argument should be one of the
+    Since it is checking a `repository` object the permission argument should be one of the
     following:
 
-    * "file.change_filerepository" - Permission to change the ``FileRepository``.
-    * "file.view_filerepository" - Permission to view the ``FileRepository``.
-    * "file.delete_filerepository" - Permission to delete the ``FileRepository``.
+    * "file.change_filerepository" - Permission to change the `FileRepository`.
+    * "file.view_filerepository" - Permission to view the `FileRepository`.
+    * "file.delete_filerepository" - Permission to delete the `FileRepository`.
     * any custom permission a plugin has defined for their repository.
 
     Args:
@@ -282,8 +282,8 @@ def has_repo_attr_obj_perms(request, view, action, permission):
             `app_label.codename`, e.g. "file.delete_filerepository".
 
     Returns:
-        True if the user has the Permission named by the ``permission`` argument on the
-        ``repository`` attribute at the object-level. False otherwise.
+        True if the user has the Permission named by the `permission` argument on the
+        `repository` attribute at the object-level. False otherwise.
     """
     plugin_repository = view.get_object().repository.cast()
     return request.user.has_perm(permission, plugin_repository)
@@ -291,7 +291,7 @@ def has_repo_attr_obj_perms(request, view, action, permission):
 
 def has_repo_attr_model_or_domain_or_obj_perms(request, view, action, permission):
     """
-    Checks if the current user has the permission on the ``repository`` attribute.
+    Checks if the current user has the permission on the `repository` attribute.
     """
     return has_model_or_domain_perms(request, view, action, permission) or has_repo_attr_obj_perms(
         request, view, action, permission
@@ -300,10 +300,10 @@ def has_repo_attr_model_or_domain_or_obj_perms(request, view, action, permission
 
 def has_repo_attr_model_or_obj_perms(request, view, action, permission):
     """
-    Checks if the current user has model-level or object-level permissions on a ``repository``.
+    Checks if the current user has model-level or object-level permissions on a `repository`.
 
-    The object in this case is the one specified by the ``repository`` attribute of a resource
-    which is being operated on. For example, when deleting a repository version, a ``repository``
+    The object in this case is the one specified by the `repository` attribute of a resource
+    which is being operated on. For example, when deleting a repository version, a `repository`
     is its attribute.
 
     This is usable as a conditional check in an AccessPolicy. Here is an example checking for the
@@ -316,12 +316,12 @@ def has_repo_attr_model_or_obj_perms(request, view, action, permission):
             "condition": "has_repo_attr_model_or_obj_perms:file.view_filerepository",
         }
 
-    Since it is checking a ``repository`` object the permission argument should be one of the
+    Since it is checking a `repository` object the permission argument should be one of the
     following:
 
-    * "file.change_filerepository" - Permission to change the ``FileRepository``.
-    * "file.view_filerepository" - Permission to view the ``FileRepository``.
-    * "file.delete_filerepository" - Permission to delete the ``FileRepository``.
+    * "file.change_filerepository" - Permission to change the `FileRepository`.
+    * "file.view_filerepository" - Permission to view the `FileRepository`.
+    * "file.delete_filerepository" - Permission to delete the `FileRepository`.
     * any custom permission a plugin has defined for their repository.
 
     Args:
@@ -333,8 +333,8 @@ def has_repo_attr_model_or_obj_perms(request, view, action, permission):
             `app_label.codename`, e.g. "file.delete_filerepository".
 
     Returns:
-        True if the user has the Permission on the ``repository`` attribute named by the
-        ``permission`` at the model or object level. False otherwise.
+        True if the user has the Permission on the `repository` attribute named by the
+        `permission` at the model or object level. False otherwise.
     """
     return has_model_perms(request, view, action, permission) or has_repo_attr_obj_perms(
         request, view, action, permission
@@ -364,8 +364,8 @@ def has_repository_obj_perms(request, view, action, permission):
             `app_label.codename`, e.g. "file.filerepository_change".
 
     Returns:
-        True if the user has the Permission on the ``Repository`` specified in the URL named by the
-        ``permission`` at object level. False otherwise.
+        True if the user has the Permission on the `Repository` specified in the URL named by the
+        `permission` at object level. False otherwise.
     """
     plugin_repository = Repository.objects.get(pk=view.kwargs["repository_pk"]).cast()
     return request.user.has_perm(permission, plugin_repository)
@@ -404,8 +404,8 @@ def has_repository_model_or_obj_perms(request, view, action, permission):
             `app_label.codename`, e.g. "file.filerepository_change".
 
     Returns:
-        True if the user has the Permission on the ``Repository`` specified in the URL named by the
-        ``permission`` at model or object level. False otherwise.
+        True if the user has the Permission on the `Repository` specified in the URL named by the
+        `permission` at model or object level. False otherwise.
     """
     return request.user.has_perm(permission) or has_repository_obj_perms(
         request, view, action, permission
@@ -414,7 +414,7 @@ def has_repository_model_or_obj_perms(request, view, action, permission):
 
 def has_repo_or_repo_ver_param_model_or_domain_or_obj_perms(request, view, action, permission):
     """
-    Checks if the current user has permission on the ``repository`` or ``repository_version``.
+    Checks if the current user has permission on the `repository` or `repository_version`.
     """
     if has_model_or_domain_perms(request, view, action, permission):
         return True
@@ -435,10 +435,10 @@ def has_repo_or_repo_ver_param_model_or_domain_or_obj_perms(request, view, actio
 
 def has_repo_or_repo_ver_param_model_or_obj_perms(request, view, action, permission):
     """
-    Checks if the current user has object-level permission on the ``repository`` object.
+    Checks if the current user has object-level permission on the `repository` object.
 
-    The object in this case is the one specified by the ``repository`` or ``repository_version``
-    parameter. For example when publishing the ``repository`` parameter is passed in as an argument.
+    The object in this case is the one specified by the `repository` or `repository_version`
+    parameter. For example when publishing the `repository` parameter is passed in as an argument.
 
     This is usable as a conditional check in an AccessPolicy. Here is an example checking for the
     "file.view_filerepository" permissions at the object-level.
@@ -450,13 +450,13 @@ def has_repo_or_repo_ver_param_model_or_obj_perms(request, view, action, permiss
             "condition": "has_repo_or_repo_ver_param_model_or_obj_perms:file.view_filerepository",
         }
 
-    Since it is checking a ``repository`` object the permission argument should be one of the
+    Since it is checking a `repository` object the permission argument should be one of the
     following:
 
-    * "file.change_filerepository" - Permission to change the ``FileRepository``.
-    * "file.view_filerepository" - Permission to view the ``FileRepository``.
-    * "file.delete_filerepository" - Permission to delete the ``FileRepository``.
-    * "file.sync_filerepository" - Permission to sync the ``FileRepository``.
+    * "file.change_filerepository" - Permission to change the `FileRepository`.
+    * "file.view_filerepository" - Permission to view the `FileRepository`.
+    * "file.delete_filerepository" - Permission to delete the `FileRepository`.
+    * "file.sync_filerepository" - Permission to sync the `FileRepository`.
 
     Args:
         request (rest_framework.request.Request): The request being made.
@@ -467,8 +467,8 @@ def has_repo_or_repo_ver_param_model_or_obj_perms(request, view, action, permiss
             `app_label.codename`, e.g. "core.delete_task".
 
     Returns:
-        True if the user has the Permission named by the ``permission`` argument on the
-            ``repository`` or ``repository_version`` parameter at the object-level or if there is
+        True if the user has the Permission named by the `permission` argument on the
+            `repository` or `repository_version` parameter at the object-level or if there is
             no repository. False otherwise.
     """
     if has_model_perms(request, view, action, permission):
@@ -490,10 +490,10 @@ def has_repo_or_repo_ver_param_model_or_obj_perms(request, view, action, permiss
 
 def has_required_repo_perms_on_upload(request, view, action, permission):
     """
-    Checks if the current user has permission to upload content to the ``repository`` object.
+    Checks if the current user has permission to upload content to the `repository` object.
 
     Since content queryset scoping prevents users from seeing orphaned content by default this
-    also checks to make sure that any user that isn't an admin has also supplied the ``repository``
+    also checks to make sure that any user that isn't an admin has also supplied the `repository`
     parameter when performing a content upload.
 
     In addition, if the user has specified labels with this content, make sure they are allowed
@@ -518,8 +518,8 @@ def has_required_repo_perms_on_upload(request, view, action, permission):
             `app_label.codename`, e.g. "core.delete_task".
 
     Returns:
-        True if the user has supplied the ``repository`` parameter and has the Permission on it
-            named by the ``permission`` argument, or is an admin. False otherwise.
+        True if the user has supplied the `repository` parameter and has the Permission on it
+            named by the `permission` argument, or is an admin. False otherwise.
     """
 
     def _forbidden_labels():
@@ -564,7 +564,7 @@ def has_required_repo_perms_on_upload(request, view, action, permission):
 
 def has_publication_param_model_or_domain_or_obj_perms(request, view, action, permission):
     """
-    Checks if the current user has permission on the ``Publication`` param.
+    Checks if the current user has permission on the `Publication` param.
     """
     if has_model_or_domain_perms(request, view, action, permission):
         return True
@@ -583,10 +583,10 @@ def has_publication_param_model_or_domain_or_obj_perms(request, view, action, pe
 
 def has_publication_param_model_or_obj_perms(request, view, action, permission):
     """
-    Checks if the current user has permission on the ``Publication`` object.
+    Checks if the current user has permission on the `Publication` object.
 
-    The object in this case is the one specified by the ``publication`` parameter. For example when
-    distributing the ``publication`` parameter is passed in as an argument.
+    The object in this case is the one specified by the `publication` parameter. For example when
+    distributing the `publication` parameter is passed in as an argument.
 
     This is usable as a conditional check in an AccessPolicy. Here is an example checking for the
     "file.view_filepublication" permission.
@@ -598,11 +598,11 @@ def has_publication_param_model_or_obj_perms(request, view, action, permission):
             "condition": "has_publication_param_model_or_obj_perms:file.view_filepublication",
         }
 
-    Since it is checking a ``Publication`` object the permission argument should be one of the
+    Since it is checking a `Publication` object the permission argument should be one of the
     following:
 
-    * "file.view_filepublication" - Permission to view the ``FilePublication``.
-    * "file.delete_filepublication" - Permission to delete the ``FilePublication``.
+    * "file.view_filepublication" - Permission to view the `FilePublication`.
+    * "file.delete_filepublication" - Permission to delete the `FilePublication`.
 
     Args:
         request (rest_framework.request.Request): The request being made.
@@ -613,8 +613,8 @@ def has_publication_param_model_or_obj_perms(request, view, action, permission):
             `app_label.codename`, e.g. "core.delete_task".
 
     Returns:
-        True if the user has the Permission named by the ``permission`` argument on the
-            ``publication`` parameter or if there is no publication. False otherwise.
+        True if the user has the Permission named by the `permission` argument on the
+            `publication` parameter or if there is no publication. False otherwise.
     """
     if has_model_perms(request, view, action, permission):
         return True
@@ -633,7 +633,7 @@ def has_publication_param_model_or_obj_perms(request, view, action, permission):
 
 def has_upload_param_model_or_domain_or_obj_perms(request, view, action, permission):
     """
-    Checks if the current user has permission on the ``Upload`` param.
+    Checks if the current user has permission on the `Upload` param.
     """
     if has_model_or_domain_perms(request, view, action, permission):
         return True
@@ -652,9 +652,9 @@ def has_upload_param_model_or_domain_or_obj_perms(request, view, action, permiss
 
 def has_upload_param_model_or_obj_perms(request, view, action, permission):
     """
-    Checks if the current user has permission on the ``Upload`` object.
+    Checks if the current user has permission on the `Upload` object.
 
-    The object in this case is the one specified by the ``upload`` parameter, for example to a
+    The object in this case is the one specified by the `upload` parameter, for example to a
     one-shot content creation call.
 
     This is usable as a conditional check in an AccessPolicy. Here is an example checking for the
@@ -667,11 +667,11 @@ def has_upload_param_model_or_obj_perms(request, view, action, permission):
             "condition": "has_upload_param_model_or_obj_perms:core.change_upload",
         }
 
-    Since it is checking a ``Upload`` object the permission argument should be one of the following:
+    Since it is checking a `Upload` object the permission argument should be one of the following:
 
-    * "core.view_upload" - Permission to view the ``Upload``.
-    * "core.change_upload" - Permission to change the ``Upload``.
-    * "core.delete_upload" - Permission to delete the ``Upload``.
+    * "core.view_upload" - Permission to view the `Upload`.
+    * "core.change_upload" - Permission to change the `Upload`.
+    * "core.delete_upload" - Permission to delete the `Upload`.
 
     Args:
         request (rest_framework.request.Request): The request being made.
@@ -682,8 +682,8 @@ def has_upload_param_model_or_obj_perms(request, view, action, permission):
             `app_label.codename`, e.g. "core.delete_task".
 
     Returns:
-        True if the user has the Permission named by the ``permission`` argument on the
-            ``Upload`` parameter or if there is no upload. False otherwise.
+        True if the user has the Permission named by the `permission` argument on the
+            `Upload` parameter or if there is no upload. False otherwise.
     """
     if has_model_perms(request, view, action, permission):
         return True
@@ -726,8 +726,8 @@ def has_group_obj_perms(request, view, action, permission):
             `app_label.codename`, e.g. "core.group_change".
 
     Returns:
-        True if the user has the Permission on the ``Group`` specified in the URL named by the
-        ``permission`` at object level. False otherwise.
+        True if the user has the Permission on the `Group` specified in the URL named by the
+        `permission` at object level. False otherwise.
     """
     group_pk = request.resolver_match.kwargs["group_pk"]
     return request.user.has_perm(permission, Group.objects.get(pk=group_pk))
@@ -756,8 +756,8 @@ def has_group_model_or_obj_perms(request, view, action, permission):
             `app_label.codename`, e.g. "core.group_change".
 
     Returns:
-        True if the user has the Permission on the ``Group`` specified in the URL named by the
-        ``permission`` at the model or object level. False otherwise.
+        True if the user has the Permission on the `Group` specified in the URL named by the
+        `permission` at the model or object level. False otherwise.
     """
     return request.user.has_perm(permission) or has_group_obj_perms(
         request, view, action, permission

--- a/pulpcore/app/models/access_policy.py
+++ b/pulpcore/app/models/access_policy.py
@@ -20,10 +20,10 @@ class AccessPolicy(BaseModel):
     Fields:
 
         creation_hooks (models.JSONField): A list of dictionaries identifying callables on the
-            ``pulpcore.plugin.access_policy.AccessPolicyFromDB`` which can add user or group roles
+            `pulpcore.plugin.access_policy.AccessPolicyFromDB` which can add user or group roles
             for newly created objects. This is a nullable field due to not all endpoints creating
             objects.
-        statements (models.JSONField): A list of ``drf-access-policy`` statements.
+        statements (models.JSONField): A list of `drf-access-policy` statements.
         viewset_name (models.TextField): The name of the viewset this instance controls
             authorization for.
         customized (BooleanField): False if the AccessPolicy has been user-modified. True otherwise.
@@ -42,18 +42,18 @@ class AccessPolicy(BaseModel):
 
 class AutoAddObjPermsMixin:
     """
-    A mixin that automatically adds roles based on the ``creation_hooks`` data.
+    A mixin that automatically adds roles based on the `creation_hooks` data.
 
-    To use this mixin, your model must support ``django-lifecycle``.
+    To use this mixin, your model must support `django-lifecycle`.
 
-    This mixin adds an ``after_create`` hook which properly interprets the ``creation_hooks``
+    This mixin adds an `after_create` hook which properly interprets the `creation_hooks`
     data and calls methods also provided by this mixin to add roles.
 
     These hooks are provided by default:
 
-    * ``add_roles_for_object_creator`` will add the roles to the creator of the object.
-    * ``add_roles_for_users`` will add the roles for one or more users by name.
-    * ``add_roles_for_groups`` will add the roles for one or more groups by name.
+    * `add_roles_for_object_creator` will add the roles to the creator of the object.
+    * `add_roles_for_users` will add the roles for one or more users by name.
+    * `add_roles_for_groups` will add the roles for one or more groups by name.
 
     """
 
@@ -126,7 +126,7 @@ class AutoAddObjPermsMixin:
         """
         Adds object-level roles for the user creating the newly created object.
 
-        If the ``get_current_authenticated_user`` returns None because the API client did not
+        If the `get_current_authenticated_user` returns None because the API client did not
         provide authentication credentials, *no* permissions are added and this passes silently.
         This allows endpoints which create objects and do not require authorization to execute
         without error.

--- a/pulpcore/app/models/base.py
+++ b/pulpcore/app/models/base.py
@@ -106,7 +106,7 @@ class MasterModel(BaseModel, metaclass=MasterModelMeta):
 
     Attributes:
 
-        TYPE (str): Default constant value saved into the ``pulp_type``
+        TYPE (str): Default constant value saved into the `pulp_type`
             field of Model instances
 
     Fields:
@@ -214,7 +214,7 @@ def master_model(options):
     """
     The Master model class of this Model's Master/Detail relationship.
 
-    Accessible at ``<model_class>._meta.master_model``, the Master model class in a Master/Detail
+    Accessible at `<model_class>._meta.master_model`, the Master model class in a Master/Detail
     relationship is the most generic non-abstract Model in this model's multiple-table chain
     of inheritance.
 

--- a/pulpcore/app/models/content.py
+++ b/pulpcore/app/models/content.py
@@ -100,12 +100,12 @@ class BulkCreateManager(models.Manager):
 
 class BulkTouchQuerySet(models.QuerySet):
     """
-    A query set that provides ``touch()``.
+    A query set that provides `touch()`.
     """
 
     def touch(self):
         """
-        Update the ``timestamp_of_interest`` on all objects of the query.
+        Update the `timestamp_of_interest` on all objects of the query.
         """
 
         # Postgres' UPDATE call doesn't support order-by. This can (and does) result in deadlocks in
@@ -335,12 +335,12 @@ class Artifact(HandleTempFilesMixin, BaseModel):
             expected_size (int): The number of bytes the download is expected to have.
 
         Raises:
-            [pulpcore.exceptions.DigestValidationError][]: When any of the ``expected_digest``
+            [pulpcore.exceptions.DigestValidationError][]: When any of the `expected_digest`
                 values don't match the digest of the data
-            [pulpcore.exceptions.SizeValidationError][]: When the ``expected_size`` value
+            [pulpcore.exceptions.SizeValidationError][]: When the `expected_size` value
                 doesn't match the size of the data
             [pulpcore.exceptions.UnsupportedDigestValidationError][]: When any of the
-                ``expected_digest`` algorithms aren't in the ALLOWED_CONTENT_CHECKSUMS list
+                `expected_digest` algorithms aren't in the ALLOWED_CONTENT_CHECKSUMS list
         Returns:
             An in-memory, unsaved [pulpcore.plugin.models.Artifact][]
         """
@@ -454,12 +454,12 @@ class PulpTemporaryFile(HandleTempFilesMixin, BaseModel):
             expected_size (int): The number of bytes the download is expected to have.
 
         Raises:
-            [pulpcore.exceptions.DigestValidationError][]: When any of the ``expected_digest``
+            [pulpcore.exceptions.DigestValidationError][]: When any of the `expected_digest`
                 values don't match the digest of the data
-            [pulpcore.exceptions.SizeValidationError][]: When the ``expected_size`` value
+            [pulpcore.exceptions.SizeValidationError][]: When the `expected_size` value
                 doesn't match the size of the data
             [pulpcore.exceptions.UnsupportedDigestValidationError][]: When any of the
-                ``expected_digest`` algorithms aren't in the ALLOWED_CONTENT_CHECKSUMS list
+                `expected_digest` algorithms aren't in the ALLOWED_CONTENT_CHECKSUMS list
 
         Returns:
             An in-memory, unsaved [pulpcore.plugin.models.PulpTemporaryFile][]

--- a/pulpcore/app/models/progress.py
+++ b/pulpcore/app/models/progress.py
@@ -292,7 +292,7 @@ class ProgressReport(BaseModel):
             iter (iterator): The iterator to loop through while incrementing
 
         Returns:
-            generator of ``iter`` argument items
+            generator of `iter` argument items
         """
         for x in iter:
             yield x

--- a/pulpcore/app/models/publication.py
+++ b/pulpcore/app/models/publication.py
@@ -611,13 +611,13 @@ class Distribution(MasterModel):
 
     This master model can be used by plugin writers to create detail Distribution objects.
 
-    The ``name`` must be unique.
+    The `name` must be unique.
 
-    The ``base_path`` must have no overlapping components. So if a Distribution with ``base_path``
-    of ``a/path/foo`` existed, you could not make a second Distribution with a ``base_path`` of
-    ``a/path`` or ``a`` because both are subpaths of ``a/path/foo``.
+    The `base_path` must have no overlapping components. So if a Distribution with `base_path`
+    of `a/path/foo` existed, you could not make a second Distribution with a `base_path` of
+    `a/path` or `a` because both are subpaths of `a/path/foo`.
 
-    Subclasses are expected to use either the ``publication`` or ``repository_version`` field, but
+    Subclasses are expected to use either the `publication` or `repository_version` field, but
     not both. The content app that serves content is not prepared to serve content both ways at the
     same time.
 
@@ -742,16 +742,16 @@ class Distribution(MasterModel):
 
     def content_handler_json(self, path):
         """
-        Handler to serve a JSON representation of the content at ``path`` for this Distribution.
+        Handler to serve a JSON representation of the content at `path` for this Distribution.
 
         This is the JSON counterpart to :meth:`content_handler`. It is invoked instead of (and
         checked before) the generic, plugin-agnostic JSON directory listing whenever the
-        client's ``Accept`` header indicates a preference for JSON over HTML. Plugins override
+        client's `Accept` header indicates a preference for JSON over HTML. Plugins override
         this to provide type-specific JSON (e.g. package metadata, a de-duplicated "package"
         listing, etc.) rather than falling back to the generic file/size/date listing that
         pulpcore builds automatically for every Distribution.
 
-        The default implementation returns ``None`` for every path, which is safe for any
+        The default implementation returns `None` for every path, which is safe for any
         Distribution subclass that doesn't override it: pulpcore's generic JSON directory
         listing (or the normal HTML/binary behavior) is used instead.
 

--- a/pulpcore/app/models/repository.py
+++ b/pulpcore/app/models/repository.py
@@ -981,7 +981,7 @@ class RepositoryVersion(BaseModel):
         Args:
             content_qs (django.db.models.QuerySet): The queryset for Content that will be
                 restricted further to the content present in this repository version. If not given,
-                ``Content.objects.all()`` is used (to return over all content types present in the
+                `Content.objects.all()` is used (to return over all content types present in the
                 repository version).
 
         Returns:
@@ -1049,14 +1049,14 @@ class RepositoryVersion(BaseModel):
         Args:
             content_qs (django.db.models.QuerySet) The queryset for Content that will be
                 restricted further to the content present in this repository version. If not given,
-                ``Content.objects.all()`` is used (to iterate over all content present in the
+                `Content.objects.all()` is used (to iterate over all content present in the
                 repository version). A plugin may want to use a specific subclass of
-                [pulpcore.plugin.models.Content][] or use e.g. ``filter()`` to select
+                [pulpcore.plugin.models.Content][] or use e.g. `filter()` to select
                 a subset of the repository version's content.
-            order_by_params (tuple of str): The parameters for the ``order_by`` clause
-                for the content. The Default is ``("pk",)``. This needs to
+            order_by_params (tuple of str): The parameters for the `order_by` clause
+                for the content. The Default is `("pk",)`. This needs to
                 specify a stable order. For example, if you want to iterate by
-                decreasing creation time stamps use ``("-pulp_created", "pk")`` to
+                decreasing creation time stamps use `("-pulp_created", "pk")` to
                 ensure that content records are still sorted by primary key even
                 if their creation timestamp happens to be equal.
             batch_size (int): The maximum batch size.
@@ -1065,8 +1065,8 @@ class RepositoryVersion(BaseModel):
             [django.db.models.QuerySet][]: A QuerySet representing a slice of the content.
 
         Example:
-            The following code could be used to loop over all ``FileContent`` in
-            ``repository_version``. It prefetches the related
+            The following code could be used to loop over all `FileContent` in
+            `repository_version`. It prefetches the related
             [pulpcore.plugin.models.ContentArtifact][] instances for every batch::
 
                 repository_version = ...

--- a/pulpcore/app/models/status.py
+++ b/pulpcore/app/models/status.py
@@ -84,7 +84,7 @@ class AppStatus(BaseModel):
     @property
     def online(self) -> bool:
         """
-        To be considered 'online', an app must have a timestamp more recent than ``self.ttl``.
+        To be considered 'online', an app must have a timestamp more recent than `self.ttl`.
         """
         age_threshold = timezone.now() - self.ttl
         return self.last_heartbeat >= age_threshold
@@ -94,7 +94,7 @@ class AppStatus(BaseModel):
         """
         Whether an app can be considered 'missing'
 
-        To be considered 'missing', an App must have a timestamp older than ``self.ttl``.
+        To be considered 'missing', an App must have a timestamp older than `self.ttl`.
 
         Returns:
             bool: True if the app is considered missing, otherwise False

--- a/pulpcore/app/serializers/base.py
+++ b/pulpcore/app/serializers/base.py
@@ -450,8 +450,8 @@ class ModelSerializer(
 
     This ensures that all Serializers provide values for the 'pulp_href` field.
 
-    The class provides a default for the ``ref_name`` attribute in the
-    ModelSerializers's ``Meta`` class. This ensures that the OpenAPI definitions
+    The class provides a default for the `ref_name` attribute in the
+    ModelSerializers's `Meta` class. This ensures that the OpenAPI definitions
     of plugins are namespaced properly.
 
     """
@@ -486,17 +486,17 @@ class ModelSerializer(
     def __init_subclass__(cls, **kwargs):
         """Set default attributes in subclasses.
 
-        Sets the default for the ``ref_name`` attribute for a ModelSerializers's
-        ``Meta`` class.
+        Sets the default for the `ref_name` attribute for a ModelSerializers's
+        `Meta` class.
 
-        If the ``Meta.ref_name`` attribute is not yet defined, set it according
-        to the best practice established within Pulp: ``<app label>.<model class
-        name>``. ``app_label`` is used to create a per plugin namespace.
+        If the `Meta.ref_name` attribute is not yet defined, set it according
+        to the best practice established within Pulp: `<app label>.<model class
+        name>`. `app_label` is used to create a per plugin namespace.
 
-        Serializers in pulpcore (``app_label`` is 'core') will not be
+        Serializers in pulpcore (`app_label` is 'core') will not be
         namespaced, i.e. ref_name is not set in this case.
 
-        The ``ref_name`` default value is computed using ``Meta.model``. If that
+        The `ref_name` default value is computed using `Meta.model`. If that
         is not defined (because the class must be subclassed to be useful),
         `ref_name` is not set.
 

--- a/pulpcore/app/serializers/repository.py
+++ b/pulpcore/app/serializers/repository.py
@@ -113,7 +113,7 @@ class RemoteSerializer(ModelSerializer, RemoteNetworkConfigSerializer, HiddenFie
 
     def validate_url(self, url):
         """
-        Check if the 'url' is a ``file://`` path, and if so, ensure it's an ALLOWED_IMPORT_PATH.
+        Check if the 'url' is a `file://` path, and if so, ensure it's an ALLOWED_IMPORT_PATH.
 
         The ALLOWED_IMPORT_PATH is specified as a Pulp setting.
 
@@ -192,8 +192,8 @@ class RepositorySyncURLSerializer(ValidateFieldsMixin, serializers.Serializer):
         required=False,
         default=False,
         help_text=_(
-            "If ``True``, synchronization will remove all content that is not present in "
-            "the remote repository. If ``False``, sync will be additive only."
+            "If `True`, synchronization will remove all content that is not present in "
+            "the remote repository. If `False`, sync will be additive only."
         ),
     )
 

--- a/pulpcore/app/serializers/user.py
+++ b/pulpcore/app/serializers/user.py
@@ -123,7 +123,7 @@ class UserSerializer(serializers.ModelSerializer, HiddenFieldsMixin):
         validators=[UniqueValidator(queryset=User.objects.all())],
     )
     password = serializers.CharField(
-        help_text=_("Users password. Set to ``null`` to disable password authentication."),
+        help_text=_("Users password. Set to `null` to disable password authentication."),
         write_only=True,
         allow_null=True,
         default=None,
@@ -458,8 +458,8 @@ class NestedRoleSerializer(serializers.Serializer):
     """
     Serializer to add/remove object roles to/from users/groups.
 
-    This is used in conjunction with ``pulpcore.app.viewsets.base.RolesMixin`` and requires the
-    underlying object to be passed as ``content_object`` in the context.
+    This is used in conjunction with `pulpcore.app.viewsets.base.RolesMixin` and requires the
+    underlying object to be passed as `content_object` in the context.
     """
 
     users = serializers.ListField(

--- a/pulpcore/app/viewsets/base.py
+++ b/pulpcore/app/viewsets/base.py
@@ -57,7 +57,7 @@ class DefaultSchema(PulpAutoSchema):
     """
     Overrides _allows_filters method to include filter fields only for read actions.
 
-    Schema can be customised per view(set). Override this class and set it as a ``schema``
+    Schema can be customised per view(set). Override this class and set it as a `schema`
     attribute of a view(set) of interest.
     """
 
@@ -82,7 +82,7 @@ class NamedModelViewSet(viewsets.GenericViewSet):
     A customized named ModelViewSet that knows how to register itself with the Pulp API router.
 
     This viewset is discoverable by its name.
-    "Normal" Django Models and Master/Detail models are supported by the ``register_with`` method.
+    "Normal" Django Models and Master/Detail models are supported by the `register_with` method.
 
     Attributes:
         lookup_field (str): The name of the field by which an object should be looked up, in

--- a/pulpcore/app/wsgi.py
+++ b/pulpcore/app/wsgi.py
@@ -1,7 +1,7 @@
 """
 WSGI config for pulp project.
 
-It exposes the WSGI callable as a module-level variable named ``application``.
+It exposes the WSGI callable as a module-level variable named `application`.
 
 For more information on this file, see
 https://docs.djangoproject.com/en/3.2/howto/deployment/wsgi/

--- a/pulpcore/content/handler.py
+++ b/pulpcore/content/handler.py
@@ -666,12 +666,12 @@ class Handler:
         """
         Match the path and stream results either from the filesystem or by downloading new data.
 
-        After deciding the client can access the distribution at ``path``, this function calls
+        After deciding the client can access the distribution at `path`, this function calls
         :meth:`Distribution.content_handler`. If that function returns a not-None result, it is
         returned to the client.
 
         Then the publication linked to the Distribution is used to determine what content should
-        be served. If ``path`` is a directory entry (i.e. not a file), the directory contents
+        be served. If `path` is a directory entry (i.e. not a file), the directory contents
         are served to the client. This method calls
         :meth:`Distribution.content_handler_list_directory` to acquire any additional entries the
         Distribution's content_handler might serve in that directory. If there is an Artifact to be

--- a/pulpcore/download/base.py
+++ b/pulpcore/download/base.py
@@ -167,10 +167,10 @@ class BaseDownloader:
         :meth:`~pulpcore.plugin.download.BaseDownloader.handle_data`.
 
         Raises:
-            [pulpcore.exceptions.DigestValidationError][]: When any of the ``expected_digest``
+            [pulpcore.exceptions.DigestValidationError][]: When any of the `expected_digest`
                 values don't match the digest of the data passed to
                 :meth:`~pulpcore.plugin.download.BaseDownloader.handle_data`.
-            [pulpcore.exceptions.SizeValidationError][]: When the ``expected_size`` value
+            [pulpcore.exceptions.SizeValidationError][]: When the `expected_size` value
                 doesn't match the size of the data passed to
                 :meth:`~pulpcore.plugin.download.BaseDownloader.handle_data`.
         """
@@ -223,10 +223,10 @@ class BaseDownloader:
 
     def validate_digests(self):
         """
-        Validate all digests validate if ``expected_digests`` is set
+        Validate all digests validate if `expected_digests` is set
 
         Raises:
-            [pulpcore.exceptions.DigestValidationError][]: When any of the ``expected_digest``
+            [pulpcore.exceptions.DigestValidationError][]: When any of the `expected_digest`
                 values don't match the digest of the data passed to
                 :meth:`~pulpcore.plugin.download.BaseDownloader.handle_data`.
         """
@@ -238,10 +238,10 @@ class BaseDownloader:
 
     def validate_size(self):
         """
-        Validate the size if ``expected_size`` is set
+        Validate the size if `expected_size` is set
 
         Raises:
-            [pulpcore.exceptions.SizeValidationError][]: When the ``expected_size`` value
+            [pulpcore.exceptions.SizeValidationError][]: When the `expected_size` value
                 doesn't match the size of the data passed to
                 :meth:`~pulpcore.plugin.download.BaseDownloader.handle_data`.
         """
@@ -287,7 +287,7 @@ class BaseDownloader:
 
         It is also expected that the subclass implementation return a
         [pulpcore.plugin.download.DownloadResult][] object. The
-        ``artifact_attributes`` value of the
+        `artifact_attributes` value of the
         [pulpcore.plugin.download.DownloadResult][] is usually set to the
         :attr:`~pulpcore.plugin.download.BaseDownloader.artifact_attributes` property value.
 

--- a/pulpcore/download/factory.py
+++ b/pulpcore/download/factory.py
@@ -32,7 +32,7 @@ class DownloaderFactory:
     connection limit settings.
 
     It supports handling urls with the `http`, `https`, and `file` protocols. The
-    ``downloader_overrides`` option allows the caller to specify the download class to be used for
+    `downloader_overrides` option allows the caller to specify the download class to be used for
     any given protocol. This allows the user to specify custom, subclassed downloaders to be built
     by the factory.
 

--- a/pulpcore/filters.py
+++ b/pulpcore/filters.py
@@ -49,7 +49,7 @@ class HyperlinkRelatedFilter(filters.Filter):
     e.g. Filter by file remotes: ?remote=/pulp/api/v3/remotes/file/file/
     Filtering by object type is not possible using PRNs.
 
-    Can also filter for foreign key to be unset by setting ``allow_null`` to True. Query parameter
+    Can also filter for foreign key to be unset by setting `allow_null` to True. Query parameter
     will then accept "null" or "" for filtering.
     e.g. Filter for no remote: ?remote="null"
     """

--- a/pulpcore/pytest_plugin.py
+++ b/pulpcore/pytest_plugin.py
@@ -1567,7 +1567,7 @@ def create_signing_service(
 
 
 def remove_signing_service(service_name, service_class="core:AsciiArmoredDetachedSigningService"):
-    """Remove a signing service created by ``create_signing_service``."""
+    """Remove a signing service created by `create_signing_service`."""
     subprocess.run(
         (
             "pulpcore-manager",

--- a/pulpcore/tasking/redis_locks.py
+++ b/pulpcore/tasking/redis_locks.py
@@ -336,14 +336,14 @@ def _legacy_scan_cleanup_for_owner(redis_conn, owner):
 
 def cleanup_locks_for_owner(redis_conn, owner, allow_legacy_scan=False):
     """
-    Release all Redis locks held by ``owner``.
+    Release all Redis locks held by `owner`.
 
     Prefers the per-owner registry (O(locks held by owner)). Falls back to a legacy
-    keyspace SCAN only when the registry is missing and ``allow_legacy_scan`` is set.
+    keyspace SCAN only when the registry is missing and `allow_legacy_scan` is set.
 
     Args:
         redis_conn: Redis connection
-        owner (str): The lock owner (worker name or ``immediate-{task_pk}``)
+        owner (str): The lock owner (worker name or `immediate-{task_pk}`)
         allow_legacy_scan (bool): Permit the legacy SCAN fallback for pre-registry locks
 
     Returns:
@@ -385,9 +385,9 @@ def collect_lock_owners(redis_conn, allow_legacy_scan=False):
 
     Owners are read from the global active-owners SET via SMEMBERS -- O(#owners) and
     scan-free (a SCAN with MATCH still walks the whole keyspace, so scanning for
-    registry keys would be O(all locks)). The legacy SCAN of the full ``task:*`` /
-    ``pulp:resource_lock:*`` keyspace is expensive and is only run when
-    ``allow_legacy_scan`` is set (throttled by the caller) to catch pre-registry locks.
+    registry keys would be O(all locks)). The legacy SCAN of the full `task:*` /
+    `pulp:resource_lock:*` keyspace is expensive and is only run when
+    `allow_legacy_scan` is set (throttled by the caller) to catch pre-registry locks.
 
     Args:
         redis_conn: Redis connection

--- a/pulpcore/tasking/redis_worker.py
+++ b/pulpcore/tasking/redis_worker.py
@@ -426,7 +426,7 @@ class RedisWorker:
         return cleanup_locks_for_owner(self.redis_conn, self.name, allow_legacy_scan=allow_legacy)
 
     def _immediate_owner_is_finished(self, owner):
-        """Return True if an ``immediate-{pk}`` owner's task is gone or finished."""
+        """Return True if an `immediate-{pk}` owner's task is gone or finished."""
         task_pk = owner[len(IMMEDIATE_OWNER_PREFIX) :]
         return not Task.objects.filter(pk=task_pk, state__in=TASK_INCOMPLETE_STATES).exists()
 

--- a/pulpcore/tasking/tasks.py
+++ b/pulpcore/tasking/tasks.py
@@ -274,7 +274,7 @@ def dispatch(
     This method creates a [pulpcore.app.models.Task][] object and returns it.
 
     The values in `args` and `kwargs` must be JSON serializable, but may contain instances of
-    ``uuid.UUID``.
+    `uuid.UUID`.
 
     Args:
         func (callable | str): The function to be run when the necessary locks are acquired.

--- a/pulpcore/tests/functional/api/test_crd_artifacts.py
+++ b/pulpcore/tests/functional/api/test_crd_artifacts.py
@@ -34,7 +34,7 @@ def _do_upload_valid_attrs(pulpcore_bindings, file, data):
 def test_upload_valid_attrs(pulpcore_bindings, pulpcore_random_file, monitor_task):
     """Upload a file, and provide valid attributes.
 
-    For each possible combination of ``sha256`` and ``size`` (including
+    For each possible combination of `sha256` and `size` (including
     neither), do the following:
 
     1. Upload a file with the chosen combination of attributes.
@@ -58,7 +58,7 @@ def test_upload_valid_attrs(pulpcore_bindings, pulpcore_random_file, monitor_tas
 def test_upload_empty_file(pulpcore_bindings, tmp_path, monitor_task):
     """Upload an empty file.
 
-    For each possible combination of ``sha256`` and ``size`` (including
+    For each possible combination of `sha256` and `size` (including
     neither), do the following:
 
     1. Upload a file with the chosen combination of attributes.
@@ -82,7 +82,7 @@ def test_upload_empty_file(pulpcore_bindings, tmp_path, monitor_task):
 def test_upload_invalid_attrs(pulpcore_bindings, pulpcore_random_file):
     """Upload a file, and provide invalid attributes.
 
-    For each possible combination of ``sha256`` and ``size`` (except for
+    For each possible combination of `sha256` and `size` (except for
     neither), do the following:
 
     1. Upload a file with the chosen combination of attributes. Verify that
@@ -112,7 +112,7 @@ def _do_upload_invalid_attrs(pulpcore_bindings, file, data):
 def test_upload_md5(pulpcore_bindings, pulpcore_random_file):
     """Attempt to upload a file using an MD5 checksum.
 
-    Assumes ALLOWED_CONTENT_CHECKSUMS does NOT contain ``md5``
+    Assumes ALLOWED_CONTENT_CHECKSUMS does NOT contain `md5`
     """
     file_attrs = {"md5": str(uuid.uuid4()), "size": pulpcore_random_file["size"]}
     with pytest.raises(pulpcore_bindings.ApiException) as e:
@@ -127,7 +127,7 @@ def test_upload_mixed_attrs(pulpcore_bindings, pulpcore_random_file):
 
     Do the following:
 
-    1. Upload a file and provide both an ``sha256`` and a ``size``. Let one
+    1. Upload a file and provide both an `sha256` and a `size`. Let one
        be valid, and the other be invalid. Verify that an error is returned.
     2. Verify that no artifacts exist in Pulp whose attributes match the
        file that was unsuccessfully uploaded.

--- a/pulpcore/tests/functional/api/using_plugin/test_distributions.py
+++ b/pulpcore/tests/functional/api/using_plugin/test_distributions.py
@@ -124,12 +124,12 @@ def test_distribution_base_path(
 ):
     distribution = file_distribution_factory(base_path=str(uuid4()).replace("-", "/"))
 
-    # Test that spaces can not be part of ``base_path``.
+    # Test that spaces can not be part of `base_path`.
     with pytest.raises(ApiException) as exc:
         file_distribution_factory(base_path=str(uuid4()).replace("-", " "))
     assert json.loads(exc.value.body)["base_path"] is not None
 
-    # Test that slash cannot be used in the beginning of ``base_path``.
+    # Test that slash cannot be used in the beginning of `base_path`.
     with pytest.raises(ApiException) as exc:
         file_distribution_factory(base_path=f"/{str(uuid4())}")
     assert json.loads(exc.value.body)["base_path"] is not None
@@ -140,7 +140,7 @@ def test_distribution_base_path(
         )
     assert json.loads(exc.value.body)["base_path"] is not None
 
-    # Test that slash cannot be in the end of ``base_path``."""
+    # Test that slash cannot be in the end of `base_path`."""
     with pytest.raises(ApiException) as exc:
         file_distribution_factory(base_path=f"{str(uuid4())}/")
     assert json.loads(exc.value.body)["base_path"] is not None
@@ -151,12 +151,12 @@ def test_distribution_base_path(
         )
     assert json.loads(exc.value.body)["base_path"] is not None
 
-    # Test that ``base_path`` can not be duplicated.
+    # Test that `base_path` can not be duplicated.
     with pytest.raises(ApiException) as exc:
         file_distribution_factory(base_path=distribution.base_path)
     assert json.loads(exc.value.body)["base_path"] is not None
 
-    # Test that distributions can't have overlapping ``base_path``.
+    # Test that distributions can't have overlapping `base_path`.
     with pytest.raises(ApiException) as exc:
         file_distribution_factory(base_path=distribution.base_path.rsplit("/", 1)[0])
     assert json.loads(exc.value.body)["base_path"] is not None
@@ -314,8 +314,8 @@ def test_distribution_serves_publication_content(
     Sets up a repository with two versions (v1 has 3 files, v2 has 2 files), publishes both,
     then verifies:
     - A distribution with an explicit publication serves that publication's content.
-    - A distribution with ``repository`` serves the latest publication (for the latest version).
-    - A distribution with ``repository_version`` serves the latest publication for that version.
+    - A distribution with `repository` serves the latest publication (for the latest version).
+    - A distribution with `repository_version` serves the latest publication for that version.
     """
     # Sync to create version 1 (3 files)
     remote = file_remote_ssl_factory(manifest_path=basic_manifest_path, policy="immediate")

--- a/pulpcore/tests/functional/api/using_plugin/test_repo_versions.py
+++ b/pulpcore/tests/functional/api/using_plugin/test_repo_versions.py
@@ -476,7 +476,7 @@ def test_create_repo_base_version(
     monitor_task,
 ):
     """Test whether one can create a repository version from any version."""
-    # Test ``base_version`` for the same repository
+    # Test `base_version` for the same repository
     remote = file_remote_ssl_factory(manifest_path=basic_manifest_path, policy="on_demand")
     repo = file_repository_factory()
     monitor_task(
@@ -512,7 +512,7 @@ def test_create_repo_base_version(
     assert latest_content.count == base_content.count
     assert file_random_content_unit.pulp_href not in {c.pulp_href for c in latest_content.results}
 
-    # Test ``base_version`` for different repositories
+    # Test `base_version` for different repositories
     repo2 = file_repository_factory()
     # create a version for repo B using repo A version 1 as base_version
     monitor_task(
@@ -533,7 +533,7 @@ def test_create_repo_base_version(
     assert latest_content2.count == base_content.count
     assert latest_content2.results == base_content.results
 
-    # Test ``base_version`` can be used together with other parameters
+    # Test `base_version` can be used together with other parameters
     repo3 = file_repository_factory()
     # create repo version 2 from version 1
     added_content = file_random_content_unit
@@ -560,7 +560,7 @@ def test_create_repo_base_version(
     # assert that the added content is present on repo version 2
     assert added_content.pulp_href in content3_hrefs
 
-    # Exception is raised when non-existent ``base_version`` is used
+    # Exception is raised when non-existent `base_version` is used
     nonexistant_version = f"{repo.versions_href}5/"
     with pytest.raises(file_bindings.ApiException) as e:
         file_bindings.RepositoriesFileApi.modify(

--- a/pulpcore/tests/unit/tasking/test_orphan_redis_locks.py
+++ b/pulpcore/tests/unit/tasking/test_orphan_redis_locks.py
@@ -1,8 +1,8 @@
 """
 Unit tests for orphan Redis lock cleanup (same-name restart and orphan owners).
 
-Tests use a real Redis provided by the ``redisdb`` pytest fixture (mirroring
-``pulp_redisdb`` in test_cache.py) and real DB rows via ``@pytest.mark.django_db``.
+Tests use a real Redis provided by the `redisdb` pytest fixture (mirroring
+`pulp_redisdb` in test_cache.py) and real DB rows via `@pytest.mark.django_db`.
 """
 
 from datetime import timedelta
@@ -34,7 +34,7 @@ from pulpcore.tasking.redis_worker import RedisWorker
 # --------------------------------------------------------------------------- #
 @pytest.fixture
 def pulp_redisdb(settings, redisdb, monkeypatch):
-    """Point pulpcore's redis connection at the ephemeral ``redisdb`` instance."""
+    """Point pulpcore's redis connection at the ephemeral `redisdb` instance."""
     monkeypatch.setattr(pulpcore.app.redis_connection, "_conn", None)
     monkeypatch.setattr(pulpcore.app.redis_connection, "_a_conn", None)
     settings.CACHE_ENABLED = True
@@ -44,7 +44,7 @@ def pulp_redisdb(settings, redisdb, monkeypatch):
 
 @pytest.fixture
 def reset_singleton(monkeypatch):
-    """Reset the in-process AppStatus singleton so ``create()`` works per-test."""
+    """Reset the in-process AppStatus singleton so `create()` works per-test."""
     monkeypatch.setattr(AppStatus.objects, "_current_app_status", None)
 
 
@@ -368,7 +368,7 @@ def test_reconcile_isolates_per_owner_errors(pulp_redisdb, reset_singleton, monk
 
 @pytest.mark.django_db
 def test_reconcile_immediate_owner_grace(pulp_redisdb, reset_singleton):
-    """Immediate grace: Given an ``immediate-{pk}`` owner whose task is still
+    """Immediate grace: Given an `immediate-{pk}` owner whose task is still
     incomplete, When reconcile runs, Then its locks are kept; once the task is
     finished they are reclaimed."""
     conn = pulp_redisdb


### PR DESCRIPTION
Now there should be no excuse for agents to produce double-ticks in our code. I checked if there is a linter rule in ruff, but alas none exist and they don't have a plugin system :disappointed: 

### 📜 Checklist

- [ ] Commits are cleanly separated with meaningful messages (simple features and bug fixes should be [squashed](https://pulpproject.org/pulpcore/docs/dev/guides/git/#rebasing-and-squashing) to one commit)
- [ ] A [changelog entry](https://pulpproject.org/pulpcore/docs/dev/guides/git/#changelog-update) or entries has been added for any significant changes
- [ ] Follows the [Pulp policy on AI Usage](https://pulpproject.org/help/more/governance/ai_policy/)
- [ ] (For new features) - User documentation and test coverage has been added

See: [Pull Request Walkthrough](https://pulpproject.org/pulpcore/docs/dev/guides/pull-request-walkthrough/)
