### PR TITLE
bugfix: do not serve removed content via grace-period fallback

### DIFF
--- a/CHANGES/2316.bugfix
+++ b/CHANGES/2316.bugfix
@@ -1,0 +1,1 @@
+Fixed phantom 302 responses for removed file paths after publication swap on file distributions — the content-app grace-period fallback no longer serves content from superseded publications when the current publication explicitly excludes the path.

--- a/pulp_file/tests/functional/api/test_distributed_publication.py
+++ b/pulp_file/tests/functional/api/test_distributed_publication.py
@@ -41,17 +41,23 @@ class DistributionPublicationContext:
 
 class TestDistributionPublicationRetention:
     @pytest.mark.parallel
-    def test_old_content_is_served_within_retention_period(
+    def test_removed_content_returns_404_immediately_after_publication_switch(
         self,
         ctx: DistributionPublicationContext,
     ):
-        """Old content is still served immediately after switching to a new publication."""
+        """Files deliberately removed from the new publication must 404 immediately.
+
+        When a distribution switches from pub_with_file to pub_without_file, direct-path
+        requests for the removed file must return 404 rather than being served from the
+        superseded publication via the grace-period fallback (phantom 302 bug).
+        """
         dist = ctx.create_distribution(publication=ctx.pub_with_file)
         file_url = ctx.get_file_url(dist)
         assert requests.get(file_url).status_code == 200
 
         ctx.update_distribution(dist, publication=ctx.pub_without_file)
-        assert requests.get(file_url).status_code == 200
+        # Removed content must not be served from the grace-period fallback.
+        assert requests.get(file_url).status_code == 404
 
     @pytest.mark.parallel
     def test_old_content_expires_after_retention_period(

--- a/pulpcore/content/handler.py
+++ b/pulpcore/content/handler.py
@@ -820,8 +820,10 @@ class Handler:
                             request, StreamResponse(headers=headers), ca
                         )
 
-        # Grace-period fallback: serve from a recently-superseded publication
-        if distro.SERVE_FROM_PUBLICATION:
+        # Grace-period fallback: serve from a recently-superseded publication.
+        # Skip when a complete current publication exists and does not contain the path —
+        # absence from a complete publication is a deliberate removal, not a transitional gap.
+        if distro.SERVE_FROM_PUBLICATION and publication is None:
             ca = await sync_to_async(distro.get_fallback_ca)(original_rel_path)
             if ca is not None:
                 if ca.artifact:


### PR DESCRIPTION
## Summary

When a distribution switches to a new publication that deliberately **removes** a file, direct-path GETs to the removed path still returned `302 → S3` (the superseded publication's artifact) instead of `404`. The phantom response was then cached, persisting for the cache TTL.

**Root cause:** The grace-period fallback (`get_fallback_ca`) was called whenever a `SERVE_FROM_PUBLICATION` distribution had no artifact at the requested path, regardless of whether the _absence_ was deliberate (path removed in the new publication) or transitional (distribution has no current publication yet).

**Fix:** Gate the fallback on `publication is None`. When the current publication is resolved and does not contain the requested path, that absence is a deliberate removal — the fallback must not override it. The fallback is only appropriate when there is _no_ current publication at all (e.g., during a brief transition).

## Changes

- `pulpcore/content/handler.py`: Add `and publication is None` guard to the grace-period fallback call
- `pulp_file/tests/functional/api/test_distributed_publication.py`: Add regression test asserting 404 immediately after publication swap for removed paths
- `CHANGES/2316.bugfix`: Towncrier changelog fragment

## Test plan

- [x] `test_removed_content_returns_404_immediately_after_publication_switch` — fails on `upstream/main`, passes on this branch
- [x] Regression analysis: 0 regressions, 1 pre-existing failure (`test_old_content_expires_after_retention_period` — unrelated; requires short retention period)
- [x] Adversarial review: 0 critical/major findings

Closes: PULP-2316