### PR TITLE
Change drf dependency type

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,7 @@ dependencies = [
   "django-guid>=3.4.0,<3.7",  # Looks like only bugfixes in z-Stream.
   "django-import-export>=2.9,<5.0",
   "django-lifecycle>=1.0,<=1.3.0",
-  "djangorestframework>=3.14.0,<=3.18.0",
+  "djangorestframework>=3.14.0,<3.19",  # API-stable z-Streams. https://www.django-rest-framework.org/community/release-notes/
   "djangorestframework-queryfields>=1.0,<=1.1.0",
   "drf-access-policy>=1.1.2,<1.5.1",
   "drf-nested-routers>=0.93.4,<=0.95.3",


### PR DESCRIPTION
They acutally have a versioning policy claiming api compatibility in z-Streams

https://www.django-rest-framework.org/community/release-notes/

<!---
Thank you for submitting a PR to the Pulp Project!

If this is your first time contributing, please read the Pull Request Walkthrough documentation
(https://pulpproject.org/pulpcore/docs/dev/guides/pull-request-walkthrough/).
-->

### 📜 Checklist

- [ ] Commits are cleanly separated with meaningful messages (simple features and bug fixes should be [squashed](https://pulpproject.org/pulpcore/docs/dev/guides/git/#rebasing-and-squashing) to one commit)
- [ ] A [changelog entry](https://pulpproject.org/pulpcore/docs/dev/guides/git/#changelog-update) or entries has been added for any significant changes
- [ ] Follows the [Pulp policy on AI Usage](https://pulpproject.org/help/more/governance/ai_policy/)
- [ ] (For new features) - User documentation and test coverage has been added

See: [Pull Request Walkthrough](https://pulpproject.org/pulpcore/docs/dev/guides/pull-request-walkthrough/)
