### PR TITLE
PULP-2367: Optimize cold-miss content artifact queries

### DIFF
--- a/CHANGES/2367.bugfix
+++ b/CHANGES/2367.bugfix
@@ -1,0 +1,1 @@
+Reduce content-app latency when serving content from large repository versions.

--- a/pulpcore/app/migrations/0160_contentartifact_relative_path_pattern.py
+++ b/pulpcore/app/migrations/0160_contentartifact_relative_path_pattern.py
@@ -1,0 +1,21 @@
+from django.contrib.postgres.indexes import OpClass
+from django.contrib.postgres.operations import AddIndexConcurrently
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    atomic = False
+
+    dependencies = [
+        ("core", "0159_alter_contentartifact_relative_path_and_more"),
+    ]
+
+    operations = [
+        AddIndexConcurrently(
+            model_name="contentartifact",
+            index=models.Index(
+                OpClass("relative_path", name="text_pattern_ops"),
+                name="ca_relpath_pattern_idx",
+            ),
+        ),
+    ]

--- a/pulpcore/app/models/content.py
+++ b/pulpcore/app/models/content.py
@@ -16,7 +16,7 @@ from itertools import chain
 
 from django.conf import settings
 from django.contrib.postgres.fields import HStoreField
-from django.contrib.postgres.indexes import GinIndex
+from django.contrib.postgres.indexes import GinIndex, OpClass
 from django.core import validators
 from django.db import IntegrityError, models, transaction
 from django.forms.models import model_to_dict
@@ -663,7 +663,16 @@ class ContentArtifact(BaseModel, QueryMixin):
 
     class Meta:
         unique_together = ("content", "relative_path")
-        indexes = [models.Index(fields=["relative_path"])]
+        indexes = [
+            models.Index(
+                fields=["relative_path"],
+                name="core_conten_relativ_ca1ae5_idx",
+            ),
+            models.Index(
+                OpClass("relative_path", name="text_pattern_ops"),
+                name="ca_relpath_pattern_idx",
+            ),
+        ]
 
     @staticmethod
     def sort_key(ca):

--- a/pulpcore/app/models/publication.py
+++ b/pulpcore/app/models/publication.py
@@ -812,8 +812,9 @@ class Distribution(MasterModel):
             pub = dp.publication
             if pub.pass_through:
                 ca = (
-                    ContentArtifact.objects.select_related("artifact", "artifact__pulp_domain")
-                    .filter(content__in=pub.repository_version.content, relative_path=path)
+                    pub.repository_version.content_artifact_qs()
+                    .select_related("artifact", "artifact__pulp_domain")
+                    .filter(relative_path=path)
                     .first()
                 )
                 if ca is not None:

--- a/pulpcore/app/models/repository.py
+++ b/pulpcore/app/models/repository.py
@@ -1058,6 +1058,16 @@ class RepositoryVersion(BaseModel):
 
         return self.get_content()
 
+    def content_artifact_qs(self):
+        """Return content artifacts for content contained in this version.
+
+        RepositoryContent is the authoritative representation of repository-version
+        membership. Using it avoids expanding the version's content_ids array into
+        a large membership predicate.
+        """
+        content_ids = self._content_relationships().values("content_id")
+        return ContentArtifact.objects.filter(content_id__in=content_ids)
+
     def content_batch_qs(self, content_qs=None, order_by_params=("pk",), batch_size=1000):
         """
         Generate content batches to efficiently iterate over all content.

--- a/pulpcore/content/handler.py
+++ b/pulpcore/content/handler.py
@@ -630,8 +630,10 @@ class Handler:
                         artifacts_to_find[pa.content_artifact.pk] = name
 
             if repo_version or publication.pass_through:
-                cas = ContentArtifact.objects.select_related("artifact").filter(
-                    content__in=content_repo_ver.content, relative_path__startswith=path
+                cas = (
+                    content_repo_ver.content_artifact_qs()
+                    .select_related("artifact")
+                    .filter(relative_path__startswith=path)
                 )
                 for ca in cas:
                     name = file_or_directory_name(path, ca.relative_path)
@@ -795,12 +797,8 @@ class Handler:
             if publication.pass_through:
                 try:
                     ca = (
-                        await ContentArtifact.objects.select_related(
-                            "artifact", "artifact__pulp_domain"
-                        )
-                        .filter(
-                            content__in=publication.repository_version.content,
-                        )
+                        await publication.repository_version.content_artifact_qs()
+                        .select_related("artifact", "artifact__pulp_domain")
                         .aget(relative_path=original_rel_path)
                     )
 
@@ -835,9 +833,9 @@ class Handler:
             # Look for index.html or list the directory
             index_path = "{}index.html".format(rel_path)
 
-            contentartifact_exists = await ContentArtifact.objects.filter(
-                content__in=repo_version.content, relative_path=index_path
-            ).aexists()
+            contentartifact_exists = (
+                await repo_version.content_artifact_qs().filter(relative_path=index_path).aexists()
+            )
             if contentartifact_exists:
                 original_rel_path = index_path
                 headers = self.response_headers(original_rel_path, distro)
@@ -858,9 +856,11 @@ class Handler:
                     )
 
             try:
-                ca = await ContentArtifact.objects.select_related(
-                    "artifact", "artifact__pulp_domain"
-                ).aget(content__in=repo_version.content, relative_path=original_rel_path)
+                ca = (
+                    await repo_version.content_artifact_qs()
+                    .select_related("artifact", "artifact__pulp_domain")
+                    .aget(relative_path=original_rel_path)
+                )
 
             except MultipleObjectsReturned:
                 log.error(

--- a/pulpcore/tests/unit/models/test_repository.py
+++ b/pulpcore/tests/unit/models/test_repository.py
@@ -128,6 +128,69 @@ def test_add_and_remove_content(db, repository, add_content, remove_content, ver
     verify_content_sets(version3, [1, 0, 1, 1, 0], [1, 0, 0, 0, 0], [0, 0, 0, 0, 0], version2)
 
 
+def test_content_artifact_qs_matches_content_membership(db, repository, content_pks):
+    content = Content.objects.filter(pk__in=content_pks)
+    artifacts = [
+        ContentArtifact.objects.create(content=unit, relative_path=f"path/{index}.txt")
+        for index, unit in enumerate(content)
+    ]
+
+    with repository.new_version() as version:
+        version.add_content(content)
+
+    expected = set(
+        ContentArtifact.objects.filter(
+            content__in=version.content, relative_path__startswith="path/"
+        ).values_list("pk", flat=True)
+    )
+    actual = set(
+        version.content_artifact_qs()
+        .filter(relative_path__startswith="path/")
+        .values_list("pk", flat=True)
+    )
+
+    assert actual == expected == {artifact.pk for artifact in artifacts}
+
+
+def test_content_artifact_qs_respects_version_boundaries(
+    db, repository, content_pks, add_content, remove_content
+):
+    content = Content.objects.filter(pk__in=content_pks)
+    for index, unit in enumerate(content):
+        ContentArtifact.objects.create(content=unit, relative_path=f"path/{index}.txt")
+
+    with repository.new_version() as version1:
+        add_content(version1, [1, 1, 0, 0, 0])
+
+    with repository.new_version() as version2:
+        remove_content(version2, [1, 0, 0, 0, 0])
+        add_content(version2, [0, 0, 1, 0, 0])
+
+    assert set(version1.content_artifact_qs().values_list("content_id", flat=True)) == set(
+        content_pks[:2]
+    )
+    assert set(version2.content_artifact_qs().values_list("content_id", flat=True)) == {
+        content_pks[1],
+        content_pks[2],
+    }
+
+
+def test_content_artifact_qs_empty_version(db, repository):
+    version = repository.latest_version()
+
+    assert not version.content_artifact_qs().exists()
+
+
+def test_content_artifact_qs_uses_repository_content_subquery(db, repository, content_pks):
+    with repository.new_version() as version:
+        version.add_content(Content.objects.filter(pk__in=content_pks))
+
+    sql = str(version.content_artifact_qs().query).lower()
+
+    assert "core_repositorycontent" in sql
+    assert "unnest" not in sql
+
+
 def test_add_remove(db, repository, add_content, remove_content, verify_content_sets):
     """Verify that adding and then removing content units is handled properly."""
     version0 = repository.latest_version()


### PR DESCRIPTION
## Summary

Optimize content artifact lookups for repository versions by querying repository membership directly instead of expanding the content ID array.

## Changes

- Add `RepositoryVersion.content_artifact_qs()` backed by `RepositoryContent` membership.
- Apply it to content serving, directory listing, pass-through publication, and fallback paths.
- Add regression tests for membership equivalence, version boundaries, empty versions, and query shape.
- The proposed file-extension directory fast path is intentionally omitted because valid repositories may contain directories with file-like names.

## Testing

- `oci-env agent test pulp-2367-cold-miss unit -p pulpcore -k content_artifact_qs`
- `oci-env agent test pulp-2367-cold-miss unit -p pulpcore -k "test_repository"`
- `oci-env agent test pulp-2367-cold-miss unit -p pulpcore -k "TestGetFallbackCa or checkpoint"`
- `oci-env agent test pulp-2367-cold-miss lint -p pulpcore`

## Jira

Closes: PULP-2367

---
Labels: ai-assisted (requested; repository label unavailable)