### PR TITLE
feat: Grant uploaders object-level access to content they create

### DIFF
--- a/CHANGES/content-creator-owner.feature
+++ b/CHANGES/content-creator-owner.feature
@@ -1,0 +1,1 @@
+Content uploaders are now granted an object-level owner role (view/change/delete/manage_roles) on the content they create, and content read-scoping now includes content a user owns even when it is not in any repository. This lets a user read back a unit they just uploaded (e.g. fetching a package by href before adding it to a repository).

--- a/pulpcore/app/apps.py
+++ b/pulpcore/app/apps.py
@@ -133,6 +133,11 @@ class PulpPluginAppConfig(apps.AppConfig):
             dispatch_uid="populate_access_policies_identifier",
         )
         post_migrate.connect(_populate_roles, sender=self, dispatch_uid="populate_roles_identifier")
+        post_migrate.connect(
+            _populate_content_owner_roles,
+            sender=self,
+            dispatch_uid=f"populate_content_owner_roles_{self.label}",
+        )
 
     def import_serializers(self):
         # circular import avoidance
@@ -346,6 +351,57 @@ def _ensure_default_domain(sender, apps, **kwargs):
                 default.redirect_to_object_storage = settings.REDIRECT_TO_OBJECT_STORAGE
                 default.storage_class = settings.STORAGES["default"]["BACKEND"]
                 default.save(skip_hooks=True)
+
+
+def _populate_content_owner_roles(sender, **kwargs):
+    """Ensure `<app>.<model>_owner` and `<app>.<model>_viewer` roles for each content type."""
+    from django.contrib.auth.models import Permission
+    from django.contrib.contenttypes.models import ContentType
+    from pulpcore.app.models.content import Content
+    from pulpcore.app.models.role import Role
+
+    for model in sender.get_models():
+        if not (issubclass(model, Content) and model is not Content):
+            continue
+        if model._meta.abstract or model._meta.proxy:
+            continue
+
+        opts = model._meta
+        ctype = ContentType.objects.get_for_model(model, for_concrete_model=False)
+
+        manage_codename = f"manage_roles_{opts.model_name}"
+        manage_perm, _ = Permission.objects.get_or_create(
+            content_type=ctype,
+            codename=manage_codename,
+            defaults={"name": f"Can manage roles on {opts.model_name}"},
+        )
+
+        view_perm = Permission.objects.filter(
+            content_type=ctype, codename=f"view_{opts.model_name}"
+        ).first()
+
+        owner_perms = list(
+            Permission.objects.filter(
+                content_type=ctype,
+                codename__in=[
+                    f"view_{opts.model_name}",
+                    f"change_{opts.model_name}",
+                    f"delete_{opts.model_name}",
+                ],
+            )
+        ) + [manage_perm]
+
+        owner_role, _ = Role.objects.update_or_create(
+            name=f"{opts.app_label}.{opts.model_name}_owner",
+            defaults={"locked": True},
+        )
+        owner_role.permissions.set(owner_perms)
+
+        viewer_role, _ = Role.objects.update_or_create(
+            name=f"{opts.app_label}.{opts.model_name}_viewer",
+            defaults={"locked": True},
+        )
+        viewer_role.permissions.set([view_perm] if view_perm else [])
 
 
 def _populate_roles(sender, apps, verbosity, **kwargs):

--- a/pulpcore/app/role_util.py
+++ b/pulpcore/app/role_util.py
@@ -12,6 +12,7 @@ from django.db.models.functions import Cast
 
 from pulpcore.app.models import Group
 from pulpcore.app.models.role import GroupRole, Role, UserRole
+from pulpcore.app.util import get_current_authenticated_user
 
 
 @lru_cache(maxsize=1)
@@ -59,6 +60,31 @@ def assign_role(rolename, entity, obj=None, domain=None):
         GroupRole.objects.create(role=role, group=entity, content_object=obj, domain=domain)
     else:
         UserRole.objects.create(role=role, user=entity, content_object=obj, domain=domain)
+
+
+def _assign_content_role(content, suffix):
+    """Grant the current authenticated user a `<app>.<model>_<suffix>` role on a content unit.
+
+    No-op outside an authenticated request/task context (e.g. sync, import, migrations)
+    and idempotent (skips assignment when the user already holds the role on the object).
+    """
+    user = get_current_authenticated_user()
+    if user is None:
+        return
+    role_name = f"{content._meta.app_label}.{content._meta.model_name}_{suffix}"
+    if content.user_roles.filter(user=user, role__name=role_name).exists():
+        return
+    assign_role(role_name, user, obj=content)
+
+
+def assign_content_owner_role(content):
+    """Grant the current user the owner role on content they created."""
+    _assign_content_role(content, "owner")
+
+
+def assign_content_viewer_role(content):
+    """Grant the current user view-only access on pre-existing (deduplicated) content."""
+    _assign_content_role(content, "viewer")
 
 
 def remove_role(rolename, entity, obj=None, domain=None):

--- a/pulpcore/app/serializers/content.py
+++ b/pulpcore/app/serializers/content.py
@@ -5,6 +5,7 @@ from rest_framework import serializers
 from rest_framework.validators import UniqueValidator
 
 from pulpcore.app import models
+from pulpcore.app.role_util import assign_content_owner_role, assign_content_viewer_role
 from pulpcore.app.serializers import (
     ContentArtifactChecksumField,
     ContentArtifactsField,
@@ -141,6 +142,12 @@ class NoArtifactContentSerializer(ModelSerializer):
             with repository.new_version() as new_version:
                 new_version.add_content(content_to_add)
 
+        # Creators own their content; uploaders of pre-existing (deduplicated) content
+        # only get read access, so they cannot manage roles on content they did not create.
+        if created:
+            assign_content_owner_role(content)
+        else:
+            assign_content_viewer_role(content)
         return content
 
     class Meta:

--- a/pulpcore/app/viewsets/content.py
+++ b/pulpcore/app/viewsets/content.py
@@ -164,22 +164,33 @@ class BaseContentViewSet(NamedModelViewSet):
         return qs
 
     def scope_queryset(self, qs):
-        """Scope the content based on repositories the user has permission to see."""
+        """Scope content by repositories the user can see, unioned with object-owned content."""
+        if self.request.user.is_superuser:
+            return qs
+
+        from pulpcore.app.role_util import get_objects_for_user
+
         # This has been optimized, see ListRepositoryVersions for more generic version
         repositories = self.queryset.model.repository_types()
-        if not self.request.user.is_superuser:
-            scoped_repos = []
-            for repo in repositories:
-                repo_viewset = get_viewset_for_model(repo)()
-                setattr(repo_viewset, "request", self.request)
-                scoped_repos.extend(repo_viewset.get_queryset().values_list("pk", flat=True))
+        scoped_repos = []
+        for repo in repositories:
+            repo_viewset = get_viewset_for_model(repo)()
+            setattr(repo_viewset, "request", self.request)
+            scoped_repos.extend(repo_viewset.get_queryset().values_list("pk", flat=True))
 
-            # calling the distinct clause at end of the query ensures that no duplicates from
-            # joined tables will be returned to the end-user; this behaviour is documented at
-            # https://docs.djangoproject.com/en/3.2/topics/db/queries, in the section Spanning
-            # multi-valued relationships
-            return qs.filter(repositories__in=scoped_repos).distinct()
-        return qs
+        # calling the distinct clause at end of the query ensures that no duplicates from
+        # joined tables will be returned to the end-user; this behaviour is documented at
+        # https://docs.djangoproject.com/en/3.2/topics/db/queries, in the section Spanning
+        # multi-valued relationships
+        repo_scoped = qs.filter(repositories__in=scoped_repos)
+
+        model = self.queryset.model
+        view_perm = f"{model._meta.app_label}.view_{model._meta.model_name}"
+        obj_scoped = get_objects_for_user(
+            self.request.user, view_perm, qs, with_superuser=False
+        )
+
+        return (repo_scoped | obj_scoped).distinct()
 
 
 class ListContentViewSet(BaseContentViewSet, mixins.ListModelMixin):

--- a/pulpcore/tests/functional/api/test_content_creator_owner.py
+++ b/pulpcore/tests/functional/api/test_content_creator_owner.py
@@ -1,0 +1,73 @@
+"""Test content creator ownership (RBAC)."""
+
+import uuid
+
+import pytest
+
+
+@pytest.mark.parallel
+def test_content_creator_owner(
+    file_bindings,
+    gen_user,
+    tmp_path,
+):
+    """Test that content creators can read their orphan content via object-owner grant.
+
+    This test verifies that:
+    1. A non-admin user can upload orphan FileContent (not in any repository)
+    2. The creator can read the content back via object-owner grant
+    3. The creator sees the content in their list
+    4. A different non-admin user cannot see the content (neither read nor list)
+
+    The key point is that read access works via the OBJECT-OWNER grant, not via
+    repository scoping or model-level content-view permission.
+    """
+    # Create non-admin users with file.file_uploader role (grants file.upload_files)
+    uploader = gen_user(model_roles=["file.file_uploader"])
+    other = gen_user(model_roles=["file.file_uploader"])
+    dedup_uploader = gen_user(model_roles=["file.file_uploader"])
+
+    # Create a temporary file to upload
+    file_path = tmp_path / "test_content.bin"
+    file_path.write_bytes(b"test content for ownership")
+
+    # Uploader uploads orphan content (no repository) via the upload action
+    relative_path = str(uuid.uuid4())
+    with uploader:
+        content = file_bindings.ContentFilesApi.upload(
+            file=str(file_path),
+            relative_path=relative_path
+        )
+        href = content.pulp_href
+
+    # Uploader can read their own content by href
+    with uploader:
+        retrieved = file_bindings.ContentFilesApi.read(href)
+        assert retrieved.pulp_href == href
+        assert retrieved.relative_path == relative_path
+
+        # Content appears in uploader's list
+        list_response = file_bindings.ContentFilesApi.list()
+        assert any(c.pulp_href == href for c in list_response.results)
+
+    # Other user cannot read the content (404, not 403, because it's filtered from their view)
+    with other:
+        with pytest.raises(file_bindings.module.ApiException) as exc:
+            file_bindings.ContentFilesApi.read(href)
+        assert exc.value.status == 404
+
+        # Content does not appear in other's list
+        list_response = file_bindings.ContentFilesApi.list()
+        assert not any(c.pulp_href == href for c in list_response.results)
+
+    # A user who uploads the SAME bytes deduplicates to the existing unit and gets
+    # view-only access (they can read it back), but NOT the owner role.
+    with dedup_uploader:
+        deduped = file_bindings.ContentFilesApi.upload(
+            file=str(file_path),
+            relative_path=relative_path,
+        )
+        assert deduped.pulp_href == href
+
+        retrieved = file_bindings.ContentFilesApi.read(href)
+        assert retrieved.pulp_href == href

--- a/pulpcore/tests/unit/roles/test_content_owner_roles.py
+++ b/pulpcore/tests/unit/roles/test_content_owner_roles.py
@@ -1,0 +1,115 @@
+import pytest
+from django.contrib.auth.models import Permission
+from django.contrib.contenttypes.models import ContentType
+
+from pulpcore.app.apps import _populate_content_owner_roles
+from pulpcore.app.models.role import Role
+
+
+@pytest.mark.django_db
+def test_populate_creates_owner_role_and_manage_roles_perm():
+    from pulp_file.app.models import FileContent
+
+    _populate_content_owner_roles(sender=FileContent._meta.app_config)
+
+    ctype = ContentType.objects.get_for_model(FileContent, for_concrete_model=False)
+    assert Permission.objects.filter(
+        content_type=ctype, codename="manage_roles_filecontent"
+    ).exists()
+
+    role = Role.objects.get(name="file.filecontent_owner")
+    assert role.locked is True
+    codenames = set(role.permissions.values_list("codename", flat=True))
+    assert codenames == {
+        "view_filecontent",
+        "change_filecontent",
+        "delete_filecontent",
+        "manage_roles_filecontent",
+    }
+
+    viewer = Role.objects.get(name="file.filecontent_viewer")
+    assert viewer.locked is True
+    assert set(viewer.permissions.values_list("codename", flat=True)) == {"view_filecontent"}
+
+
+@pytest.mark.django_db
+def test_assign_content_viewer_role_grants_view_only(monkeypatch):
+    from django.contrib.auth import get_user_model
+    from pulp_file.app.models import FileContent
+    from pulpcore.app import role_util
+    from pulpcore.app.role_util import assign_content_viewer_role, get_objects_for_user
+
+    _populate_content_owner_roles(sender=FileContent._meta.app_config)
+
+    user = get_user_model().objects.create(username="dedup_uploader")
+    monkeypatch.setattr(role_util, "get_current_authenticated_user", lambda: user)
+
+    content = FileContent.objects.create(relative_path="c.txt", digest="4" * 64)
+    assign_content_viewer_role(content)
+
+    qs = FileContent.objects.all()
+    assert content in get_objects_for_user(user, "file.view_filecontent", qs, with_superuser=False)
+    # View only: no change/delete/manage_roles on the deduplicated content unit.
+    for perm in ("change_filecontent", "delete_filecontent", "manage_roles_filecontent"):
+        assert not user.has_perm(f"file.{perm}", content)
+
+
+@pytest.mark.django_db
+def test_assign_content_owner_role_grants_current_user(monkeypatch):
+    from django.contrib.auth import get_user_model
+    from pulp_file.app.models import FileContent
+    from pulpcore.app import role_util
+    from pulpcore.app.role_util import assign_content_owner_role, get_objects_for_user
+
+    _populate_content_owner_roles(sender=FileContent._meta.app_config)
+
+    user = get_user_model().objects.create(username="uploader")
+    monkeypatch.setattr(role_util, "get_current_authenticated_user", lambda: user)
+
+    content = FileContent.objects.create(relative_path="a.txt", digest="0" * 64)
+    assign_content_owner_role(content)
+
+    visible = get_objects_for_user(
+        user, "file.view_filecontent", FileContent.objects.all(), with_superuser=False
+    )
+    assert content in visible
+
+
+@pytest.mark.django_db
+def test_assign_content_owner_role_noop_without_user(monkeypatch):
+    from pulp_file.app.models import FileContent
+    from pulpcore.app import role_util
+    from pulpcore.app.role_util import assign_content_owner_role
+
+    _populate_content_owner_roles(sender=FileContent._meta.app_config)
+    monkeypatch.setattr(role_util, "get_current_authenticated_user", lambda: None)
+
+    content = FileContent.objects.create(relative_path="b.txt", digest="1" * 64)
+    assign_content_owner_role(content)  # must not raise
+    assert content.user_roles.count() == 0
+
+
+@pytest.mark.django_db
+def test_scope_queryset_includes_owned_orphan_content(monkeypatch):
+    from types import SimpleNamespace
+    from django.contrib.auth import get_user_model
+    from pulp_file.app.models import FileContent
+    from pulp_file.app.viewsets import FileContentViewSet
+    from pulpcore.app import role_util
+    from pulpcore.app.role_util import assign_content_owner_role
+    from pulpcore.app.util import get_default_domain
+
+    _populate_content_owner_roles(sender=FileContent._meta.app_config)
+    user = get_user_model().objects.create(username="owner2")
+    monkeypatch.setattr(role_util, "get_current_authenticated_user", lambda: user)
+
+    owned = FileContent.objects.create(relative_path="owned.txt", digest="2" * 64)
+    other = FileContent.objects.create(relative_path="other.txt", digest="3" * 64)
+    assign_content_owner_role(owned)  # not in any repository
+
+    view = FileContentViewSet()
+    view.request = SimpleNamespace(user=user, pulp_domain=get_default_domain())
+    scoped = view.scope_queryset(FileContent.objects.all())
+
+    assert owned in scoped
+    assert other not in scoped


### PR DESCRIPTION
Uploading content outside a repository returned a 201 with an href the uploader then got a 404 fetching, because reads were scoped only to content reachable through visible repositories.

Now each content type gets locked owner and viewer roles. On upload, the creator is granted the owner role on new content, or the viewer role when the upload deduplicates to an existing unit, so a deduplicating uploader can still read back what they uploaded without being able to change, delete, or manage roles on content they did not create. Content read-scoping unions repository-scoped content with content the user owns.

The grant is a no-op outside an authenticated request and superusers are unaffected. This lives at the base content layer, so plugins need no changes.

<!---
Thank you for submitting a PR to the Pulp Project!

If this is your first time contributing, please read the Pull Request Walkthrough documentation
(https://pulpproject.org/pulpcore/docs/dev/guides/pull-request-walkthrough/).
-->

### 📜 Checklist

- [x] Commits are cleanly separated with meaningful messages (simple features and bug fixes should be [squashed](https://pulpproject.org/pulpcore/docs/dev/guides/git/#rebasing-and-squashing) to one commit)
- [x] A [changelog entry](https://pulpproject.org/pulpcore/docs/dev/guides/git/#changelog-update) or entries has been added for any significant changes
- [x] Follows the [Pulp policy on AI Usage](https://pulpproject.org/help/more/governance/ai_policy/)
- [ ] (For new features) - User documentation and test coverage has been added

See: [Pull Request Walkthrough](https://pulpproject.org/pulpcore/docs/dev/guides/pull-request-walkthrough/)
