### PR TITLE
Fix gnupg compatibility wrapper for the gpg_verify() func

### DIFF
--- a/CHANGES/+openpgp_verify_compat.bugfix
+++ b/CHANGES/+openpgp_verify_compat.bugfix
@@ -1,0 +1,1 @@
+Preserve OpenPGP verification compatibility for failed signatures and fix key ID calculation for OpenPGP v6.

--- a/pulpcore/app/models/openpgp.py
+++ b/pulpcore/app/models/openpgp.py
@@ -6,7 +6,7 @@ from django.utils import timezone
 from pysequoia import ArmorKind, armor
 
 from pulpcore.app.models import AutoAddObjPermsMixin, Content, Distribution, Repository
-from pulpcore.app.util import get_domain_pk, gpg_verify
+from pulpcore.app.util import get_domain_pk, gpg_verify, openpgp_key_id
 
 
 def _openpgp_packlen(length):
@@ -207,8 +207,19 @@ class OpenPGPDistribution(Distribution, AutoAddObjPermsMixin):
             if repository_version is None:
                 return None
             key_id = result.group("key_id")
+            fingerprints = OpenPGPPublicKey.objects.filter(
+                pk__in=repository_version.content
+            ).values_list("fingerprint", flat=True)
+            fingerprint = next(
+                (
+                    fingerprint
+                    for fingerprint in fingerprints
+                    if openpgp_key_id(fingerprint).lower() == key_id.lower()
+                ),
+                None,
+            )
             key = OpenPGPPublicKey.objects.filter(
-                pk__in=repository_version.content, fingerprint__iendswith=key_id
+                pk__in=repository_version.content, fingerprint=fingerprint
             ).first()
             if key is None:
                 return None
@@ -225,7 +236,7 @@ class OpenPGPDistribution(Distribution, AutoAddObjPermsMixin):
             fingerprints = OpenPGPPublicKey.objects.filter(
                 pk__in=repository_version.content
             ).values_list("fingerprint", flat=True)
-            return {fingerprint[-16:] + ".pub" for fingerprint in fingerprints}
+            return {openpgp_key_id(fingerprint) + ".pub" for fingerprint in fingerprints}
         return set()
 
     class Meta:

--- a/pulpcore/app/util.py
+++ b/pulpcore/app/util.py
@@ -387,26 +387,46 @@ class VerifyResult:
     Verification result mimicking the interface of gnupg.Verify for compatibility.
 
     Attributes:
-        valid (bool): Always True; invalid signatures raise InvalidSignatureError instead.
-        fingerprint (str): Fingerprint of the signing subkey (uppercase hex).
-        pubkey_fingerprint (str): Fingerprint of the signing certificate (uppercase hex).
-        key_id (str): Short (16-char) key ID derived from the fingerprint.
+        valid (bool): Whether the signature is valid.
+        status (str or None): A human-readable verification status.
+        fingerprint (str or None): Fingerprint of the signing subkey (uppercase hex).
+        pubkey_fingerprint (str or None): Fingerprint of the signing certificate (uppercase hex).
+        key_id (str or None): Short (16-char) key ID derived from the fingerprint.
         data (bytes or None): The verified plaintext content for inline signatures, None for
             detached signatures.
     """
 
-    def __init__(self, decrypted):
-        self.valid = True
-        self.data = bytes(decrypted.bytes) if decrypted.bytes is not None else None
-        vs = decrypted.valid_sigs[0]
-        self.fingerprint = vs.signing_key.upper()
-        self.pubkey_fingerprint = vs.certificate.upper()
-        self.key_id = vs.signing_key[-16:].upper()
+    def __init__(self, decrypted=None, *, status=None):
+        self.valid = decrypted is not None
+        self.status = status
+        self.data = (
+            bytes(decrypted.bytes)
+            if decrypted is not None and decrypted.bytes is not None
+            else None
+        )
+        if decrypted is None or not decrypted.valid_sigs:
+            self.fingerprint = None
+            self.pubkey_fingerprint = None
+            self.key_id = None
+        else:
+            vs = decrypted.valid_sigs[0]
+            self.fingerprint = vs.signing_key.upper()
+            self.pubkey_fingerprint = vs.certificate.upper()
+            self.key_id = openpgp_key_id(vs.signing_key)
 
     def __repr__(self):
         return (
             f"<VerifyResult valid={self.valid} fingerprint={self.fingerprint} key_id={self.key_id}>"
         )
+
+
+def openpgp_key_id(fingerprint):
+    """Return the OpenPGP key ID for a hexadecimal fingerprint.
+
+    OpenPGP v4 key IDs use the low-order 64 bits, while v6 key IDs use the
+    high-order 64 bits. The fingerprint length distinguishes these versions.
+    """
+    return (fingerprint[:16] if len(fingerprint) == 64 else fingerprint[-16:]).upper()
 
 
 def gpg_verify(public_keys, signature, detached_data=None):
@@ -448,7 +468,8 @@ def gpg_verify(public_keys, signature, detached_data=None):
         else:
             result = verify(bytes=sig_data, store=store)
     except Exception:
-        raise InvalidSignatureError(_("The signature is not valid."))
+        message = _("The signature is not valid.")
+        raise InvalidSignatureError(message, verified=VerifyResult(status=message)) from None
 
     return VerifyResult(result)
 

--- a/pulpcore/pytest_plugin.py
+++ b/pulpcore/pytest_plugin.py
@@ -1484,6 +1484,8 @@ def import_signing_key(key_url, home, *, backend="gpg"):
     if backend == "sq":
         from pysequoia import Cert
 
+        from pulpcore.app.util import openpgp_key_id
+
         completed = subprocess.run(
             ("sq", "--home", str(home), "key", "import"),
             input=response.content,
@@ -1493,7 +1495,7 @@ def import_signing_key(key_url, home, *, backend="gpg"):
 
         cert = Cert.from_bytes(response.content)
         fingerprint = cert.fingerprint.upper()
-        keyid = fingerprint[-16:]
+        keyid = openpgp_key_id(fingerprint)
 
         return None, fingerprint, keyid
     else:

--- a/pulpcore/tests/unit/test_gpg_verify.py
+++ b/pulpcore/tests/unit/test_gpg_verify.py
@@ -3,7 +3,7 @@
 import pytest
 from pysequoia import CipherSuite, Profile, SignatureMode, Tsk, sign
 
-from pulpcore.app.util import VerifyResult, gpg_verify
+from pulpcore.app.util import VerifyResult, gpg_verify, openpgp_key_id
 from pulpcore.exceptions.validation import InvalidSignatureError
 
 # Test key configurations: (name, key_generator, description)
@@ -98,7 +98,7 @@ class TestGpgVerify:
         assert result.valid is True
         # pubkey_fingerprint is the primary key, fingerprint is the signing subkey
         assert result.pubkey_fingerprint.upper() == fixture["fingerprint"].upper()
-        assert result.key_id == result.fingerprint[-16:].upper()
+        assert result.key_id == openpgp_key_id(result.fingerprint)
         assert result.data is None  # detached signatures return None for data
 
     def test_inline_signature_valid(self, inline_sig_fixture):
@@ -110,7 +110,7 @@ class TestGpgVerify:
         assert isinstance(result, VerifyResult)
         assert result.valid is True
         assert result.pubkey_fingerprint.upper() == fixture["fingerprint"].upper()
-        assert result.key_id == result.fingerprint[-16:].upper()
+        assert result.key_id == openpgp_key_id(result.fingerprint)
         assert result.data == fixture["data"]
 
 
@@ -141,7 +141,7 @@ class TestVerifyResultAPI:
         assert isinstance(result.pubkey_fingerprint, str)
         assert result.pubkey_fingerprint.upper() == fingerprint.upper()
         assert isinstance(result.key_id, str)
-        assert result.key_id == result.fingerprint[-16:].upper()
+        assert result.key_id == openpgp_key_id(result.fingerprint)
         assert result.data is None  # detached signature
 
         # Test repr
@@ -188,8 +188,11 @@ class TestGpgVerifyErrorHandling:
         tampered_file = tmp_path / "tampered.txt"
         tampered_file.write_bytes(b"tampered data")
 
-        with pytest.raises(InvalidSignatureError):
+        with pytest.raises(InvalidSignatureError) as exc_info:
             gpg_verify(pubkey, str(sig_file), detached_data=str(tampered_file))
+        assert exc_info.value.verified.valid is False
+        assert exc_info.value.verified.status
+        assert exc_info.value.verified.fingerprint is None
 
     def test_wrong_key(self, tmp_path):
         """Test that wrong public key fails validation."""
@@ -206,8 +209,10 @@ class TestGpgVerifyErrorHandling:
         data_file = tmp_path / "data.txt"
         data_file.write_bytes(data)
 
-        with pytest.raises(InvalidSignatureError):
+        with pytest.raises(InvalidSignatureError) as exc_info:
             gpg_verify(wrong_pubkey, str(sig_file), detached_data=str(data_file))
+        assert exc_info.value.verified.valid is False
+        assert exc_info.value.verified.status
 
     def test_invalid_signature_data(self, tmp_path):
         """Test that invalid signature data raises InvalidSignatureError."""


### PR DESCRIPTION
Restore the "verified" attribute so that it can be checked by consumers. Derive OpenPGP key IDs correctly according to the key version, since it differs between OpenPGP v4 and v6.

Assisted-By: Codex Luna 5.6

<!---
Thank you for submitting a PR to the Pulp Project!

If this is your first time contributing, please read the Pull Request Walkthrough documentation
(https://pulpproject.org/pulpcore/docs/dev/guides/pull-request-walkthrough/).
-->

### 📜 Checklist

- [ ] Commits are cleanly separated with meaningful messages (simple features and bug fixes should be [squashed](https://pulpproject.org/pulpcore/docs/dev/guides/git/#rebasing-and-squashing) to one commit)
- [ ] A [changelog entry](https://pulpproject.org/pulpcore/docs/dev/guides/git/#changelog-update) or entries has been added for any significant changes
- [ ] Follows the [Pulp policy on AI Usage](https://pulpproject.org/help/more/governance/ai_policy/)
- [ ] (For new features) - User documentation and test coverage has been added

See: [Pull Request Walkthrough](https://pulpproject.org/pulpcore/docs/dev/guides/pull-request-walkthrough/)
