### PR TITLE
Speed up RepositoryVersion saves on add/remove content

### DIFF
--- a/pulpcore/app/models/repository.py
+++ b/pulpcore/app/models/repository.py
@@ -1199,7 +1199,7 @@ class RepositoryVersion(BaseModel):
         with transaction.atomic():
             if to_add:
                 self.content_ids += list(to_add)
-                self.save()
+                self.save(update_fields=["content_ids", "pulp_last_updated"])
 
             # Normalize representation if content has already been removed in this version and
             # is re-added: Undo removal by setting version_removed to None.
@@ -1264,7 +1264,7 @@ class RepositoryVersion(BaseModel):
 
             if to_remove:
                 self.content_ids = list(content_ids - to_remove)
-                self.save()
+                self.save(update_fields=["content_ids", "pulp_last_updated"])
 
     def set_content(self, content):
         """


### PR DESCRIPTION
Was asking sol to take a look at our RepoContent/content_ids problem and it pointed this out. Postgres can't optimize the update to be on the HOT path since the indexes become targets without specifying the fields, or so the AI says. Can't hurt

Assisted-by: gpt-5.6-sol

<!---
Thank you for submitting a PR to the Pulp Project!

If this is your first time contributing, please read the Pull Request Walkthrough documentation
(https://pulpproject.org/pulpcore/docs/dev/guides/pull-request-walkthrough/).
-->

### 📜 Checklist

- [ ] Commits are cleanly separated with meaningful messages (simple features and bug fixes should be [squashed](https://pulpproject.org/pulpcore/docs/dev/guides/git/#rebasing-and-squashing) to one commit)
- [ ] A [changelog entry](https://pulpproject.org/pulpcore/docs/dev/guides/git/#changelog-update) or entries has been added for any significant changes
- [ ] Follows the [Pulp policy on AI Usage](https://pulpproject.org/help/more/governance/ai_policy/)
- [ ] (For new features) - User documentation and test coverage has been added

See: [Pull Request Walkthrough](https://pulpproject.org/pulpcore/docs/dev/guides/pull-request-walkthrough/)
