### PR TITLE
Fix RepositoryVersion.contains always returning False

### DIFF
--- a/CHANGES/+rv-contains.bugfix
+++ b/CHANGES/+rv-contains.bugfix
@@ -1,0 +1,1 @@
+Fixed `RepositoryVersion.contains` always returning False.

--- a/pulpcore/app/models/repository.py
+++ b/pulpcore/app/models/repository.py
@@ -1170,7 +1170,10 @@ class RepositoryVersion(BaseModel):
         Returns:
             bool: True if the repository version contains the content, False otherwise
         """
-        return content.pk in self.content
+        return RepositoryVersion.objects.filter(
+            pk=self.pk,
+            content_ids__contains=[content.pk],
+        ).exists()
 
     def add_content(self, content):
         """


### PR DESCRIPTION
This was recently modified, but it was wrong! Doesn't seem to break anything. Haven't checked if any of our plugin code calls this method or not. The with_content filters don't so maybe this didn't affect anyone.

Assisted-by: gpt-5.6-sol

<!---
Thank you for submitting a PR to the Pulp Project!

If this is your first time contributing, please read the Pull Request Walkthrough documentation
(https://pulpproject.org/pulpcore/docs/dev/guides/pull-request-walkthrough/).
-->

### 📜 Checklist

- [ ] Commits are cleanly separated with meaningful messages (simple features and bug fixes should be [squashed](https://pulpproject.org/pulpcore/docs/dev/guides/git/#rebasing-and-squashing) to one commit)
- [ ] A [changelog entry](https://pulpproject.org/pulpcore/docs/dev/guides/git/#changelog-update) or entries has been added for any significant changes
- [ ] Follows the [Pulp policy on AI Usage](https://pulpproject.org/help/more/governance/ai_policy/)
- [ ] (For new features) - User documentation and test coverage has been added

See: [Pull Request Walkthrough](https://pulpproject.org/pulpcore/docs/dev/guides/pull-request-walkthrough/)
